### PR TITLE
Timestep growth and retry changes

### DIFF
--- a/jenkins/gold_configs/mcrwind
+++ b/jenkins/gold_configs/mcrwind
@@ -1,6 +1,7 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=799877d5cc8594a75e1452071ade3c96f46688e2
+GOLD_COMMIT=2c29dfd2614450938c1ca8518441513fa9abcfba
+# 2c29dfd2614450938c1ca8518441513fa9abcfba - changed timestep reduction when retrying a timestep
 # 799877d5cc8594a75e1452071ade3c96f46688e2 - [sources] collect changes from all sources once and limit ecr after doing sources
 # e08c628a46b5b6245df9dde0c64153c522d45084 - random_utils for seed control and reproducible random numbers
 # 2d84935c0665426247309775c20d722fd5db5f95 - 64-bit plotfiles for gold configs

--- a/jenkins/gold_configs/mcrwind
+++ b/jenkins/gold_configs/mcrwind
@@ -1,6 +1,7 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=2c29dfd2614450938c1ca8518441513fa9abcfba
+GOLD_COMMIT=0093dc8220e96ebfe76399749c8ec80f9b990f99
+# 0093dc8220e96ebfe76399749c8ec80f9b990f99 - timestep retry now should not have side-effects (except for self-gravity)
 # 2c29dfd2614450938c1ca8518441513fa9abcfba - changed timestep reduction when retrying a timestep
 # 799877d5cc8594a75e1452071ade3c96f46688e2 - [sources] collect changes from all sources once and limit ecr after doing sources
 # e08c628a46b5b6245df9dde0c64153c522d45084 - random_utils for seed control and reproducible random numbers

--- a/src/IO/hdf5/restart_hdf5_v1.F90
+++ b/src/IO/hdf5/restart_hdf5_v1.F90
@@ -483,7 +483,7 @@ contains
       use randomization,    only: initseed, seed_size
 #endif /* RANDOMIZE */
 #ifdef SN_SRC
-      use snsources,        only: nsn_last
+      use snsources,        only: nsn
 #endif /* SN_SRC */
 
       implicit none
@@ -608,7 +608,7 @@ contains
          call h5ltget_attribute_int_f(file_id,"/","current_seed", ibuf, error) ; initseed = ibuf(:seed_size)
 #endif /* RANDOMIZE */
 #ifdef SN_SRC
-         call h5ltget_attribute_int_f(file_id,"/","nsn_last", ibuf, error) ; nsn_last = ibuf(1)
+         call h5ltget_attribute_int_f(file_id,"/","nsn", ibuf, error) ; nsn = ibuf(1)
 #endif /* SN_SRC */
 
          call h5ltget_attribute_string_f(file_id,"/","problem_name", problem_name, error)
@@ -639,7 +639,7 @@ contains
          ibuff(3) = nhdf
          if (restart_hdf5_version > 1.11) ibuff(5) = require_problem_IC
 #ifdef SN_SRC
-         ibuff(6) = nsn_last
+         ibuff(6) = nsn
 #endif /* SN_SRC */
 #ifdef RANDOMIZE
          ibuff(7:seed_size+6) = initseed
@@ -667,7 +667,7 @@ contains
          nhdf  = ibuff(3)
          if (restart_hdf5_version > 1.11) require_problem_IC = ibuff(5)
 #ifdef SN_SRC
-         nsn_last = ibuff(6)
+         nsn   = ibuff(6)
 #endif /* SN_SRC */
 #ifdef RANDOMIZE
          initseed = ibuff(7:seed_size+6)

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -46,7 +46,6 @@ module global
         &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, &
         &    divB_0_method, force_cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd
 
-   real, parameter :: dt_default_grow = 2.
    logical         :: cfl_violated             !< True when cfl condition is violated
    logical         :: dirty_debug              !< Allow initializing arrays with some insane values and checking if these values can propagate
    integer(kind=4) :: show_n_dirtys            !< use to limit the amount of printed messages on dirty values found
