### PR TITLE
No local mpi

### DIFF
--- a/src/grid/cg_level.F90
+++ b/src/grid/cg_level.F90
@@ -478,7 +478,6 @@ contains
 !! Unfortunately the previous approach did not work properly for complicated refinements.
 !!
 !! Possible improvements of performance
-!! * do local exchanges directly, without calling MPI.
 !! * merge smaller blocks into larger ones,
 !!
 !! \todo Put this%pse into a separate type and pass a pointer to it or even a pointer to pre-filtered segment list
@@ -522,7 +521,7 @@ contains
       type :: gcp
          type(grid_container), pointer :: p
       end type gcp
-      type(gcp), dimension(:), allocatable :: l_pse
+      type(gcp), dimension(:), allocatable :: l_pse ! auxiliary array used to convert entries in this%pse into pointers to grid containers for local exchanges
 
       allocate(l_pse(lbound(this%pse(proc)%c(:), dim=1):ubound(this%pse(proc)%c(:), dim=1)))
       ! OPT: the this%pse is sorted, so the setting of l_pse can be done in a bit faster, less safe way. Or do it fast first, then try the safe way to fill up, what is missing, if anything

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -437,6 +437,8 @@ contains
 !!
 !! \details Some data can be locally copied without MPI, but this seems to have really little impact on the performance.
 !! Some tests show that purely MPI code without local copies is marginally faster.
+!!
+!! \todo implement local copies without MPI anyway
 !<
 
    subroutine restrict_q_1var(this, iv, pos)
@@ -609,6 +611,8 @@ contains
 !! \details This routine communicates selected 3D array from coarse to fine grid.
 !! The prolonged data is then copied to the destination if the cg%ignore_prolongation allows it.
 !! OPT: Find a way to prolong only what is really needed.
+!!
+!! \todo implement local copies without MPI
 !<
 
    subroutine prolong_q_1var(this, iv, pos, bnd_type)
@@ -799,6 +803,8 @@ contains
 !! When the order of interpolation is 0 (injection) both methods degenerate into one.
 !! Both methods have their area of applicability amd both should be implemented.
 !! \warning This routine does only the first approach.
+!!
+!! \todo implement local copies without MPI
 !<
 
    subroutine prolong_bnd_from_coarser(this, ind, bnd_type, dir, nocorners)
@@ -963,6 +969,8 @@ contains
 !!
 !! OPT: As prolong_bnd_from_coarser calls coarse%level_3d_boundaries in some cases (except for all_cg%ord_prolong_nb == O_INJ) it should be possible to reduce number
 !! of MPI messages by relying on corner data on the coarse level (corners can be obtained along with face values). Be careful as this may break things in vertical_bf_prep.
+!!
+!! \todo implement local copies without MPI (provide appropriate pointers)
 !<
 
    subroutine vertical_b_prep(this)

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -187,9 +187,6 @@ contains
 !! Note that some of them were never used.
 !! \todo Try to define MPI_types for communication right before MPI_Isend/MPI_Irecv calls and release just after use. Then compare performance.
 !!
-!! \todo Check how much performance is lost due to using MPI calls even for local copies. Decide whether it is worth to convert local MPI calls to direct memory copies.
-!! For other suggestions on performance optimisation see description of cg_level::mpi_bnd_types.
-!!
 !! \warning this == leaves could be unsafe: need to figure out how to handle unneeded edges; this == all_cg or base%level or other concatenation of whole levels should work well
 !<
 

--- a/src/grid/grid_container.F90
+++ b/src/grid/grid_container.F90
@@ -54,7 +54,7 @@ module grid_cont
       real, allocatable, dimension(:,:,:,:) :: buf4       !< buffer for the 4D (vector) data to be sent or received
       integer(kind=4), pointer :: req                     !< request ID, used for most asynchronous communication, such as fine-coarse flux exchanges
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: se2 !< auxiliary range, used in cg_level_connected:vertical_bf_prep
-      type(grid_container), pointer :: local
+      type(grid_container), pointer :: local              !< set this pointer to non-null when the exchange is local
    end type segment
 
    !> \brief coefficient-layer pair used for prolongation


### PR DESCRIPTION
At last! Implemented local memory copies for boundary updates where possible. Seems to improve performance a bit (especially for low AMR_bsize, when there are hundreds of grid pieces per process). Should be followed by similar change in prolongation/restriction routines (much less critical).
