### PR TITLE
[WIP] No stack arrays

### DIFF
--- a/src/fluids/dust/initdust.F90
+++ b/src/fluids/dust/initdust.F90
@@ -192,11 +192,11 @@ contains
       implicit none
       class(dust_fluid), intent(in)                :: this
       integer(kind=4), intent(in)                  :: n         !< number of cells in the current sweep
-      real, dimension(:,:), intent(inout), pointer :: flux      !< flux of dust
-      real, dimension(:,:), intent(inout), pointer :: cfr       !< freezing speed for dust
+      real, dimension(:,:), intent(out),   pointer :: flux      !< flux of dust
+      real, dimension(:,:), intent(out),   pointer :: cfr       !< freezing speed for dust
       real, dimension(:,:), intent(in),    pointer :: uu        !< part of u for dust
-      real, dimension(:),   intent(inout), pointer :: vx        !< velocity of dust fluid for current sweep
-      real, dimension(:),   intent(inout), pointer :: ps        !< pressure of dust fluid for current sweep
+      real, dimension(:),   intent(in),    pointer :: vx        !< velocity of dust fluid for current sweep
+      real, dimension(:),   intent(out),   pointer :: ps        !< pressure of dust fluid for current sweep
       real, dimension(:,:), intent(in),    pointer :: bb        !< magnetic field x,y,z-components table
       real, dimension(:),   intent(in),    pointer :: cs_iso2   !< local isothermal sound speed squared (optional)
       logical,              intent(in)             :: use_vx    !< use provided vx instead of computing it

--- a/src/fluids/fluidtypes.F90
+++ b/src/fluids/fluidtypes.F90
@@ -157,12 +157,12 @@ module fluidtypes
          implicit none
          class(component_fluid), intent(in)           :: this
          integer(kind=4), intent(in)                  :: n         !< number of cells in the current sweep
-         real, dimension(:,:), intent(inout), pointer :: flux      !< flux of fluid
+         real, dimension(:,:), intent(out),   pointer :: flux      !< flux of fluid
          real, dimension(:,:), intent(in),    pointer :: uu        !< part of u for fluid
-         real, dimension(:,:), intent(inout), pointer :: cfr       !< freezing speed for fluid
+         real, dimension(:,:), intent(out),   pointer :: cfr       !< freezing speed for fluid
          real, dimension(:,:), intent(in),    pointer :: bb        !< magnetic field x,y,z-components table
-         real, dimension(:),   intent(inout), pointer :: vx        !< velocity of fluid for current sweep
-         real, dimension(:),   intent(inout), pointer :: ps        !< pressure of fluid for current sweep
+         real, dimension(:),   intent(in),    pointer :: vx        !< velocity of fluid for current sweep
+         real, dimension(:),   intent(out),   pointer :: ps        !< pressure of fluid for current sweep
          real, dimension(:),   intent(in),    pointer :: cs_iso2   !< isothermal sound speed squared
          logical,              intent(in)             :: use_vx    !< use provided vx instead of computing it
       end subroutine flux_interface

--- a/src/fluids/fluxes.F90
+++ b/src/fluids/fluxes.F90
@@ -90,9 +90,9 @@ contains
       integer(kind=4), intent(in)                              :: n        !< size of input arrays
       real, dimension(n, flind%all),    target,  intent(out)   :: flux     !< array storing all fluxes
       real, dimension(n, flind%all),    target,  intent(out)   :: cfr      !< array storing all freezing speeds
-      real, dimension(n, flind%all),    target,  intent(out)   :: uu       !< array with current fluid state
+      real, dimension(n, flind%all),    target,  intent(in)    :: uu       !< array with current fluid state
       real, dimension(n, nmag),         target,  intent(in)    :: bb       !< array with current magnetic field state
