### PR TITLE
Fixed 'Attempting to use an MPI routine before initializing MPICH'

### DIFF
--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -110,6 +110,7 @@ contains
       implicit none
 
       integer :: nit, ac
+      real    :: ts                  !< Timestep wallclock
       logical :: finished
       integer, parameter :: nit_over = 5 ! maximum number of auxiliary iterations after reaching level_max
 
@@ -119,6 +120,10 @@ contains
 
       call init_mpi                          ! First, we must initialize the communication (and things that do not depend on init_mpi if there are any)
       code_progress = PIERNIK_INIT_MPI       ! Now we can initialize grid and everything that depends at most on init_mpi. All calls prior to PIERNIK_INIT_GRID can be reshuffled when necessary
+
+      ! Timers should not be started before initializing MPI
+      ts=set_timer(tmr_fu,.true.)
+
       call check_environment
 
 #ifdef PIERNIK_OPENCL

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -34,7 +34,7 @@ program piernik
    use all_boundaries,    only: all_bnd
    use cg_leaves,         only: leaves
    use cg_list_global,    only: all_cg
-   use constants,         only: PIERNIK_START, PIERNIK_INITIALIZED, PIERNIK_FINISHED, PIERNIK_CLEANUP, fplen, stdout, I_ONE, CHK, FINAL_DUMP, tmr_fu
+   use constants,         only: PIERNIK_START, PIERNIK_INITIALIZED, PIERNIK_FINISHED, PIERNIK_CLEANUP, fplen, stdout, I_ONE, CHK, FINAL_DUMP
    use dataio,            only: write_data, user_msg_handler, check_log, check_tsl, dump
    use dataio_pub,        only: nend, tend, msg, printinfo, warn, die, code_progress
    use finalizepiernik,   only: cleanup_piernik
@@ -65,12 +65,10 @@ program piernik
    logical, save        :: tleft = .true.      !< Used in main loop, to test whether to stop simulation or not
    character(len=fplen) :: nstr, tstr
    logical, save        :: first_step = .true.
-   real                 :: ts                  !< Timestep wallclock
    real                 :: tlast
    logical              :: try_rebalance
 
    try_rebalance = .false.
-   ts=set_timer(tmr_fu,.true.)
    tlast = 0.0
 
    code_progress = PIERNIK_START

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -48,7 +48,7 @@ program piernik
    use named_array_list,  only: qna, wna
    use refinement,        only: emergency_fix
    use refinement_update, only: update_refinement
-   use timer,             only: walltime_end, set_timer
+   use timer,             only: walltime_end
    use timestep,          only: time_step
    use user_hooks,        only: finalize_problem, problem_domain_update
 #ifdef PERFMON


### PR DESCRIPTION
This was caused by early use of timer module which implied calling MPI_Wtime() before MPI_Init()