### PR TITLE
[cg_list_balance] BUGFIX

### DIFF
--- a/src/grid/cg_list_balance.F90
+++ b/src/grid/cg_list_balance.F90
@@ -269,7 +269,7 @@ contains
          p = LAST
          do while (p >= FIRST .and. i /= 0)
             if (i<0) then
-               do while (from(p+1)>0)
+               do while (from(p+1)>0 .and. i<0)
                   from(p+1) = from(p+1) - I_ONE
                   i = i + 1
                enddo


### PR DESCRIPTION
balance_fill_lowest was unable to distribute new grids properly for really unbalanced workload (Bug introduced really in c456201f, or at least not fully fixed there)
