### PR TITLE
Change index ordering in rtvd related routines

### DIFF
--- a/src/base/gridgeometry.F90
+++ b/src/base/gridgeometry.F90
@@ -139,9 +139,9 @@ contains
       if ( any( [allocated(cg%gc_xdim), allocated(cg%gc_ydim), allocated(cg%gc_zdim)] ) ) then
          call die("[gridgeometry:geo_coeffs_arrays] double allocation")
       else
-         allocate(cg%gc_xdim(GC1:GC3, flind%all, cg%n_(xdim)))
-         allocate(cg%gc_ydim(GC1:GC3, flind%all, cg%n_(ydim)))
-         allocate(cg%gc_zdim(GC1:GC3, flind%all, cg%n_(zdim)))
+         allocate(cg%gc_xdim(GC1:GC3, cg%n_(xdim), flind%all))
+         allocate(cg%gc_ydim(GC1:GC3, cg%n_(ydim), flind%all))
+         allocate(cg%gc_zdim(GC1:GC3, cg%n_(zdim), flind%all))
       endif
 
    end subroutine geo_coeffs_arrays
@@ -188,14 +188,16 @@ contains
 
          call geo_coeffs_arrays(flind, cg)
 
-         cg%gc_xdim(GC1,:,:) = spread( cg%coord(INV_CENTER, xdim)%r(:), 1, flind%all)
-         cg%gc_xdim(GC2,:,:) = spread( cg%coord(RIGHT, xdim)%r(:),      1, flind%all)
-         cg%gc_xdim(GC3,:,:) = spread( cg%coord(LEFT, xdim)%r(:),       1, flind%all)
+         do i = 1, flind%all
+            cg%gc_xdim(GC1,:,i) = cg%coord(INV_CENTER, xdim)%r(:)
+            cg%gc_xdim(GC2,:,i) = cg%coord(RIGHT, xdim)%r(:)
+            cg%gc_xdim(GC3,:,i) = cg%coord(LEFT, xdim)%r(:)
+         enddo
 
          do i = lbound(flind%all_fluids,1), ubound(flind%all_fluids,1)
-            cg%gc_xdim(GC1, flind%all_fluids(i)%fl%imy, :) = cg%gc_xdim(GC1, flind%all_fluids(i)%fl%imy, :) * cg%coord(INV_CENTER, xdim)%r(:)
-            cg%gc_xdim(GC2, flind%all_fluids(i)%fl%imy, :) = cg%gc_xdim(GC2, flind%all_fluids(i)%fl%imy, :) * cg%coord(RIGHT, xdim)%r(:)
-            cg%gc_xdim(GC3, flind%all_fluids(i)%fl%imy, :) = cg%gc_xdim(GC3, flind%all_fluids(i)%fl%imy, :) * cg%coord(LEFT, xdim)%r(:)
+            cg%gc_xdim(GC1, :, flind%all_fluids(i)%fl%imy) = cg%gc_xdim(GC1, :, flind%all_fluids(i)%fl%imy) * cg%coord(INV_CENTER, xdim)%r(:)
+            cg%gc_xdim(GC2, :, flind%all_fluids(i)%fl%imy) = cg%gc_xdim(GC2, :, flind%all_fluids(i)%fl%imy) * cg%coord(RIGHT, xdim)%r(:)
+            cg%gc_xdim(GC3, :, flind%all_fluids(i)%fl%imy) = cg%gc_xdim(GC3, :, flind%all_fluids(i)%fl%imy) * cg%coord(LEFT, xdim)%r(:)
          enddo
          cg%gc_ydim(GC2:GC3,:,:) = 1.0     ! [ 1/r , 1 , 1]
 
@@ -258,7 +260,7 @@ contains
 
       if (sweep == xdim) then
          do i = 1, size(iarr_all_dn)
-            res(i,:) = cg%inv_x(:) * (u(iarr_all_my(i),:)**2 / u(iarr_all_dn(i),:) + p(i,:))
+            res(:, i) = cg%inv_x(:) * (u(:, iarr_all_my(i))**2 / u(:, iarr_all_dn(i)) + p(:, i))
          enddo
       else
          ! Note that there's no additional source term for angular momentum since we're using

