### PR TITLE
Maclaurin unhacking

### DIFF
--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -71,6 +71,10 @@ contains
 #ifdef HDF5
       use dataio_user, only: user_vars_hdf5, user_attrs_wr
 #endif /* HDF5 */
+#ifdef MACLAURIN_PROBLEM
+      use problem_pub, only: maclaurin2bnd_potential
+      use user_hooks,  only: ext_bnd_potential
+#endif /* MACLAURIN_PROBLEM */
 
       implicit none
 
@@ -79,6 +83,9 @@ contains
       user_attrs_wr    => problem_initial_conditions_attrs
       user_vars_hdf5   => maclaurin_error_vars
 #endif /* HDF5 */
+#ifdef MACLAURIN_PROBLEM
+       ext_bnd_potential => maclaurin2bnd_potential
+#endif /* MACLAURIN_PROBLEM */
 
    end subroutine problem_pointers
 

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -72,7 +72,6 @@ contains
       use dataio_user, only: user_vars_hdf5, user_attrs_wr
 #endif /* HDF5 */
 #ifdef MACLAURIN_PROBLEM
-      use problem_pub, only: maclaurin2bnd_potential
       use user_hooks,  only: ext_bnd_potential
 #endif /* MACLAURIN_PROBLEM */
 
@@ -418,9 +417,6 @@ contains
       use func,             only: operator(.equals.), operator(.notequals.)
       use mpisetup,         only: master
       use named_array_list, only: qna
-#ifdef MACLAURIN_PROBLEM
-      use problem_pub,      only: xs, as, ap_potential
-#endif /* MACLAURIN_PROBLEM */
       use units,            only: newtong
 
       implicit none
@@ -532,10 +528,6 @@ contains
          cgl => cgl%nxt
       enddo
 #ifdef MACLAURIN_PROBLEM
-
-      xs = [ x0, y0, z0 ]
-      as = - 4./3. * a1**3 * pi * newtong * d0 !> \todo add correction for e /= 0
-
       apot_i = qna%ind(apt_n)
       cgl => leaves%first
       do while (associated(cgl))
@@ -662,5 +654,80 @@ contains
       end select
 
    end subroutine maclaurin_error_vars
+
+!< \brief Analytical, point-like potential outside of semi-major axis
+
+   real function ap_potential(x, y, z) result(phi)
+
+      use constants, only: pi
+      use units,     only: newtong
+
+      implicit none
+
+      real, intent(in) :: x, y, z
+
+      phi = - 4./3. * a1**3 * pi * newtong * d0 / sqrt((x-x0)**2 + (y-y0)**2 + (z-z0)**2)
+
+   end function ap_potential
+
+!>
+!! \brief Set up analytical potential at external boundaries
+!!
+!! \details This routine can be used to bypass multipole solver.
+!! It can be used for diagnosing inaccuracies that come from laplacian or multigrid without
+!! being bothered by limitations of the multipole representation and its limits.
+!<
+
+   subroutine maclaurin2bnd_potential
+
+      use cg_leaves,  only: leaves
+      use cg_list,    only: cg_list_element
+      use constants,  only: xdim, ydim, zdim, LO, HI, GEO_XYZ
+      use dataio_pub, only: die
+      use domain,     only: dom
+      use grid_cont,  only: grid_container
+      use units,      only: fpiG
+
+      implicit none
+
+      integer :: i, j, k
+      type(cg_list_element), pointer :: cgl
+      type(grid_container), pointer :: cg
+
+      if (dom%geometry_type /= GEO_XYZ) call die("[initproblem:maclaurin2bnd_potential] only cartesian geometry implemented")
+
+      cgl => leaves%first
+      do while (associated(cgl))
+         cg => cgl%cg
+         if (any(cg%ext_bnd(xdim, :))) then
+            do j = cg%js, cg%je
+               do k = cg%ks, cg%ke
+                  if (cg%ext_bnd(xdim, LO)) cg%mg%bnd_x(j, k, LO) = ap_potential(cg%fbnd(xdim, LO), cg%y(j), cg%z(k)) * fpiG
+                  if (cg%ext_bnd(xdim, HI)) cg%mg%bnd_x(j, k, HI) = ap_potential(cg%fbnd(xdim, HI), cg%y(j), cg%z(k)) * fpiG
+               enddo
+            enddo
+         endif
+
+         if (any(cg%ext_bnd(ydim, :))) then
+            do i = cg%is, cg%ie
+               do k = cg%ks, cg%ke
+                  if (cg%ext_bnd(ydim, LO)) cg%mg%bnd_y(i, k, LO) = ap_potential(cg%x(i), cg%fbnd(ydim, LO), cg%z(k)) * fpiG
+                  if (cg%ext_bnd(ydim, HI)) cg%mg%bnd_y(i, k, HI) = ap_potential(cg%x(i), cg%fbnd(ydim, HI), cg%z(k)) * fpiG
+               enddo
+            enddo
+         endif
+
+         if (any(cg%ext_bnd(zdim, :))) then
+            do i = cg%is, cg%ie
+               do j = cg%js, cg%je
+                  if (cg%ext_bnd(zdim, LO)) cg%mg%bnd_z(i, j, LO) = ap_potential(cg%x(i), cg%y(j), cg%fbnd(zdim, LO)) * fpiG
+                  if (cg%ext_bnd(zdim, HI)) cg%mg%bnd_z(i, j, HI) = ap_potential(cg%x(i), cg%y(j), cg%fbnd(zdim, HI)) * fpiG
+               enddo
+            enddo
+         endif
+         cgl => cgl%nxt
+      enddo
+
+   end subroutine maclaurin2bnd_potential
 
 end module initproblem

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -57,9 +57,6 @@ module initproblem
    character(len=dsetnamelen), parameter :: apot_n = "apot" !< name of the analytical potential field
    character(len=dsetnamelen), parameter :: asrc_n = "asrc" !< name of the source field used for "ares" calculation (auxiliary space)
    character(len=dsetnamelen), parameter :: ares_n = "ares" !< name of the numerical residuum with respect to analytical potential field
