### PR TITLE
Fix intent type in MG's residual functions

### DIFF
--- a/src/multigrid/multigrid_Laplace.F90
+++ b/src/multigrid/multigrid_Laplace.F90
@@ -84,7 +84,7 @@ contains
 
       implicit none
 
-      class(cg_list_bnd_T), intent(in) :: cg_llst !< pointer to a list of grids for which we approximate the solution
+      class(cg_list_bnd_T), intent(inout) :: cg_llst !< pointer to a list of grids for which we approximate the solution
       integer(kind=4),      intent(in) :: src     !< index of source in cg%q(:)
       integer(kind=4),      intent(in) :: soln    !< index of solution in cg%q(:)
       integer(kind=4),      intent(in) :: def     !< index of defect in cg%q(:)

--- a/src/multigrid/multigrid_Laplace2.F90
+++ b/src/multigrid/multigrid_Laplace2.F90
@@ -66,7 +66,7 @@ contains
 
       implicit none
 
-      class(cg_list_bnd_T), intent(in) :: cg_llst !< pointer to a level for which we approximate the solution
+      class(cg_list_bnd_T), intent(inout) :: cg_llst !< pointer to a level for which we approximate the solution
       integer(kind=4),      intent(in) :: src     !< index of source in cg%q(:)
       integer(kind=4),      intent(in) :: soln    !< index of solution in cg%q(:)
       integer(kind=4),      intent(in) :: def     !< index of defect in cg%q(:)

--- a/src/multigrid/multigrid_Laplace4.F90
+++ b/src/multigrid/multigrid_Laplace4.F90
@@ -79,7 +79,7 @@ contains
 
       implicit none
 
-      class(cg_list_bnd_T), intent(in) :: cg_llst !< pointer to a level for which we approximate the solution
+      class(cg_list_bnd_T), intent(inout) :: cg_llst !< pointer to a level for which we approximate the solution
       integer(kind=4),      intent(in) :: src     !< index of source in cg%q(:)
       integer(kind=4),      intent(in) :: soln    !< index of solution in cg%q(:)
       integer(kind=4),      intent(in) :: def     !< index of defect in cg%q(:)

--- a/src/multigrid/multigrid_Laplace4M.F90
+++ b/src/multigrid/multigrid_Laplace4M.F90
@@ -90,7 +90,7 @@ contains
 
       implicit none
 
-      class(cg_list_bnd_T), intent(in) :: cg_llst !< pointer to a level for which we approximate the solution
+      class(cg_list_bnd_T), intent(inout) :: cg_llst !< pointer to a level for which we approximate the solution
       integer(kind=4),      intent(in) :: src     !< index of source in cg%q(:)
       integer(kind=4),      intent(in) :: soln    !< index of solution in cg%q(:)
       integer(kind=4),      intent(in) :: def     !< index of defect in cg%q(:)


### PR DESCRIPTION
`cg_llst` is _inout_ in `residual`, yet passed as _in_ down the stack