--- a/src/fluids/cosmicrays/fluxcosmicrays.F90
+++ b/src/fluids/cosmicrays/fluxcosmicrays.F90
@@ -53,10 +53,13 @@ contains
       real, dimension(n),   intent(in)             :: vion
       real, dimension(:,:), intent(in),    pointer :: uuc
       real, dimension(:,:), intent(inout), pointer :: fluxc
+      integer :: i
 
       fluxc   = 0.0
 
-      fluxc(:,RNG)= uuc(:,RNG)*spread(vion(RNG),1,flind%crs%all)
+      do i = 1, flind%crs%all
+         fluxc(RNG, i) = uuc(RNG, i)*vion(RNG)
+      enddo
 
    end subroutine flux_crs
 

--- a/src/fluids/dust/initdust.F90
+++ b/src/fluids/dust/initdust.F90
@@ -198,14 +198,14 @@ contains
       nm = n-1
 
       ps(:)  = 0.0
-      vx(RNG)=uu(imx,RNG)/uu(idn,RNG) ; vx(1) = vx(2); vx(n) = vx(nm)
+      vx(RNG)=uu(RNG, imx)/uu(RNG, idn) ; vx(1) = vx(2); vx(n) = vx(nm)
 
-      flux(idn,RNG)=uu(imx,RNG)
-      flux(imx,RNG)=uu(imx,RNG)*vx(RNG)
-      flux(imy,RNG)=uu(imy,RNG)*vx(RNG)
-      flux(imz,RNG)=uu(imz,RNG)*vx(RNG)
+      flux(RNG, idn)=uu(RNG, imx)
+      flux(RNG, imx)=uu(RNG, imx)*vx(RNG)
+      flux(RNG, imy)=uu(RNG, imy)*vx(RNG)
+      flux(RNG, imz)=uu(RNG, imz)*vx(RNG)
 
-      flux(:,1) = flux(:,2); flux(:,n) = flux(:,nm)
+      flux(1, :) = flux(2, :); flux(n, :) = flux(nm, :)
 
 #ifdef LOCAL_FR_SPEED
 
@@ -215,15 +215,15 @@ contains
 !     minvx = minval(vx(RNG))
 !     maxvx = maxval(vx(RNG))
 !     amp   = (maxvx-minvx)*half
-!      cfr(1,RNG) = max(sqrt(vx(RNG)**2+cfr_smooth*amp),small)
+!      cfr(RNG, 1) = max(sqrt(vx(RNG)**2+cfr_smooth*amp),small)
       absvx = abs(vx)
-      cfr(idn,RNG) = max( absvx(1:n-2), absvx(2:nm), absvx(3:n) )
+      cfr(RNG, idn) = max( absvx(1:n-2), absvx(2:nm), absvx(3:n) )
 
-      cfr(idn,1) = cfr(idn,2); cfr(idn,n) = cfr(idn,nm)
+      cfr(1, idn) = cfr(2, idn); cfr(n, idn) = cfr(nm, idn)
 
-      cfr(imx,:) = cfr(idn,:)
-      cfr(imy,:) = cfr(idn,:)
-      cfr(imz,:) = cfr(idn,:)
+      cfr(:, imx) = cfr(:, idn)
+      cfr(:, imy) = cfr(:, idn)
+      cfr(:, imz) = cfr(:, idn)
 
 #endif /* LOCAL_FR_SPEED */
 

--- a/src/fluids/ionized/initionized.F90
+++ b/src/fluids/ionized/initionized.F90
@@ -276,35 +276,35 @@ contains
 
       nm = n-1
 #ifdef MAGNETIC
-      pmag(RNG)= emag(bb(xdim,RNG),bb(ydim,RNG),bb(zdim,RNG));  pmag(1) = pmag(2); pmag(n) = pmag(nm)
+      pmag(RNG)= emag(bb(RNG, xdim), bb(RNG, ydim), bb(RNG, zdim));  pmag(1) = pmag(2); pmag(n) = pmag(nm)
 #else /* !MAGNETIC */
       pmag(:) = 0.0
 #endif /* !MAGNETIC */
-      vx(RNG)=uu(imx,RNG)/uu(idn,RNG); vx(1) = vx(2); vx(n) = vx(nm)
+      vx(RNG)=uu(RNG, imx)/uu(RNG, idn); vx(1) = vx(2); vx(n) = vx(nm)
 
 #ifndef ISO
       if (associated(cs_iso2)) call die("[initionized:flux_ion] cs_iso2 should not be present")
 #endif /* !ISO */
 
 #ifdef ISO
