### PR TITLE
[common_hdf5] fix counting while writing ener and while ISO

### DIFF
--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -97,9 +97,12 @@ contains
    subroutine init_hdf5(vars)
 
       use constants,  only: dsetnamelen, singlechar
-      use fluidindex, only: iarr_all_dn, iarr_all_mx, iarr_all_my, iarr_all_mz, iarr_all_en
+      use fluidindex, only: iarr_all_dn, iarr_all_mx, iarr_all_my, iarr_all_mz
       use fluids_pub, only: has_ion, has_dst, has_neu
       use global,     only: force_cc_mag
+#ifndef ISO
+      use fluidindex, only: iarr_all_en
+#endif /* !ISO */
 #ifdef COSM_RAYS
       use dataio_pub, only: warn, msg
       use fluidindex, only: iarr_all_crs
@@ -134,7 +137,12 @@ contains
             case ('velz', 'momz')
                nhdf_vars = nhdf_vars + size(iarr_all_mz,1)
             case ('ener', 'ethr', 'pres')
+#ifdef ISO
+               if (has_neu) nhdf_vars = nhdf_vars + 1
+               if (has_ion) nhdf_vars = nhdf_vars + 1
+#else /* !ISO */
                nhdf_vars = nhdf_vars + size(iarr_all_en,1)
+#endif /* !ISO */
 #ifdef COSM_RAYS
             case ('encr')
                nhdf_vars = nhdf_vars + size(iarr_all_crs,1)


### PR DESCRIPTION
fix counting vars, e.g. in default kepler run