-#ifdef MACLAURIN_PROBLEM
-   character(len=dsetnamelen), parameter :: apt_n  = "apt"  !< name of the potential as it was due to point-like source
-#endif /* MACLAURIN_PROBLEM */
 
 contains
 
@@ -223,9 +220,6 @@ contains
       call all_cg%reg_var(apot_n, ord_prolong = ord_prolong)
       call all_cg%reg_var(ares_n)
       call all_cg%reg_var(asrc_n)
-#ifdef MACLAURIN_PROBLEM
-      call all_cg%reg_var(apt_n)
-#endif /* MACLAURIN_PROBLEM */
 
       ! Set up automatic refinement criteria on densities
       do id = lbound(iarr_all_dn, dim=1, kind=4), ubound(iarr_all_dn, dim=1, kind=4)
@@ -527,23 +521,6 @@ contains
 
          cgl => cgl%nxt
       enddo
-#ifdef MACLAURIN_PROBLEM
-      apot_i = qna%ind(apt_n)
-      cgl => leaves%first
-      do while (associated(cgl))
-         cg => cgl%cg
-
-         do k = cg%ks, cg%ke
-            do j = cg%js, cg%je
-               do i = cg%is, cg%ie
-                  cg%q(apot_i)%arr(i, j, k) = ap_potential(cg%x(i), cg%y(j), cg%z(k))
-               enddo
-            enddo
-         enddo
-
-         cgl => cgl%nxt
-      enddo
-#endif /* MACLAURIN_PROBLEM */
 
    end subroutine compute_maclaurin_potential
 
@@ -645,10 +622,6 @@ contains
             elsewhere
                tab(:,:,:) = 0.
             endwhere
-#ifdef MACLAURIN_PROBLEM
-         case ("a-pt")
-            tab(:,:,:) = cg%q(qna%ind(apot_n))%span(cg%ijkse) - cg%q(qna%ind(apt_n))%span(cg%ijkse)
-#endif /* MACLAURIN_PROBLEM */
          case default
             ierrh = -1
       end select

--- a/problems/maclaurin/problem.par.quite_accurate
+++ b/problems/maclaurin/problem.par.quite_accurate
@@ -29,7 +29,7 @@
 
  $END_CONTROL
     tend   = 0.0
-    nend   = 1 ! we can set here 0 as weel, but this would issue a warning
+    nend   = 1 ! we can set here 0 as well, but this would issue a warning
  /
 
  $OUTPUT_CONTROL

--- a/src/base/problem_pub.F90
+++ b/src/base/problem_pub.F90
@@ -30,13 +30,11 @@
 !! \brief This module contains problem variables intended to use across the code.
 !!
 !! \details It is strongly discouraged to use this feature for purposes other than debugging.