-      p(RNG)  = cs_iso2(RNG) * uu(idn,RNG)
+      p(RNG)  = cs_iso2(RNG) * uu(RNG, idn)
       ps(RNG) = p(RNG) + pmag(RNG)
 #else /* !ISO */
-      ps(RNG) = (uu(ien,RNG) - ekin(uu(imx,RNG),uu(imy,RNG),uu(imz,RNG),uu(idn,RNG)) )*(this%gam_1) &
+      ps(RNG) = (uu(RNG, ien) - ekin(uu(RNG, imx),uu(RNG, imy),uu(RNG, imz),uu(RNG, idn)) )*(this%gam_1) &
            & + (2.0 - this%gam)*pmag(RNG)
       p(RNG) = ps(RNG)- pmag(RNG);  p(1) = p(2); p(n) = p(nm)
 #endif /* !ISO */
       ps(1) = ps(2); ps(n) = ps(nm)
 
-      flux(idn,RNG)=uu(imx,RNG)
-      flux(imx,RNG)=uu(imx,RNG)*vx(RNG)+ps(RNG) - bb(xdim,RNG)**2
-      flux(imy,RNG)=uu(imy,RNG)*vx(RNG)-bb(ydim,RNG)*bb(xdim,RNG)
-      flux(imz,RNG)=uu(imz,RNG)*vx(RNG)-bb(zdim,RNG)*bb(xdim,RNG)
+      flux(RNG, idn)=uu(RNG, imx)
+      flux(RNG, imx)=uu(RNG, imx)*vx(RNG)+ps(RNG) - bb(RNG, xdim)**2
+      flux(RNG, imy)=uu(RNG, imy)*vx(RNG)-bb(RNG, ydim)*bb(RNG, xdim)
+      flux(RNG, imz)=uu(RNG, imz)*vx(RNG)-bb(RNG, zdim)*bb(RNG, xdim)
 #ifndef ISO
-      flux(ien,RNG)=(uu(ien,RNG)+ps(RNG))*vx(RNG)-bb(xdim,RNG)*(bb(xdim,RNG)*uu(imx,RNG) &
-                +bb(ydim,RNG)*uu(imy,RNG)+bb(zdim,RNG)*uu(imz,RNG))/uu(idn,RNG)
+      flux(RNG, ien)=(uu(RNG, ien)+ps(RNG))*vx(RNG)-bb(RNG, xdim)*(bb(RNG, xdim)*uu(RNG, imx) &
+                +bb(RNG, ydim)*uu(RNG, imy)+bb(RNG, zdim)*uu(RNG, imz))/uu(RNG, idn)
 #endif /* !ISO */
-      flux(:,1) = flux(:,2) ; flux(:,n) = flux(:,nm)
+      flux(1, :) = flux(2, :) ; flux(n, :) = flux(nm, :)
 
 #ifdef LOCAL_FR_SPEED
 
@@ -315,9 +315,9 @@ contains
       maxvx = maxval(vx(RNG))
       amp   = half*(maxvx-minvx)
 #ifdef ISO
-      cfr(1,RNG) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(2.0*pmag(RNG) +          p(RNG))/uu(idn,RNG)),small)
+      cfr(RNG, 1) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(2.0*pmag(RNG) +          p(RNG))/uu(RNG, idn)),small)
 #else /* !ISO */
-      cfr(1,RNG) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(2.0*pmag(RNG) + this%gam*p(RNG))/uu(idn,RNG)),small)
+      cfr(RNG, 1) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(2.0*pmag(RNG) + this%gam*p(RNG))/uu(RNG, idn)),small)
 #endif /* !ISO */
       !> \deprecated BEWARE: that is the cause of fast decreasing of timestep in galactic disk problem
       !>
@@ -328,9 +328,9 @@ contains
       !!    enddo
       !<
 
-      cfr(1,1) = cfr(1,2);  cfr(1,n) = cfr(1,nm)
+      cfr(1,1) = cfr(2,1);  cfr(n, 1) = cfr(nm, 1)
       do i = 2, this%all
