### PR TITLE
more intuitive res_id instead of using new_id

### DIFF
--- a/problems/2D_RIEMANN/problem.par
+++ b/problems/2D_RIEMANN/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/3body/problem.par
+++ b/problems/3body/problem.par
@@ -22,7 +22,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/magnetized_advection_test/problem.par
+++ b/problems/advection_test/magnetized_advection_test/problem.par
@@ -40,7 +40,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par
+++ b/problems/advection_test/problem.par
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.conservation_test
+++ b/problems/advection_test/problem.par.conservation_test
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.conservation_test.__STRANGE_CRASH___
+++ b/problems/advection_test/problem.par.conservation_test.__STRANGE_CRASH___
@@ -40,7 +40,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.cylindrical
+++ b/problems/advection_test/problem.par.cylindrical
@@ -32,7 +32,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.cylindrical.conservation_test
+++ b/problems/advection_test/problem.par.cylindrical.conservation_test
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.explodes_unphysically
+++ b/problems/advection_test/problem.par.explodes_unphysically
@@ -32,7 +32,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.refined
+++ b/problems/advection_test/problem.par.refined
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.restart_test
+++ b/problems/advection_test/problem.par.restart_test
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.restart_test_v2
+++ b/problems/advection_test/problem.par.restart_test_v2
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/advection_test/problem.par.rotating
+++ b/problems/advection_test/problem.par.rotating
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/analytic_periodic_potential/problem.par
+++ b/problems/analytic_periodic_potential/problem.par
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/analytic_periodic_potential/problem.par.crashing
+++ b/problems/analytic_periodic_potential/problem.par.crashing
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/blob/problem.par
+++ b/problems/blob/problem.par
@@ -30,7 +30,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/blob/problem.par.wt3_hi
+++ b/problems/blob/problem.par.wt3_hi
@@ -26,7 +26,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/blob/problem.par.wt3_med
+++ b/problems/blob/problem.par.wt3_med
@@ -26,7 +26,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/conservation_test/problem.par
+++ b/problems/conservation_test/problem.par
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/conservation_test/problem.par.conservation_test
+++ b/problems/conservation_test/problem.par.conservation_test
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/conservation_test/problem.par.cylindrical
+++ b/problems/conservation_test/problem.par.cylindrical
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/conservation_test/problem.par.cylindrical.AMR
+++ b/problems/conservation_test/problem.par.cylindrical.AMR
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/crtest/problem.par
+++ b/problems/crtest/problem.par
@@ -26,7 +26,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/crtest/problem.par.build
+++ b/problems/crtest/problem.par.build
@@ -22,7 +22,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/crtest/problem.par.debug
+++ b/problems/crtest/problem.par.debug
@@ -22,7 +22,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/crtest/problem.par.expanding_domain
+++ b/problems/crtest/problem.par.expanding_domain
@@ -25,7 +25,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/crwind/problem.par
+++ b/problems/crwind/problem.par
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/crwind/problem.par.build
+++ b/problems/crwind/problem.par.build
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/crwind/problem.par.highres
+++ b/problems/crwind/problem.par.highres
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/crwind/problem.par.lowres
+++ b/problems/crwind/problem.par.lowres
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/crwind/problem.par.smalltest
+++ b/problems/crwind/problem.par.smalltest
@@ -24,7 +24,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/divvtest/problem.par
+++ b/problems/divvtest/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/dustblob/problem.par
+++ b/problems/dustblob/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/dustwave/problem.par
+++ b/problems/dustwave/problem.par
@@ -22,7 +22,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/dustybox/problem.par
+++ b/problems/dustybox/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/fargo_test/problem.par
+++ b/problems/fargo_test/problem.par
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = 'foo'
+    res_id   = 'foo'
     nrestart = 0
  /
 

