### PR TITLE
fix the problem with truncation of datafield name

### DIFF
--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -110,7 +110,7 @@ module constants
    integer, parameter :: units_len = 5 * cbuff_len       !< length for unit strings
    integer, parameter :: fplen = 24                      !< length of buffer for printed FP or integer number
    integer, parameter :: domlen = 16                     !< should be <= cbuff_len
-   integer, parameter :: dsetnamelen = 16                !< length of dataset name and state variable names in hdf files
+   integer, parameter :: dsetnamelen = cbuff_len         !< length of dataset name and state variable names in hdf files
    integer, parameter :: idlen = 3                       !< COMMENT ME
    integer, parameter :: singlechar = 1                  !< a single character
 


### PR DESCRIPTION
little fixup to #197 (the field was effectively named "magnetic_field_d").