-         cfr(i,:) = cfr(1,:)
+         cfr(:, i) = cfr(:, 1)
       enddo
 #endif /* LOCAL_FR_SPEED */
 

--- a/src/fluids/neutral/initneutral.F90
+++ b/src/fluids/neutral/initneutral.F90
@@ -249,22 +249,22 @@ contains
 #endif /* LOCAL_FR_SPEED */
 
       nm = n-1
-      vx(RNG) = uu(imx,RNG)/uu(idn,RNG) ; vx(1) = vx(2); vx(n) = vx(nm)
+      vx(RNG) = uu(RNG, imx)/uu(RNG, idn) ; vx(1) = vx(2); vx(n) = vx(nm)
 #ifdef ISO
-      ps(RNG) = cs_iso2(RNG) * uu(idn,RNG) ; ps(1) = ps(2); ps(n) = ps(nm)
+      ps(RNG) = cs_iso2(RNG) * uu(RNG, idn) ; ps(1) = ps(2); ps(n) = ps(nm)
 #else /* !ISO */
-      ps(RNG) = (uu(ien,RNG) - ekin(uu(imx,RNG),uu(imy,RNG),uu(imz,RNG),uu(idn,RNG)) )*(this%gam_1)
+      ps(RNG) = (uu(RNG, ien) - ekin(uu(RNG, imx),uu(RNG, imy),uu(RNG, imz),uu(RNG, idn)) )*(this%gam_1)
       ps(RNG) = max(ps(RNG), smallp)
 #endif /* !ISO */
 
-      flux(idn,RNG)=uu(imx,RNG)
-      flux(imx,RNG)=uu(imx,RNG)*vx(RNG)+ps(RNG)
-      flux(imy,RNG)=uu(imy,RNG)*vx(RNG)
-      flux(imz,RNG)=uu(imz,RNG)*vx(RNG)
+      flux(RNG, idn)=uu(RNG, imx)
+      flux(RNG, imx)=uu(RNG, imx)*vx(RNG)+ps(RNG)
+      flux(RNG, imy)=uu(RNG, imy)*vx(RNG)
+      flux(RNG, imz)=uu(RNG, imz)*vx(RNG)
 #ifndef ISO
-      flux(ien,RNG)=(uu(ien,RNG)+ps(RNG))*vx(RNG)
+      flux(RNG, ien)=(uu(RNG, ien)+ps(RNG))*vx(RNG)
 #endif /* !ISO */
-      flux(:,1) = flux(:,2) ; flux(:,n) = flux(:,nm)
+      flux(1, :) = flux(2, :) ; flux(n, :) = flux(nm, :)
 
 #ifdef LOCAL_FR_SPEED
 
@@ -276,9 +276,9 @@ contains
       amp   = half*(maxvx-minvx)
       !    c_fr  = 0.0
 #ifdef ISO
-      cfr(1,RNG) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(         ps(RNG))/uu(idn,RNG)),small)
+      cfr(RNG, 1) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(         ps(RNG))/uu(RNG, idn)),small)
 #else /* !ISO */
-      cfr(1,RNG) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(this%gam*ps(RNG))/uu(idn,RNG)),small)
+      cfr(RNG, 1) = sqrt(vx(RNG)**2+cfr_smooth*amp) + max(sqrt( abs(this%gam*ps(RNG))/uu(RNG, idn)),small)
 #endif /* !ISO */
       !> \deprecated BEWARE: that is the cause of fast decreasing of timestep in galactic disk problem
       !>
@@ -289,9 +289,9 @@ contains
       !!    enddo
       !<
 
-      cfr(1,1) = cfr(1,2);  cfr(1,n) = cfr(1,nm)
+      cfr(1,1) = cfr(2,1);  cfr(n, 1) = cfr(nm, 1)
       do i = 2, this%all
-         cfr(i,:) = cfr(1,:)
+         cfr(:, i) = cfr(:, 1)
       enddo
 #endif /* LOCAL_FR_SPEED */
 


### PR DESCRIPTION
Changing index ordering from (variable, spatial) to (spatial, variable) yields approximate ~20% speedup. I have no idea we we haven't checked it for so long... Probably we could squeez out more if similar changes will be made outside of _sweeps_ scope. Following changes were inspired by a discussion with @mmamon, all kudos go to him.