--- a/problems/int_bnd_test/problem.par
+++ b/problems/int_bnd_test/problem.par
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/jeans/problem.par
+++ b/problems/jeans/problem.par
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/jeans/problem.par.3d
+++ b/problems/jeans/problem.par.3d
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/jeans/problem.par.dirichlet
+++ b/problems/jeans/problem.par.dirichlet
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/kepler/problem.par
+++ b/problems/kepler/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/kepler/problem.par.2d
+++ b/problems/kepler/problem.par.2d
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/kepler/problem.par.build
+++ b/problems/kepler/problem.par.build
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/kepler/problem.par.kep
+++ b/problems/kepler/problem.par.kep
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/khi/problem.par
+++ b/problems/khi/problem.par
@@ -18,7 +18,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/lingrav/problem.par
+++ b/problems/lingrav/problem.par
@@ -24,7 +24,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/maclaurin/mpi_test.par
+++ b/problems/maclaurin/mpi_test.par
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par
+++ b/problems/maclaurin/problem.par
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
+++ b/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
@@ -29,7 +29,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par.cyl
+++ b/problems/maclaurin/problem.par.cyl
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par.cyl2
+++ b/problems/maclaurin/problem.par.cyl2
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par.particle
+++ b/problems/maclaurin/problem.par.particle
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par.quite_accurate
+++ b/problems/maclaurin/problem.par.quite_accurate
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par.refined
+++ b/problems/maclaurin/problem.par.refined
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/maclaurin/problem.par.refinement_shapes
+++ b/problems/maclaurin/problem.par.refinement_shapes
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par
+++ b/problems/mandelbrot/problem.par
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.polar
+++ b/problems/mandelbrot/problem.par.polar
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.polar.1-2-3-4-5-6
+++ b/problems/mandelbrot/problem.par.polar.1-2-3-4-5-6
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.polar.3-3-3-3-3-3
+++ b/problems/mandelbrot/problem.par.polar.3-3-3-3-3-3
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.polar.3x3x3x3x3x3
+++ b/problems/mandelbrot/problem.par.polar.3x3x3x3x3x3
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.polar.FM
+++ b/problems/mandelbrot/problem.par.polar.FM
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.zoom_1
+++ b/problems/mandelbrot/problem.par.zoom_1
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.zoom_2
+++ b/problems/mandelbrot/problem.par.zoom_2
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.zoom_3
+++ b/problems/mandelbrot/problem.par.zoom_3
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mandelbrot/problem.par.zoom_4
+++ b/problems/mandelbrot/problem.par.zoom_4
@@ -20,7 +20,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mcrtest/problem.par
+++ b/problems/mcrtest/problem.par
@@ -25,7 +25,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mcrtest/problem.par.build
+++ b/problems/mcrtest/problem.par.build
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mcrtest/problem.par.build2
+++ b/problems/mcrtest/problem.par.build2
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/mcrwind/problem.par
+++ b/problems/mcrwind/problem.par
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.build
+++ b/problems/mcrwind/problem.par.build
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.highres
+++ b/problems/mcrwind/problem.par.highres
@@ -26,7 +26,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.lowres
+++ b/problems/mcrwind/problem.par.lowres
@@ -26,7 +26,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.multigrid
+++ b/problems/mcrwind/problem.par.multigrid
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.multisn_wind
+++ b/problems/mcrwind/problem.par.multisn_wind
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.selfgrav
+++ b/problems/mcrwind/problem.par.selfgrav
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.singlesn_test
+++ b/problems/mcrwind/problem.par.singlesn_test
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/mcrwind/problem.par.smalltest
+++ b/problems/mcrwind/problem.par.smalltest
@@ -25,7 +25,7 @@
  $RESTART_CONTROL
     restart      = 'last'
     nrestart     = 0
-    new_id       = ''
+    res_id       = ''
  /
 
  $END_CONTROL

--- a/problems/otvortex/problem.par.build
+++ b/problems/otvortex/problem.par.build
@@ -26,7 +26,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/particle_map_test/problem.par
+++ b/problems/particle_map_test/problem.par
@@ -22,7 +22,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/pr_test/problem.par
+++ b/problems/pr_test/problem.par
@@ -30,7 +30,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/roche/problem.par
+++ b/problems/roche/problem.par
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/sedov/problem.par.AMR
+++ b/problems/sedov/problem.par.AMR
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/sedov/problem.par._vulnerable_to_deadlock_in_refinement_after_domain_expansion_
+++ b/problems/sedov/problem.par._vulnerable_to_deadlock_in_refinement_after_domain_expansion_
@@ -26,7 +26,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/sedov/problem.par.build
+++ b/problems/sedov/problem.par.build
@@ -26,7 +26,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/sedov/problem.par.build-outflow
+++ b/problems/sedov/problem.par.build-outflow
@@ -27,7 +27,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/sedov/problem.par.expanding_domain
+++ b/problems/sedov/problem.par.expanding_domain
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/selfgrav_clump/problem.par
+++ b/problems/selfgrav_clump/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/selfgrav_clump/problem.par.1D
+++ b/problems/selfgrav_clump/problem.par.1D
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/selfgrav_clump/problem.par.2D
+++ b/problems/selfgrav_clump/problem.par.2D
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/selfgrav_clump/problem.par.conservation_test
+++ b/problems/selfgrav_clump/problem.par.conservation_test
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/selfgrav_clump/problem.par.cyl
+++ b/problems/selfgrav_clump/problem.par.cyl
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/selfgrav_clump/problem.par.expanding_domain
+++ b/problems/selfgrav_clump/problem.par.expanding_domain
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj1a
+++ b/problems/shock1d_rj/problem.par.rj1a
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj1b
+++ b/problems/shock1d_rj/problem.par.rj1b
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj2a
+++ b/problems/shock1d_rj/problem.par.rj2a
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj2b
+++ b/problems/shock1d_rj/problem.par.rj2b
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj3a
+++ b/problems/shock1d_rj/problem.par.rj3a
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj3b
+++ b/problems/shock1d_rj/problem.par.rj3b
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj4a
+++ b/problems/shock1d_rj/problem.par.rj4a
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj4b
+++ b/problems/shock1d_rj/problem.par.rj4b
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj4c
+++ b/problems/shock1d_rj/problem.par.rj4c
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/problem.par.rj4d
+++ b/problems/shock1d_rj/problem.par.rj4d
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/shock1d_rj/sod/problem.par
+++ b/problems/shock1d_rj/sod/problem.par
@@ -23,7 +23,7 @@ $UNITS
 
 $RESTART_CONTROL
    restart  = 'last'