+!!
+!! \todo Get rid of this file
 !<
 
 module problem_pub
-
-#ifdef MACLAURIN_PROBLEM
-   use constants, only: ndims
-#endif /* MACLAURIN_PROBLEM */
 
    implicit none
 
@@ -47,80 +45,8 @@ module problem_pub
    real :: jeans_d0
    integer :: jeans_mode
 #endif /* JEANS_PROBLEM */
-#ifdef MACLAURIN_PROBLEM
-   real, dimension(ndims) :: xs ! position of the sphere
-   real :: as ! factor used to calculate the potential
-#endif /* MACLAURIN_PROBLEM */
 
 contains
 
-#ifdef MACLAURIN_PROBLEM
-!> \brief Calculate point-like potential for the maclaurin problem
-
-   real function ap_potential(x, y, z) result(phi)
-
-      use constants, only: xdim, ydim, zdim
-
-      implicit none
-
-      real, intent(in) :: x, y, z
-
-      phi = as / sqrt((x-xs(xdim))**2 + (y-xs(ydim))**2 + (z-xs(zdim))**2)
-
-   end function ap_potential
-
-   subroutine maclaurin2bnd_potential
-
-      use cg_leaves,  only: leaves
-      use cg_list,    only: cg_list_element
-      use constants,  only: xdim, ydim, zdim, LO, HI, GEO_XYZ
-      use dataio_pub, only: die
-      use domain,     only: dom
-      use grid_cont,  only: grid_container
-      use units,      only: fpiG
-
-      implicit none
-
-      integer :: i, j, k
-      type(cg_list_element), pointer :: cgl
-      type(grid_container), pointer :: cg
-
-      if (dom%geometry_type /= GEO_XYZ) call die("[problem_pub:maclaurin2bnd_potential] only cartesian geometry implemented")
-
-      cgl => leaves%first
-      do while (associated(cgl))
-         cg => cgl%cg
-         if (any(cg%ext_bnd(xdim, :))) then
-            do j = cg%js, cg%je
-               do k = cg%ks, cg%ke
-                  if (cg%ext_bnd(xdim, LO)) cg%mg%bnd_x(j, k, LO) = ap_potential(cg%fbnd(xdim, LO), cg%y(j), cg%z(k)) * fpiG
-                  if (cg%ext_bnd(xdim, HI)) cg%mg%bnd_x(j, k, HI) = ap_potential(cg%fbnd(xdim, HI), cg%y(j), cg%z(k)) * fpiG
-               enddo
-            enddo
-         endif
-
-         if (any(cg%ext_bnd(ydim, :))) then
-            do i = cg%is, cg%ie
-               do k = cg%ks, cg%ke
-                  if (cg%ext_bnd(ydim, LO)) cg%mg%bnd_y(i, k, LO) = ap_potential(cg%x(i), cg%fbnd(ydim, LO), cg%z(k)) * fpiG
-                  if (cg%ext_bnd(ydim, HI)) cg%mg%bnd_y(i, k, HI) = ap_potential(cg%x(i), cg%fbnd(ydim, HI), cg%z(k)) * fpiG
-               enddo
-            enddo
-         endif
-
-         if (any(cg%ext_bnd(zdim, :))) then
-            do i = cg%is, cg%ie
-               do j = cg%js, cg%je
-                  if (cg%ext_bnd(zdim, LO)) cg%mg%bnd_z(i, j, LO) = ap_potential(cg%x(i), cg%y(j), cg%fbnd(zdim, LO)) * fpiG
-                  if (cg%ext_bnd(zdim, HI)) cg%mg%bnd_z(i, j, HI) = ap_potential(cg%x(i), cg%y(j), cg%fbnd(zdim, HI)) * fpiG
-               enddo
-            enddo
-         endif
-         cgl => cgl%nxt
-      enddo
-
-   end subroutine maclaurin2bnd_potential
-
-#endif /* MACLAURIN_PROBLEM */
 
 end module problem_pub

--- a/src/base/user_hooks.F90
+++ b/src/base/user_hooks.F90
@@ -35,7 +35,7 @@ module user_hooks
    private
    public :: problem_customize_solution, problem_grace_passed, finalize_problem, cleanup_problem, problem_refine_derefine, &
         &    custom_emf_bnd, at_user_dims_settings, at_user_area_settings, problem_post_restart, user_vars_arr_in_restart, &