@@ -123,7 +122,7 @@ contains
 !!   <tr><td>integration_order</td><td>2      </td><td>1 or 2 (or 3 - currently unavailable)</td><td>\copydoc global::integration_order</td></tr>
 !!   <tr><td>cfr_smooth       </td><td>0.0    </td><td>real value                           </td><td>\copydoc global::cfr_smooth       </td></tr>
 !!   <tr><td>dt_initial       </td><td>-1.    </td><td>positive real value or -1.           </td><td>\copydoc global::dt_initial       </td></tr>
-!!   <tr><td>dt_max_grow      </td><td>2.     </td><td>real value > 1.1                     </td><td>\copydoc global::dt_max_grow      </td></tr>
+!!   <tr><td>dt_max_grow      </td><td>2.     </td><td>real value, should be > 1.           </td><td>\copydoc global::dt_max_grow      </td></tr>
 !!   <tr><td>dt_min           </td><td>0.     </td><td>positive real value                  </td><td>\copydoc global::dt_min           </td></tr>
 !!   <tr><td>dt_max           </td><td>0.     </td><td>positive real value                  </td><td>\copydoc global::dt_max           </td></tr>
 !!   <tr><td>limiter          </td><td>vanleer</td><td>string                               </td><td>\copydoc global::limiter          </td></tr>
@@ -191,7 +190,7 @@ contains
       smallc      = 1.e-10
       smallei     = 1.e-10
       dt_initial  = -1.              !< negative value indicates automatic choice of initial timestep
-      dt_max_grow = dt_default_grow  !< for sensitive setups consider setting this as low as 1.1
+      dt_max_grow = 2.               !< for sensitive setups consider setting this as low as 1.1
       dt_min      = tiny(1.)
       dt_max      = huge(1.)
       relax_time  = 0.
@@ -227,10 +226,9 @@ contains
          cfl_max = min(max(cfl_max, min(cfl*1.1, cfl+0.05, (1.+cfl)/2.) ), 1.0) ! automatically sanitize cfl_max
          if (integration_order > 2) call die ('[global:init_global]: "ORIG" scheme integration_order must be 1 or 2')
 
-         if (dt_max_grow < 1.01) then
-            write(msg,'(2(a,g10.3))')"[global:init_global] dt_max_grow = ",dt_max_grow," is way too low. Resetting to ",dt_default_grow
+         if (dt_max_grow <= 1.01) then
+            write(msg,'(2(a,g10.3))')"[global:init_global] dt_max_grow = ",dt_max_grow," is low. Recommended values are in 1.1 .. 2.0 range."
             call warn(msg)
-            dt_max_grow = dt_default_grow
          endif
 
          cbuff(1) = limiter

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -39,7 +39,7 @@ module global
 
    private
    public :: cleanup_global, init_global, &
-        &    cfl, cfl_max, cflcontrol, cfl_violated, &
+        &    cfl, cfl_max, cflcontrol, cfl_violated, tstep_attempt, &
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, &
         &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, repeat_step, skip_sweep, geometry25D, &
@@ -56,6 +56,7 @@ module global
    integer         :: divB_0_method            !< encoded method of making div(B) = 0 (currently DIVB_CT or DIVB_HDC)
    logical         :: force_cc_mag             !< treat magnetic field as cell-centered in the Riemann solver (temporary hack)
    integer(kind=4) :: psi_bnd                  !< BND_INVALID or enforce some other psi boundary
+   integer         :: tstep_attempt            !< /= 0 when we retry timesteps
 
    ! Namelist variables
 
@@ -146,7 +147,7 @@ contains
    subroutine init_global
 
       use constants,  only: big_float, PIERNIK_INIT_MPI, INVALID, DIVB_CT, DIVB_HDC, &
-           &                BND_INVALID, BND_ZERO, BND_REF, BND_OUT
+           &                BND_INVALID, BND_ZERO, BND_REF, BND_OUT, I_ZERO
       use dataio_pub, only: die, msg, warn, code_progress, printinfo
       use dataio_pub, only: nh  ! QA_WARN required for diff_nml
       use mpisetup,   only: cbuff, ibuff, lbuff, rbuff, master, slave, piernik_MPI_Bcast
@@ -387,6 +388,8 @@ contains
          endif
       endif
 #endif /* MAGNETIC */
