### PR TITLE
Revert rtvd to calculating 2 steps inside relaxing_tvd

### DIFF
--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -154,7 +154,6 @@ module constants
    ! 3D and 4D array names
    ! fluids
    character(len=dsetnamelen), parameter :: fluid_n = "fluid"   !< main array
-   character(len=dsetnamelen), parameter :: uh_n    = "uh"      !< auxiliary array for half-step values
    character(len=dsetnamelen), parameter :: u0_n    = "u0"      !< backup copy for timestep retrying
    ! magnetic field
    character(len=dsetnamelen), parameter :: mag_n   = "mag"     !< main array

--- a/src/grid/cg_list_global.F90
+++ b/src/grid/cg_list_global.F90
@@ -228,7 +228,7 @@ contains
 
    subroutine register_fluids(this)
 
-      use constants,  only: wa_n, fluid_n, uh_n, mag_n, u0_n, b0_n, ndims, AT_NO_B, AT_OUT_B, VAR_XFACE, VAR_YFACE, VAR_ZFACE, PIERNIK_INIT_FLUIDS
+      use constants,  only: wa_n, fluid_n, mag_n, u0_n, b0_n, ndims, AT_NO_B, AT_OUT_B, VAR_XFACE, VAR_YFACE, VAR_ZFACE, PIERNIK_INIT_FLUIDS
       use dataio_pub, only: die, code_progress
       use fluidindex, only: flind
       use global,     only: repeat_step
@@ -250,7 +250,6 @@ contains
 
       call this%reg_var(wa_n,                                                           multigrid=.true.)  !! Auxiliary array. Multigrid required only for CR diffusion
       call this%reg_var(fluid_n, vital = .true., restart_mode = AT_NO_B,  dim4 = flind%all)                !! Main array of all fluids' components, "u"
-      call this%reg_var(uh_n,                                             dim4 = flind%all)                !! Main array of all fluids' components (for t += dt/2)
 
 !> \todo Do not even allocate magnetic stuff if MAGNETIC is not declared
       call this%reg_var(mag_n,   vital = &


### PR DESCRIPTION
This is a controversial change. Nevertheless I'd like to consider it. 

Disadvantages:
- problems with external gravitational potential as it will certainly screw _outd_ and such

Advantages:
- less communication
- lesser memory footprint
- make certain algorithms (FARGO I'm looking at you) easier