-      real, dimension(n, flind%fluids), target,  intent(inout) :: vx       !< array storing velocity in current sweep direction (reused later)
+      real, dimension(n, flind%fluids), target,  intent(in)    :: vx       !< array storing velocity in current sweep direction (reused later)
       real, dimension(n, flind%fluids), target,  intent(out)   :: pp       !< array storing pressure in current sweep (reused later)
       real, dimension(:),               pointer, intent(in)    :: cs_iso2  !< array with current sound speed squared
       logical,                                   intent(in)    :: use_vx   !< use provided vx instead of computing it

--- a/src/fluids/ionized/initionized.F90
+++ b/src/fluids/ionized/initionized.F90
@@ -267,11 +267,11 @@ contains
       implicit none
       class(ion_fluid),     intent(in)             :: this
       integer(kind=4),      intent(in)             :: n         !< number of cells in the current sweep
-      real, dimension(:,:), intent(inout), pointer :: flux      !< flux of ionized fluid
-      real, dimension(:,:), intent(inout), pointer :: cfr       !< freezing speed for ionized fluid
+      real, dimension(:,:), intent(out),   pointer :: flux      !< flux of ionized fluid
+      real, dimension(:,:), intent(out),   pointer :: cfr       !< freezing speed for ionized fluid
       real, dimension(:,:), intent(in),    pointer :: uu        !< part of u for ionized fluid
-      real, dimension(:),   intent(inout), pointer :: vx        !< velocity of ionized fluid for current sweep
-      real, dimension(:),   intent(inout), pointer :: ps        !< pressure of ionized fluid for current sweep
+      real, dimension(:),   intent(in),    pointer :: vx        !< velocity of ionized fluid for current sweep
+      real, dimension(:),   intent(out),   pointer :: ps        !< pressure of ionized fluid for current sweep
       real, dimension(:,:), intent(in),    pointer :: bb        !< magnetic field x,y,z-components table
       real, dimension(:),   intent(in),    pointer :: cs_iso2   !< local isothermal sound speed squared (optional)
       logical,              intent(in)             :: use_vx    !< use provided vx instead of computing it

--- a/src/fluids/neutral/initneutral.F90
+++ b/src/fluids/neutral/initneutral.F90
@@ -243,11 +243,11 @@ contains
       implicit none
       class(neutral_fluid), intent(in)             :: this
       integer(kind=4),      intent(in)             :: n         !< number of cells in the current sweep
-      real, dimension(:,:), intent(inout), pointer :: flux      !< flux of neutral fluid
-      real, dimension(:,:), intent(inout), pointer :: cfr       !< freezing speed for neutral fluid
+      real, dimension(:,:), intent(out),   pointer :: flux      !< flux of neutral fluid
+      real, dimension(:,:), intent(out),   pointer :: cfr       !< freezing speed for neutral fluid
       real, dimension(:,:), intent(in),    pointer :: uu        !< part of u for neutral fluid
-      real, dimension(:),   intent(inout), pointer :: vx        !< velocity of neutral fluid for current sweep
-      real, dimension(:),   intent(inout), pointer :: ps        !< pressure of neutral fluid for current sweep
+      real, dimension(:),   intent(in),    pointer :: vx        !< velocity of neutral fluid for current sweep
+      real, dimension(:),   intent(out),   pointer :: ps        !< pressure of neutral fluid for current sweep
       real, dimension(:,:), intent(in),    pointer :: bb        !< magnetic field x,y,z-components table
       real, dimension(:),   intent(in),    pointer :: cs_iso2   !< isothermal sound speed squared
       logical,              intent(in)             :: use_vx    !< use provided vx instead of computing it


### PR DESCRIPTION
An attempt to reduce the performance difference of code compiled with different options.
* `-fstack-arrays` – which is safer but often requires to set ulimit -s unlimited or other workarounds to avoid SIGSEGV,
* `-fno-stack-arrays` – which is slower in the 1D parts of the hydro solver because of numerous temporary array allocations.

For Intel compiler the default is opposite and one can enforce placing arrays on the heap in case of SIGSEGV during temporary array allocation.