+
+      tstep_attempt = I_ZERO
 
    end subroutine init_global
 

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -59,7 +59,7 @@ module global
 
    ! Namelist variables
 
-   real    :: dt_initial               !< initial timestep
+   real    :: dt_initial               !< if >0. : initial timestep; if 0. or < -1. : automatic timestep; reduced automatic timestep otherwise
    real    :: dt_max_grow              !< maximum timestep growth rate
    real    :: dt_shrink                !< dt shrink rate when timestep retry is used
    real    :: dt_min                   !< minimum allowed timestep
@@ -122,7 +122,7 @@ contains
 !!   <tr><td>smallc           </td><td>1.e-10 </td><td>real value                           </td><td>\copydoc global::smallc           </td></tr>
 !!   <tr><td>integration_order</td><td>2      </td><td>1 or 2 (or 3 - currently unavailable)</td><td>\copydoc global::integration_order</td></tr>
 !!   <tr><td>cfr_smooth       </td><td>0.0    </td><td>real value                           </td><td>\copydoc global::cfr_smooth       </td></tr>
-!!   <tr><td>dt_initial       </td><td>-1.    </td><td>positive real value or -1.           </td><td>\copydoc global::dt_initial       </td></tr>
+!!   <tr><td>dt_initial       </td><td>-1.    </td><td>positive real value or -1. .. 0.     </td><td>\copydoc global::dt_initial       </td></tr>
 !!   <tr><td>dt_max_grow      </td><td>2.     </td><td>real value, should be > 1.           </td><td>\copydoc global::dt_max_grow      </td></tr>
 !!   <tr><td>dt_shrink        </td><td>0.5    </td><td>real value, should be < 1.           </td><td>\copydoc global::dt_shrink        </td></tr>
 !!   <tr><td>dt_min           </td><td>0.     </td><td>positive real value                  </td><td>\copydoc global::dt_min           </td></tr>
@@ -191,7 +191,7 @@ contains
       use_smalld  = .true.
       smallc      = 1.e-10
       smallei     = 1.e-10
-      dt_initial  = -1.              !< negative value indicates automatic choice of initial timestep
+      dt_initial  = -1.              !< -1. indicates automatic choice of initial timestep, -0.5 would give half of that
       dt_max_grow = 2.               !< for sensitive setups consider setting this as low as 1.1
       dt_shrink   = 0.5
       dt_min      = tiny(1.)

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -109,7 +109,7 @@ contains
       use dataio_pub,           only: tend, msg, warn
       use fargo,                only: timestep_fargo, fargo_mean_omega
       use fluidtypes,           only: var_numbers
-      use global,               only: t, dt_old, dt_max_grow, dt_initial, dt_min, dt_max, nstep, use_fargo
+      use global,               only: t, dt_old, dt_max_grow, dt_initial, dt_min, dt_max, nstep, use_fargo, cfl_violated
       use grid_cont,            only: grid_container
       use mpisetup,             only: master, piernik_MPI_Allreduce
       use sources,              only: timestep_sources
@@ -185,7 +185,7 @@ contains
       endif
 
       if (associated(cfl_manager)) call cfl_manager
-      c_all_old = c_all
+      if (.not.cfl_violated) c_all_old = c_all
 
       if (dt < dt_min) then ! something nasty had happened
          if (master) then

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -175,7 +175,11 @@ contains
 
       ! finally apply some sanity factors
       if (nstep <=1) then
-         if (dt_initial > zero) dt = min(dt, dt_initial)
+         if (dt_initial > zero) then
+            dt = min(dt, dt_initial)
+         else if (dt_initial < zero) then ! extra factor for shortening first timestep
+            dt = min(dt, -dt_initial * dt)
+         endif
       else
          if (dt_old > zero) dt = min(dt, dt_old*dt_max_grow)
       endif

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -147,7 +147,6 @@ contains
       do while (associated(cgl))
          cg => cgl%cg
 
