### PR TITLE
Decrease default cfl for mcrwind test

### DIFF
--- a/problems/mcrwind/problem.par.build
+++ b/problems/mcrwind/problem.par.build
@@ -49,7 +49,7 @@
  /
 
  $NUMERICAL_SETUP
-    cfl          = 0.9
+    cfl          = 0.65
     smalld       = 1.e-5
     smallei      = 1.e-4
     integration_order = 2


### PR DESCRIPTION
Without redoing timesteps it's much faster
