### PR TITLE
remove double quotes in recent history using sed

### DIFF
--- a/python/piernik_setup.py
+++ b/python/piernik_setup.py
@@ -128,7 +128,7 @@ env.dat: piernik.def *.h $(SRCS_V)
 head_block2 = '''
 \tawk '{print}' piernik.def | sed -e '/^$$/ d' -e "/^\// d" ) > env.dat
 \t@$(ECHO) "Recent history:" >> env.dat
-\t@git log -5 --decorate --graph >> env.dat
+\t@git log -5 --decorate --graph | sed -e 's/"//g' >> env.dat
 
 version.F90: env.dat
 \t@( $(ECHO) "module version"; \\


### PR DESCRIPTION
The  compilation of version.F90 fails when the commit messages have double quotes.
```
Error: Empty set of digits in BOZ constant at (1)
```
This can happen for example when you use `git revert` to revert previous commits. Replacing double quotes by escaped characters `\"` in the version.F90 file does not seem to work either.