### PR TITLE
Separate mark for fields that serve as a backup

### DIFF
--- a/src/IO/hdf5/restart_hdf5_v1.F90
+++ b/src/IO/hdf5/restart_hdf5_v1.F90
@@ -236,7 +236,7 @@ contains
       endif
       ir = rank4 - rank + 1 ! 1 for 4-D arrays, 2 for 3-D arrays (to simplify use of count(:), offset(:), stride(:), block(:), dimsf(:) and chunk_dims(:)
 
-      if (area_type == AT_IGNORE) return !> \todo write a list of unsaved arrays?
+      if (area_type <= AT_IGNORE) return
       call set_area_for_restart(area_type, area)
 
       dimsf      = [dim1, area(:)] ! Dataset dimensions
@@ -379,7 +379,7 @@ contains
       ir = rank4 - rank + 1 ! 1 for 4-D arrays, 2 for 3-D arrays (to simplify use of count(:), offset(:), stride(:), block(:), dimsf(:) and chunk_dims(:)
 
       if (present(alt_area_type)) area_type = alt_area_type
-      if (area_type == AT_IGNORE) return !! \todo write a list of unsaved arrays?
+      if (area_type <= AT_IGNORE) return
       call set_area_for_restart(area_type, area)
 
       dimsf = [dim1, area(:)]      ! Dataset dimensions

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -153,7 +153,7 @@ contains
             else
                d_size = int(cg_n_b, kind=HSIZE_T)
             endif
-            if (qna%lst(i)%restart_mode /= AT_IGNORE) &  ! create "/data/grid_%08d/qna%lst(i)%name"
+            if (qna%lst(i)%restart_mode > AT_IGNORE) &  ! create "/data/grid_%08d/qna%lst(i)%name"
                  call create_empty_cg_dataset(cg_g_id, qna%lst(i)%name, d_size, Z_avail, O_RES)
          enddo
       endif
@@ -167,7 +167,7 @@ contains
             else
                d_size = int([ wna%lst(i)%dim4, cg_n_b ], kind=HSIZE_T)
             endif
-            if (wna%lst(i)%restart_mode /= AT_IGNORE) &  ! create "/data/grid_%08d/wna%lst(i)%name"
+            if (wna%lst(i)%restart_mode > AT_IGNORE) &  ! create "/data/grid_%08d/wna%lst(i)%name"
                  call create_empty_cg_dataset(cg_g_id, wna%lst(i)%name, d_size, Z_avail, O_RES)
          enddo
       endif

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -203,9 +203,10 @@ module constants
    character(len=*), parameter :: tmr_mg  = "multigrid"      !< timer for gravity multigrid solver
    character(len=*), parameter :: tmr_mgd = "multigrid_diff" !< timer for gravityCR diffusion multigrid solver
 
-   ! Handling boundary cells in the output
+   ! Handling boundary cells in the output (AT stands for Area Type)
    enum, bind(C)
-      enumerator :: AT_IGNORE       !! no output
+      enumerator :: AT_BACKUP       !! backup field: no output AND no backup
+      enumerator :: AT_IGNORE       !! no output for anything less or equal AT_IGNORE
       enumerator :: AT_NO_B         !! no boundary cells
       enumerator :: AT_OUT_B        !! external boundary cells
       enumerator :: AT_USER         !! user defined area type

--- a/src/base/named_array_list.F90
+++ b/src/base/named_array_list.F90
@@ -51,7 +51,9 @@ module named_array_list
    type :: na_var
       character(len=dsetnamelen)                 :: name          !< a user-provided id for the array
       logical                                    :: vital         !< fields that are subject of automatic prolongation and restriction (e.g. state variables)
-      integer(kind=4)                            :: restart_mode  !< AT_IGNORE: do not write to restart, AT_NO_B write without ext. boundaries, AT_OUT_B write with ext. boundaries
+      integer(kind=4)                            :: restart_mode  !< AT_BACKUP, AT_IGNORE: do not write to restart
+                                                                  !< AT_NO_B write without ext. boundaries
+                                                                  !< AT_OUT_B write with ext. boundaries
                                                                   !< \todo position /= VAR_CENTER should automatically force AT_OUT_B if AT_IGNORE was not chosen
       integer(kind=4)                            :: ord_prolong   !< Prolongation order for the variable
       integer(kind=4), allocatable, dimension(:) :: position      !< VAR_CENTER by default, also possible VAR_CORNER and VAR_[XYZ]FACE
@@ -222,7 +224,7 @@ contains
 
       if (allocated(this%lst)) then
          do i = lbound(this%lst(:), dim=1, kind=4), ubound(this%lst(:), dim=1, kind=4)
-            if (this%lst(i)%restart_mode /= AT_IGNORE) call append_int_to_array(lst, i)
+            if (this%lst(i)%restart_mode > AT_IGNORE) call append_int_to_array(lst, i)
          enddo
       endif
       if (.not.allocated(lst)) allocate(lst(0))  ! without it intrinsics like size, ubound, lbound return bogus values

--- a/src/grid/cg_list_global.F90
+++ b/src/grid/cg_list_global.F90
@@ -137,7 +137,7 @@ contains
       class(cg_list_global_T),                          intent(inout) :: this          !< object invoking type-bound procedure
       character(len=*),                                 intent(in)    :: name          !< Name of the variable to be registered
       logical,                                optional, intent(in)    :: vital         !< .false. for arrays that don't need to be prolonged or restricted automatically
-      integer(kind=4),                        optional, intent(in)    :: restart_mode  !< Write to the restart if not AT_IGNORE. Several write modes can be supported.
+      integer(kind=4),                        optional, intent(in)    :: restart_mode  !< Write to the restart if >= AT_IGNORE. Several write modes can be supported.
       integer(kind=4),                        optional, intent(in)    :: ord_prolong   !< Prolongation order for the variable
       integer(kind=4),                        optional, intent(in)    :: dim4          !< If present then register the variable in the cg%w array.
       integer(kind=4), dimension(:), pointer, optional, intent(in)    :: position      !< If present then use this value instead of VAR_CENTER

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -139,7 +139,7 @@ contains
          do j = lbound(na_lists, dim=1), ubound(na_lists, dim=1)
             associate (na => na_lists(j)%p)
                do i = lbound(na%lst(:), dim=1), ubound(na%lst(:), dim=1)
-                  if (na%lst(i)%restart_mode /= AT_IGNORE) then
+                  if (na%lst(i)%restart_mode > AT_IGNORE) then
                      rname = get_rname(na%lst(i)%name)
                      if (cfl_violated) then
                         if (cgl%cg%has_previous_timestep) then
@@ -188,7 +188,7 @@ contains
    subroutine restart_arrays
 
       use cg_list_global,   only: all_cg
-      use constants,        only: AT_IGNORE, dsetnamelen, INVALID
+      use constants,        only: AT_BACKUP, AT_IGNORE, dsetnamelen, INVALID
       use dataio_pub,       only: printinfo, msg
       use mpisetup,         only: master
       use named_array_list, only: qna, wna
@@ -206,7 +206,7 @@ contains
          associate (na => na_lists(j)%p)
 
             do i = lbound(na%lst(:), dim=1), ubound(na%lst(:), dim=1)
-               if (na%lst(i)%restart_mode /= AT_IGNORE) then
+               if (na%lst(i)%restart_mode > AT_IGNORE) then
                   rname = get_rname(na%lst(i)%name)
                   if (.not. na%exists(rname)) then
                      if (master) then
@@ -216,9 +216,9 @@ contains
                      allocate(pos_copy(size(na%lst(i)%position)))
                      pos_copy = na%lst(i)%position
                      if (na%lst(i)%dim4 /= INVALID) then
-                        call all_cg%reg_var(rname, dim4=na%lst(i)%dim4, position=pos_copy, multigrid=na%lst(i)%multigrid)
+                        call all_cg%reg_var(rname, dim4=na%lst(i)%dim4, position=pos_copy, multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
                      else
-                        call all_cg%reg_var(rname,                      position=pos_copy, multigrid=na%lst(i)%multigrid)
+                        call all_cg%reg_var(rname,                      position=pos_copy, multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
                      endif
                      deallocate(pos_copy)
                   endif


### PR DESCRIPTION
The `restart_mode` was overloaded a bit to distinguish between *fields that don't need to be put into restart and thus don't need to be backed up for timestep retry* and *fields that are back up of other fields and should never be backed up, under any circumstances*.