### PR TITLE
correct order of array of indexes in coriolis module

### DIFF
--- a/src/base/coriolis.F90
+++ b/src/base/coriolis.F90
@@ -85,14 +85,14 @@ contains
 
       integer(kind=4), intent(in)              :: sweep  !< string of characters that points out the current sweep direction
       real, dimension(:,:), intent(in)         :: u      !< current fluid state vector
-      real, dimension(flind%fluids, size(u,2)) :: rotacc !< an array for Coriolis accelerations
+      real, dimension(size(u,1), flind%fluids) :: rotacc !< an array for Coriolis accelerations
 
       ! Coriolis force for corotating coords
       select case (sweep)
          case (xdim)
-            rotacc(:,:) = +2.0 * coriolis_omega * u(:, iarr_all_my(:))/u(:, iarr_all_dn(:))
+            rotacc(:,:) = +2.0 * coriolis_omega * u(:, iarr_all_my)/u(:, iarr_all_dn)
          case (ydim)
-            rotacc(:,:) = -2.0 * coriolis_omega * u(:, iarr_all_mx(:))/u(:, iarr_all_dn(:))
+            rotacc(:,:) = -2.0 * coriolis_omega * u(:, iarr_all_mx)/u(:, iarr_all_dn)
 !         case (zdim) !no z-component of the Coriolis force
          case default
             rotacc(:,:) = 0.0

--- a/src/base/coriolis.F90
+++ b/src/base/coriolis.F90
@@ -90,9 +90,9 @@ contains
       ! Coriolis force for corotating coords
       select case (sweep)
          case (xdim)
-            rotacc(:,:) = +2.0 * coriolis_omega * u(iarr_all_my(:), :)/u(iarr_all_dn(:), :)
+            rotacc(:,:) = +2.0 * coriolis_omega * u(:, iarr_all_my(:))/u(:, iarr_all_dn(:))
          case (ydim)
-            rotacc(:,:) = -2.0 * coriolis_omega * u(iarr_all_mx(:), :)/u(iarr_all_dn(:), :)
+            rotacc(:,:) = -2.0 * coriolis_omega * u(:, iarr_all_mx(:))/u(:, iarr_all_dn(:))
 !         case (zdim) !no z-component of the Coriolis force
          case default
             rotacc(:,:) = 0.0


### PR DESCRIPTION
Indexes for mass and momentum densities are in the wrong order in the coriolis module. However there is some other bug because this does not help in the advection test to get some deflection for the cartesian coordinates setup.