### PR TITLE
GPL URL does not show up in doxygen docs

### DIFF
--- a/doc/general/new_source_file.F90
+++ b/doc/general/new_source_file.F90
@@ -14,7 +14,7 @@
 !    GNU General Public License for more details.
 !
 !    You should have received a copy of the GNU General Public License
-!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!    along with PIERNIK.  If not, see http://www.gnu.org/licenses/.
 !
 !    Initial implementation of PIERNIK code was based on TVD split MHD code by
 !    Ue-Li Pen


### PR DESCRIPTION
The link appearing between angle brackets is interpreted as a comment by doxygen.