### PR TITLE
[refinement] sanitize AMR_bsize

### DIFF
--- a/src/grid/refinement.F90
+++ b/src/grid/refinement.F90
@@ -148,6 +148,7 @@ contains
             level_max = base_level_id
             n_updAMR  = huge(I_ONE)
          endif
+         where (.not. dom%has_dir(:)) AMR_bsize(:) = huge(1)
 
          ibuff(1) = level_min
          ibuff(2) = level_max


### PR DESCRIPTION
Setting AMR_bsize to 0 or 1 for non-existing directions often resulted in errors or strange execution of the code. 