-   new_id   = ''
+   res_id   = ''
    nrestart = 0
 /
 

--- a/problems/slab/problem.par
+++ b/problems/slab/problem.par
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/slab/problem.par.2d
+++ b/problems/slab/problem.par.2d
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/stream/problem_BA.par
+++ b/problems/stream/problem_BA.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/stream/problem_lin.par
+++ b/problems/stream/problem_lin.par
@@ -29,7 +29,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/stream3D/problem.par
+++ b/problems/stream3D/problem.par
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/streaming_global/problem.par
+++ b/problems/streaming_global/problem.par
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = 'foo'
+    res_id   = 'foo'
     nrestart = 0
  /
 

--- a/problems/streaming_global/problem.par.build
+++ b/problems/streaming_global/problem.par.build
@@ -28,7 +28,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = 'foo'
+    res_id   = 'foo'
     nrestart = 0
  /
 

--- a/problems/tearing/problem.par.build
+++ b/problems/tearing/problem.par.build
@@ -22,7 +22,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = 'new'
+    res_id   = 'new'
     nrestart = 0
  /
 

--- a/problems/turbulence/problem.par
+++ b/problems/turbulence/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/wind/problem.par
+++ b/problems/wind/problem.par
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/wt4/problem.par
+++ b/problems/wt4/problem.par
@@ -23,7 +23,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/wt4/problem.par.cylindrical
+++ b/problems/wt4/problem.par.cylindrical
@@ -24,7 +24,7 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/yt_test/problem.par
+++ b/problems/yt_test/problem.par
@@ -17,7 +17,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/problems/yt_test/problem.par.yt_fails
+++ b/problems/yt_test/problem.par.yt_fails
@@ -17,7 +17,7 @@
 
  $RESTART_CONTROL
     restart  = 'none'
-    new_id   = ''
+    res_id   = ''
     nrestart = 0
  /
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -36,7 +36,7 @@
 
 module dataio
 
-   use dataio_pub, only: domain_dump, fmin, fmax, vizit, nend, tend, wend, new_id, nrestart, problem_name, run_id, multiple_h5files, use_v2_io, nproc_io, enable_compression, gzip_level, gdf_strict, h5_64bit
+   use dataio_pub, only: domain_dump, fmin, fmax, vizit, nend, tend, wend, res_id, nrestart, problem_name, run_id, multiple_h5files, use_v2_io, nproc_io, enable_compression, gzip_level, gdf_strict, h5_64bit
    use constants,  only: cwdlen, fmt_len, cbuff_len, dsetnamelen, RES, TSL
    use timer,      only: wallclock
 
@@ -98,7 +98,7 @@ module dataio
    end type tsl_container
 
    namelist /END_CONTROL/     nend, tend, wend
-   namelist /RESTART_CONTROL/ restart, new_id, nrestart, resdel
+   namelist /RESTART_CONTROL/ restart, res_id, nrestart, resdel
    namelist /OUTPUT_CONTROL/  problem_name, run_id, dt_hdf, dt_res, dt_tsl, dt_log, tsl_with_mom, tsl_with_ptc, &
                               domain_dump, vars, mag_center, vizit, fmin, fmax, user_message_file, system_message_file, &
                               multiple_h5files, use_v2_io, nproc_io, enable_compression, gzip_level, initial_hdf_dump, &
