### PR TITLE
fix use printinfo in non_inertial

### DIFF
--- a/src/base/non_inertial.F90
+++ b/src/base/non_inertial.F90
@@ -52,6 +52,9 @@ contains
       use constants,  only: PIERNIK_INIT_GRID, GEO_XYZ
       use dataio_pub, only: die, code_progress
       use domain,     only: dom
+#ifdef VERBOSE
+      use dataio_pub, only: printinfo
+#endif /* VERBOSE */
 
       implicit none
 


### PR DESCRIPTION
We want to successfully compile the code even if VERBOSE