### PR TITLE
[refinement] BUGFIX for weird 2D decompositions

### DIFF
--- a/src/gravity/pcg.F90
+++ b/src/gravity/pcg.F90
@@ -64,7 +64,7 @@ contains
       use cg_list_global,   only: all_cg
       use constants,        only: base_level_id
       use dataio_pub,       only: warn
-      use domain,           only: AMR_bsize
+      use domain,           only: AMR_bsize, dom
       use mpisetup,         only: master
       use named_array_list, only: qna
       use refinement_flag,  only: level_max
@@ -78,7 +78,7 @@ contains
             call warn("[pcg:pcg_init] Multigrid-preconditioned conjugate gradient solver is experimental!")
             if (use_CG_outer) &
                  call warn("[pcg:pcg_init] Current implementation of Multigrid-Preconditioned Conjugate Gradient Method is known to converge poorly for outer potential.")
-            if (level_max > base_level_id .and. any(AMR_bsize > 0)) &
+            if (level_max > base_level_id .and. any((AMR_bsize > 0) .and. dom%has_dir)) &
                  call warn("[pcg:pcg_init] Current implementation of Multigrid-Preconditioned Conjugate Gradient Method is known to converge poorly on refined grids.")
          endif
       endif

--- a/src/grid/refinement.F90
+++ b/src/grid/refinement.F90
@@ -111,7 +111,7 @@ contains
       do d = xdim, zdim
          if (dom%has_dir(d))  then
             if (AMR_bsize(d) < dom%nb) then
-               if (allow_AMR .and. master) call warn("[refinement:init_refinement] Refinements disabled (AMR_bsize too small)")
+               if (allow_AMR .and. master .and. AMR_bsize(d) > 1) call warn("[refinement:init_refinement] Refinements disabled (AMR_bsize too small)")
                allow_AMR = .false.
             else
                if (mod(dom%n_d(d), AMR_bsize(d)) /= 0) then
@@ -155,7 +155,6 @@ contains
             level_max = base_level_id
             n_updAMR  = huge(I_ONE)
          endif
-         where (.not. dom%has_dir(:)) AMR_bsize(:) = huge(I_ONE)
 
          cbuff(1                 :  n_ref_auto_param) = refine_vars(:)%rvar
          cbuff(1+n_ref_auto_param:2*n_ref_auto_param) = refine_vars(:)%rname
@@ -222,7 +221,7 @@ contains
 
       endif
 
-      if (.not. allow_AMR) AMR_bsize=0
+      if (.not. allow_AMR) AMR_bsize = 0
 
       ! Such large refinements may require additional work in I/O routines, visualization, computing MPI tags and so on.
       if (level_max > 40) call warn("[refinement:init_refinement] BEWARE: At such large refinements, integer overflows may happen under certain conditions.")


### PR DESCRIPTION
Setting AMR_bsize(3) <= 1 in 2D (X-Y) setups was causing wrong decompositions and crashes.