@@ -125,7 +125,7 @@ contains
 !! <table border="+1">
 !! <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
 !! <tr><td>restart </td><td>'last'</td><td>'last' or another string of characters</td><td>\copydoc dataio::restart     </td></tr>
-!! <tr><td>new_id  </td><td>''    </td><td>string of characters                  </td><td>\copydoc dataio_pub::new_id  </td></tr>
+!! <tr><td>res_id  </td><td>''    </td><td>string of characters                  </td><td>\copydoc dataio_pub::res_id  </td></tr>
 !! <tr><td>nrestart</td><td>3     </td><td>integer                               </td><td>\copydoc dataio_pub::nrestart</td></tr>
 !! <tr><td>resdel  </td><td>0     </td><td>integer                               </td><td>\copydoc dataio::resdel      </td></tr>
 !! </table>
@@ -267,7 +267,7 @@ contains
       run_id       = "___"
       restart      = 'last'   ! 'last': automatic choice of the last restart file regardless of "nrestart" value;
                               ! if something else is set: "nrestart" value is fixing
-      new_id       = ''
+      res_id       = ''
       nrestart     = 3
       resdel       = 0
 
@@ -390,9 +390,9 @@ contains
          rbuff(2)  = wend
 
 
-!   namelist /RESTART_CONTROL/ restart, new_id, nrestart, resdel
+!   namelist /RESTART_CONTROL/ restart, res_id, nrestart, resdel
          cbuff(20) = restart
-         cbuff(21) = new_id
+         cbuff(21) = res_id
 
          ibuff(20) = nrestart
          ibuff(21) = resdel
@@ -449,9 +449,9 @@ contains
          tend                = rbuff(1)
          wend                = rbuff(2)
 
-!   namelist /RESTART_CONTROL/ restart, new_id, nrestart, resdel
+!   namelist /RESTART_CONTROL/ restart, res_id, nrestart, resdel
          restart             = trim(cbuff(20))
-         new_id              = trim(cbuff(21))
+         res_id              = trim(cbuff(21))
 
          nrestart            = int(ibuff(20), kind=4)
          resdel              = ibuff(21)
@@ -563,7 +563,6 @@ contains
          t_start     = t
          nres_start  = nrestart
          nhdf_start  = nhdf-1
-         if (new_id /= '') run_id=new_id
 #else /* !HDF5 */
          call die("[dataio:init_dataio] cannot use restart without HDF5")
 #endif /* !HDF5 */

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -60,7 +60,7 @@ module dataio_pub
    ! Simulation control
    character(len=cbuff_len)    :: problem_name                   !< The problem name
    character(len=idlen)        :: run_id                         !< Auxiliary run identifier
-   character(len=idlen)        :: new_id                         !< Auxiliary new run identifier to change run_id when restarting simulation (e.g. to avoid overwriting of the output from the previous (pre-restart) simulation; if new_id = '' then run_id is still used)
+   character(len=idlen)        :: res_id                         !< Auxiliary run to restart identifier, yet different then current run_id of restarted simulation (e.g. to avoid overwriting of the output from the previous (pre-restart) simulation; if res_id = '' then run_id is used also for reading restart file)
    real                        :: tend                           !< simulation time to end
    real                        :: wend                           !< wall clock time to end (in hours)
 

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -1026,8 +1026,8 @@ contains
 
    function output_fname(wr_rd, ext, no, bcast, prefix) result(filename)
 
-      use constants,  only: cwdlen, RD, WR, I_FOUR, fnamelen
-      use dataio_pub, only: problem_name, run_id, wd_wr, wd_rd, warn, die, msg
+      use constants,  only: cwdlen, idlen, RD, WR, I_FOUR, fnamelen
+      use dataio_pub, only: problem_name, run_id, res_id, wd_wr, wd_rd, warn, die, msg
       use mpisetup,   only: master, piernik_MPI_Bcast
 
       implicit none
@@ -1037,6 +1037,7 @@ contains
       logical,               intent(in), optional :: bcast
       character(len=*),      intent(in), optional :: prefix
       character(len=cwdlen)                       :: filename, temp  ! File name
+      character(len=idlen)                        :: file_id
 
 
       ! Sanity checks go here
@@ -1052,11 +1053,17 @@ contains
          endif
       endif
 
+      if ((wr_rd == RD) .and. (res_id /= '')) then
+         file_id = res_id
+      else
+         file_id = run_id
+      endif
+
       if (master) then
          if (present(prefix)) then
