### PR TITLE
[initionized] Fix definition of is_magnetized logical variable

### DIFF
--- a/src/fluids/ionized/initionized.F90
+++ b/src/fluids/ionized/initionized.F90
@@ -74,7 +74,7 @@ contains
 #ifdef MAGNETIZED
       is_magnetized = .true.
 #else /* !MAGNETIZED */
-      is_magnetized = .true.
+      is_magnetized = .false.
 #endif /* !MAGNETIZED */
 
       call this%set_fluid_index(flind, is_magnetized, selfgrav, has_energy, cs_iso, gamma, ION)


### PR DESCRIPTION
I think this should be defined as `.false.`