-        &    user_reaction_to_redo_step, late_initial_conditions, problem_domain_update, problem_post_IC
+        &    user_reaction_to_redo_step, late_initial_conditions, problem_domain_update, problem_post_IC, ext_bnd_potential
 
    interface
 
@@ -83,5 +83,6 @@ module user_hooks
    procedure(tab_args),    pointer :: custom_emf_bnd             => NULL()
    procedure(indx_args),   pointer :: at_user_dims_settings      => NULL()
    procedure(user_area),   pointer :: at_user_area_settings      => NULL()
+   procedure(no_args),     pointer :: ext_bnd_potential          => NULL() !< An user-provided replacement for multipole_solver
 
 end module user_hooks

--- a/src/gravity/multigridmultipole.F90
+++ b/src/gravity/multigridmultipole.F90
@@ -313,19 +313,17 @@ contains
 
    subroutine multipole_solver
 
-      use cg_leaves,          only: leaves
-!!$      use cg_level_connected, only: finest !, cg_level_connected_T
-      use constants,          only: dirtyH
-!!$      use dataio_pub,         only: die
-      use global,             only: dirty_debug
-!!$      use multigridvars,      only: solution
-#ifdef MACLAURIN_PROBLEM
-      use problem_pub,        only: maclaurin2bnd_potential
-#endif /* MACLAURIN_PROBLEM */
+      use cg_leaves,  only: leaves
+      use constants,  only: dirtyH
+      use global,     only: dirty_debug
+      use user_hooks, only: ext_bnd_potential
 
       implicit none
 
-!!$      type(cg_level_connected_T), pointer :: curl
+      if (associated(ext_bnd_potential)) then
+         call ext_bnd_potential
+         return
+      endif
 
       call refresh_multipole
 
@@ -346,7 +344,6 @@ contains
 !!$      endif
       call potential2img_mass
 
-#ifndef MACLAURIN_PROBLEM
       if (use_point_monopole) then
          call find_img_CoM
          call isolated_monopole
@@ -356,9 +353,6 @@ contains
          call img_mass2moments
          call moments2bnd_potential
       endif
-#else /* MACLAURIN_PROBLEM */
-      call maclaurin2bnd_potential
-#endif /* ! MACLAURIN_PROBLEM */
 
       !> \todo The approach with lmpole should be reworked completely. With AMR use only current level and reinitialize some things if refinements have changed
 !!$      if (.not. associated(lmpole, finest)) then

--- a/src/multigrid/multigrid_vstats.F90
+++ b/src/multigrid/multigrid_vstats.F90
@@ -112,9 +112,9 @@ contains
       class(vcycle_stats), intent(in) :: this
 
       real                   :: at
-      integer                :: i, lm, ftype
+      integer                :: i, lm
       character(len=fplen)   :: normred
-      character(len=fmt_len), parameter, dimension(2) :: fmt_norm = [ '(a,i3,1x,2a,f7.3,a,i3,a,f7.3,a,f13.10,a)', '(a,i3,1x,2a,f7.3,a,i3,a,f7.3,a,e13.6,a) ' ]
+      character(len=fmt_len) :: fmt_norm
 
       if (slave) return
 
@@ -123,9 +123,8 @@ contains
       at = 0.
       if (this%count > 0) at = sum(this%time(1:this%count))/this%count ! average V-cycle time on PE# 0
 
-      ftype = 1
-      if (this%norm_final < 1e-8) ftype = 2
-      write(msg, fmt_norm(ftype))"[multigrid] ", this%count, trim(this%cprefix), "cycles, dt_wall=", this%time(0), " +", this%count, "*", at, ", norm/rhs= ", this%norm_final, " : "
+      fmt_norm = '(a,i3,1x,2a,' // merge('f7.1', 'f7.3', this%time(0)>=1000.) // ',a,i3,a,f7.3,a,' // merge('e13.6 ', 'f13.10', this%norm_final < 1e-8) // ',a)'
+      write(msg, fmt_norm)"[multigrid] ", this%count, trim(this%cprefix), "cycles, dt_wall=", this%time(0), " +", this%count, "*", at, ", norm/rhs= ", this%norm_final, " : "
 
       do i = 0, min(this%count, ubound(this%factor, 1))
          if (this%factor(i) < 1.0e4) then


### PR DESCRIPTION
* Removed ugly #ifdef MACLAURIN_PROBLEM .
* Added `user_hooks::ext_bnd_potential` for bypassing default multipole solver.