-            write(temp,'(2(a,"_"),a3,"_",i4.4,a4)') trim(prefix), trim(problem_name), run_id, no, ext
+            write(temp,'(2(a,"_"),a3,"_",i4.4,a4)') trim(prefix), trim(problem_name), file_id, no, ext
          else
-            write(temp,'(a,"_",a3,"_",i4.4,a4)') trim(problem_name), run_id, no, ext
+            write(temp,'(a,"_",a3,"_",i4.4,a4)') trim(problem_name), file_id, no, ext
          endif
          select case (wr_rd)
             case (RD)

--- a/src/IO/hdf5/restart_hdf5_v1.F90
+++ b/src/IO/hdf5/restart_hdf5_v1.F90
@@ -466,7 +466,7 @@ contains
       use common_hdf5,      only: output_fname
       use constants,        only: cwdlen, cbuff_len, domlen, idlen, xdim, ydim, zdim, LO, HI, RD
       use dataio_pub,       only: msg, warn, die, printio, require_problem_IC, problem_name, piernik_hdf5_version, fix_string, &
-           &                      domain_dump, last_hdf_time, last_res_time, last_log_time, last_tsl_time, nhdf, nres, run_id
+           &                      domain_dump, last_hdf_time, last_res_time, last_log_time, last_tsl_time, nhdf, nres, res_id
       use dataio_user,      only: user_reg_var_restart, user_attrs_rd
       use domain,           only: dom
       use fluidindex,       only: flind
@@ -601,7 +601,7 @@ contains
 
          call h5ltget_attribute_string_f(file_id,"/","problem_name", problem_name, error)
          call h5ltget_attribute_string_f(file_id,"/","domain",       domain_dump,  error)
-         call h5ltget_attribute_string_f(file_id,"/","run_id",       run_id,       error)
+         call h5ltget_attribute_string_f(file_id,"/","run_id",       res_id,       error)
 
          if (restart_hdf5_version > 1.11) then
             call h5ltget_attribute_int_f(file_id,"/","require_problem_IC", ibuf, error)
@@ -609,7 +609,7 @@ contains
          endif
 
          problem_name = fix_string(problem_name)   !> \deprecated BEWARE: >=HDF5-1.8.4 has weird issues with strings
-         run_id  = fix_string(run_id)    !> \deprecated   this bit hacks it around
+         res_id  = fix_string(res_id)    !> \deprecated   this bit hacks it around
          domain_dump  = fix_string(domain_dump)
 
          call h5fclose_f(file_id, error)
@@ -636,7 +636,7 @@ contains
 
          cbuff(1) = problem_name
          cbuff(2)(1:domlen) = domain_dump
-         cbuff(3)(1:idlen)  = run_id
+         cbuff(3)(1:idlen)  = res_id
       endif
 
       call piernik_MPI_Bcast(ibuff)
@@ -658,7 +658,7 @@ contains
 
          problem_name = cbuff(1)
          domain_dump = cbuff(2)(1:domlen)
-         run_id = cbuff(3)(1:idlen)
+         res_id = cbuff(3)(1:idlen)
 
       endif
 

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -499,7 +499,7 @@ contains
            &                        cg_size_aname, cg_offset_aname, cg_lev_aname, base_d_gname, cg_cnt_aname, data_gname, &
            &                        output_fname, STAT_OK
       use constants,          only: cwdlen, dsetnamelen, cbuff_len, ndims, xdim, zdim, INVALID, RD, LO, HI
-      use dataio_pub,         only: die, warn, printio, msg, last_hdf_time, last_res_time, last_log_time, last_tsl_time, problem_name, run_id, domain_dump, &
+      use dataio_pub,         only: die, warn, printio, msg, last_hdf_time, last_res_time, last_log_time, last_tsl_time, problem_name, res_id, domain_dump, &
            &                        require_problem_IC, piernik_hdf5_version2, nres, nhdf, fix_string
       use dataio_user,        only: user_reg_var_restart, user_attrs_rd
       use domain,             only: dom
@@ -641,7 +641,7 @@ contains
             case ("domain")
                domain_dump = fix_string(trim(cbuf(:len(domain_dump))))
             case ("run_id")
-               run_id = fix_string(trim(cbuf(:len(run_id))))
+               res_id = fix_string(trim(cbuf(:len(res_id))))
             case default
                write(msg,'(3a,i14,a)')"[restart_hdf5_v2:read_restart_hdf5_v2] String attribute '",trim(real_attrs(ia)),"' with value = ",cbuf," was ignored"
                call warn(msg)


### PR DESCRIPTION
[dataio,restart_hdf5_v1,2] always use run_id for current simulation, and res_id for reading restart files. More intuitive than using new_id