### PR TITLE
Update for QA

### DIFF
--- a/bin/qa.py
+++ b/bin/qa.py
@@ -26,7 +26,7 @@ test_for_interfaces = re.compile('''
 #       ^(?!\s{0,9}!).*(subroutine|function|type(,|\s::))
 #   ''',re.VERBOSE)
 module_body = re.compile(
-    '''^\s{0,3}(module|contains|program)''', re.VERBOSE)
+    '''^(module|contains|program)''', re.VERBOSE)
 just_end = re.compile('''^\s{0,9}end''', re.IGNORECASE)
 
 have_implicit = re.compile('''implicit\snone''', re.IGNORECASE)

--- a/src/fluids/fluidtypes.F90
+++ b/src/fluids/fluidtypes.F90
@@ -89,16 +89,16 @@ module fluidtypes
 
       real :: c !< COMMENT ME (this quantity was previously a member of phys_prop, but is used in completely different way than other phys_prop% members
 
-      contains
-         procedure :: set_fluid_index
-         procedure :: set_cs  => update_sound_speed
-         procedure :: set_gam => update_adiabatic_index
-         procedure :: set_c   => update_freezing_speed
-         procedure :: info    => printinfo_component_fluid
-         procedure(tag),          nopass, deferred :: get_tag
-         procedure(cs_get),         pass, deferred :: get_cs
-         procedure(flux_interface), pass, deferred :: compute_flux
-         procedure(pass_flind),     pass, deferred :: initialize_indices
+   contains
+      procedure :: set_fluid_index
+      procedure :: set_cs  => update_sound_speed
+      procedure :: set_gam => update_adiabatic_index
+      procedure :: set_c   => update_freezing_speed
+      procedure :: info    => printinfo_component_fluid
+      procedure(tag),          nopass, deferred :: get_tag
+      procedure(cs_get),         pass, deferred :: get_cs
+      procedure(flux_interface), pass, deferred :: compute_flux
+      procedure(pass_flind),     pass, deferred :: initialize_indices
    end type component_fluid
 
    type :: fluid_arr
@@ -168,7 +168,7 @@ module fluidtypes
       end subroutine flux_interface
    end interface
 
-   contains
+contains
 
       subroutine update_adiabatic_index(this,new_gamma)
          use dataio_pub, only: warn

--- a/src/multigrid/multigrid_helpers.F90
+++ b/src/multigrid/multigrid_helpers.F90
@@ -38,7 +38,7 @@ module multigrid_helpers
    public :: all_dirty, set_relax_boundaries, copy_and_max
    private
 
- contains
+contains
 
 !>
 !! \brief Put insane FP values into all multigrid working arrays


### PR DESCRIPTION
Since I don't know how to do it better atm, `contains` for modules **mustn't** be led by whitespaces or `qa.py` will not work properly.