-         !> \todo make the timestep_* routines members of fluidtypes::component_fluid
          do ifl = lbound(flind%all_fluids, dim=1), ubound(flind%all_fluids, dim=1)
             call timestep_fluid(cg, flind%all_fluids(ifl)%fl, dt_, c_)
             dt    = min(dt, dt_)

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -174,7 +174,7 @@ contains
       call piernik_MPI_Allreduce(c_all, pMAX)
 
       ! finally apply some sanity factors
-      if (nstep <=1) then
+      if (nstep < 1) then
          if (dt_initial > zero) then
             dt = min(dt, dt_initial)
          else if (dt_initial < zero) then ! extra factor for shortening first timestep

--- a/src/fluids/fluidtypes.F90
+++ b/src/fluids/fluidtypes.F90
@@ -88,12 +88,14 @@ module fluidtypes
       type(phys_prop) :: snap
 
       real :: c !< COMMENT ME (this quantity was previously a member of phys_prop, but is used in completely different way than other phys_prop% members
+      real :: c_old
 
    contains
       procedure :: set_fluid_index
       procedure :: set_cs  => update_sound_speed
       procedure :: set_gam => update_adiabatic_index
       procedure :: set_c   => update_freezing_speed
+      procedure :: res_c   => reset_freezing_speed
       procedure :: info    => printinfo_component_fluid
       procedure(tag),          nopass, deferred :: get_tag
       procedure(cs_get),         pass, deferred :: get_cs
@@ -200,8 +202,16 @@ contains
          class(component_fluid) :: this
          real, intent(in)       :: new_c
 
-         this%c   = new_c
+         this%c_old = this%c
+         this%c     = new_c
       end subroutine update_freezing_speed
+
+      subroutine reset_freezing_speed(this)
+         implicit none
+         class(component_fluid) :: this
+
+         this%c     = this%c_old
+      end subroutine reset_freezing_speed
 
       subroutine update_sound_speed(this,new_cs)
          implicit none

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -111,6 +111,7 @@ contains
          t = t_saved
          nstep = nstep_saved
          dt = dtm * dt_shrink
+         call reset_freezing_speed
          call downgrade_magic_mass
 #ifdef RANDOMIZE
          call randoms_redostep(.true.)
@@ -222,5 +223,19 @@ contains
       enddo
 
    end subroutine restart_arrays
+
+   subroutine reset_freezing_speed
+
+      use fluidindex, only: flind
+
+      implicit none
+
+      integer :: ifl
+
+      do ifl = lbound(flind%all_fluids, dim=1), ubound(flind%all_fluids, dim=1)
+         call flind%all_fluids(ifl)%fl%res_c
+      enddo
+
+   end subroutine reset_freezing_speed
 
 end module timestep_retry

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -84,9 +84,9 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: pSUM, I_ONE, dsetnamelen, AT_IGNORE
+      use constants,        only: pSUM, I_ZERO, I_ONE, dsetnamelen, AT_IGNORE
       use dataio_pub,       only: warn, msg, die
-      use global,           only: dt, dtm, t, t_saved, cfl_violated, nstep, nstep_saved, dt_shrink, repeat_step
+      use global,           only: dt, dtm, t, t_saved, cfl_violated, nstep, nstep_saved, dt_shrink, repeat_step, tstep_attempt
       use mass_defect,      only: downgrade_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
@@ -107,7 +107,9 @@ contains
       call restart_arrays
 
       if (cfl_violated) then
-         if (master) call warn("[timestep_retry:repeat_fluidstep] Redoing previous step...")
+         tstep_attempt = tstep_attempt + I_ONE
+         write(msg, '(a,i2,a)') "[timestep_retry:repeat_fluidstep] Redoing previous step (", tstep_attempt, ")"
+         if (master) call warn(msg)
          t = t_saved
          nstep = nstep_saved
          dt = dtm * dt_shrink
@@ -118,6 +120,7 @@ contains
 #endif /* RANDOMIZE */
          if (associated(user_reaction_to_redo_step)) call user_reaction_to_redo_step
       else
+         tstep_attempt = I_ZERO
          nstep_saved = nstep
          t_saved = t
 #ifdef RANDOMIZE


### PR DESCRIPTION
Change of _gold_ for `mcrwind` is required because we change the way how we retry timesteps and `mcrwind` is using this way too much.