### PR TITLE
BUGFIX: dfftw_cleanup moved a bit

### DIFF
--- a/src/base/finalizepiernik.F90
+++ b/src/base/finalizepiernik.F90
@@ -85,10 +85,10 @@ contains
 #ifdef RESISTIVE
       call cleanup_resistivity;    call nextdot(.false.)
 #endif /* RESISTIVE */
+      call cleanup_grid;           call nextdot(.false.)
 #ifdef MULTIGRID
       call cleanup_multigrid;      call nextdot(.false.)
 #endif /* MULTIGRID */
-      call cleanup_grid;           call nextdot(.false.)
       call cleanup_sortable_list;  call nextdot(.false.)
       call cleanup_fluids;         call nextdot(.false.)
 #ifdef GRAV


### PR DESCRIPTION
dfftw_cleanup should not be called before all dfftw_destroy_plan are called

This perhaps fixes problem observed in 8348762f