### PR TITLE
3D multipole solver

### DIFF
--- a/problems/maclaurin/mpi_test.par
+++ b/problems/maclaurin/mpi_test.par
@@ -87,7 +87,7 @@
     max_cycles = 100
     vcycle_abort  = 100.
     lmax = 16
-!    use_point_monopole = .true.
+!    mpole_solver = "monopole"
  /
 
  $AMR

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -103,7 +103,7 @@ contains
 !! <tr><td>lmax                  </td><td>16     </td><td>integer value  </td><td>\copydoc multipole::lmax                          </td></tr>
 !! <tr><td>mmax                  </td><td>-1     </td><td>integer value  </td><td>\copydoc multipole::mmax                          </td></tr>
 !! <tr><td>ord_prolong_mpole     </td><td>-2     </td><td>integer value  </td><td>\copydoc multipole::ord_prolong_mpole             </td></tr>
-!! <tr><td>use_point_monopole    </td><td>.false.</td><td>logical        </td><td>\copydoc multipole::use_point_monopole            </td></tr>
+!! <tr><td>mpole_solver          </td><td>.false.</td><td>logical        </td><td>\copydoc multipole::mpole_solver                  </td></tr>
 !! <tr><td>interp_pt2mom         </td><td>.false.</td><td>logical        </td><td>\copydoc multipole::interp_pt2mom                 </td></tr>
 !! <tr><td>interp_mom2pot        </td><td>.false.</td><td>logical        </td><td>\copydoc multipole::interp_mom2pot                </td></tr>
 !! <tr><td>multidim_code_3D      </td><td>.false.</td><td>logical        </td><td>\copydoc multigridvars::multidim_code_3d          </td></tr>
@@ -129,7 +129,7 @@ contains
       use multigrid_Laplace,  only: ord_laplacian, ord_laplacian_outer
       use multigrid_Laplace4, only: L4_strength
       use multigrid_old_soln, only: nold_max, ord_time_extrap
-      use multipole,          only: use_point_monopole, lmax, mmax, ord_prolong_mpole
+      use multipole,          only: mpole_solver, lmax, mmax, ord_prolong_mpole
       use multipole_array,    only: interp_pt2mom, interp_mom2pot
       use pcg,                only: use_CG, use_CG_outer, preconditioner, default_preconditioner, pcg_init
 
@@ -141,7 +141,7 @@ contains
       namelist /MULTIGRID_GRAVITY/ norm_tol, coarsest_tol, vcycle_abort, vcycle_giveup, max_cycles, nsmool, nsmoob, use_CG, use_CG_outer, &
            &                       overrelax, L4_strength, ord_laplacian, ord_laplacian_outer, ord_time_extrap, &
            &                       base_no_fft, fft_patient, &
-           &                       lmax, mmax, ord_prolong_mpole, use_point_monopole, interp_pt2mom, interp_mom2pot, multidim_code_3D, &
+           &                       lmax, mmax, ord_prolong_mpole, mpole_solver, interp_pt2mom, interp_mom2pot, multidim_code_3D, &
            &                       grav_bnd_str, preconditioner
 
       if (.not.frun) call die("[multigrid_gravity:multigrid_grav_par] Called more than once.")
@@ -172,7 +172,7 @@ contains
       ord_prolong_mpole      = O_D2
       ord_time_extrap        = O_LIN
 
-      use_point_monopole     = .false.
+      mpole_solver           = "img_mass"
       base_no_fft            = .false.
       fft_patient            = .false.
       interp_pt2mom          = .false.
@@ -249,7 +249,6 @@ contains
          ibuff( 9) = ord_time_extrap
          ibuff(10) = ord_laplacian_outer
 
-         lbuff(1)  = use_point_monopole
          lbuff(2)  = base_no_fft
          lbuff(3)  = fft_patient
          lbuff(4)  = interp_pt2mom
@@ -260,6 +259,7 @@ contains
 
          cbuff(1)  = grav_bnd_str
          cbuff(2)  = preconditioner
+         cbuff(3)  = mpole_solver
       endif
 
       call piernik_MPI_Bcast(cbuff, cbuff_len)
@@ -286,7 +286,6 @@ contains
          ord_time_extrap   = ibuff( 9)
          ord_laplacian_outer = ibuff(10)
 
-         use_point_monopole = lbuff(1)
          base_no_fft        = lbuff(2)
          fft_patient        = lbuff(3)
          interp_pt2mom      = lbuff(4)
@@ -297,6 +296,8 @@ contains
 
          grav_bnd_str   = cbuff(1)(1:len(grav_bnd_str))
          preconditioner = cbuff(2)(1:len(preconditioner))
+         mpole_solver   = cbuff(3)(1:len(mpole_solver))
+
       endif
 
       ! boundaries

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -104,6 +104,7 @@ contains
 !! <tr><td>mmax                  </td><td>-1     </td><td>integer value  </td><td>\copydoc multipole::mmax                          </td></tr>
 !! <tr><td>ord_prolong_mpole     </td><td>-2     </td><td>integer value  </td><td>\copydoc multipole::ord_prolong_mpole             </td></tr>
 !! <tr><td>mpole_solver          </td><td>.false.</td><td>logical        </td><td>\copydoc multipole::mpole_solver                  </td></tr>
+!! <tr><td>level_3D              </td><td>1      </td><td>integer value  </td><td>\copydoc multipole::level_3D                      </td></tr>
 !! <tr><td>interp_pt2mom         </td><td>.false.</td><td>logical        </td><td>\copydoc multipole::interp_pt2mom                 </td></tr>
 !! <tr><td>interp_mom2pot        </td><td>.false.</td><td>logical        </td><td>\copydoc multipole::interp_mom2pot                </td></tr>
 !! <tr><td>multidim_code_3D      </td><td>.false.</td><td>logical        </td><td>\copydoc multigridvars::multidim_code_3d          </td></tr>
@@ -129,7 +130,7 @@ contains
       use multigrid_Laplace,  only: ord_laplacian, ord_laplacian_outer
       use multigrid_Laplace4, only: L4_strength
       use multigrid_old_soln, only: nold_max, ord_time_extrap
-      use multipole,          only: mpole_solver, lmax, mmax, ord_prolong_mpole
+      use multipole,          only: mpole_solver, lmax, mmax, ord_prolong_mpole, level_3D
       use multipole_array,    only: interp_pt2mom, interp_mom2pot
       use pcg,                only: use_CG, use_CG_outer, preconditioner, default_preconditioner, pcg_init
 
@@ -141,7 +142,7 @@ contains
       namelist /MULTIGRID_GRAVITY/ norm_tol, coarsest_tol, vcycle_abort, vcycle_giveup, max_cycles, nsmool, nsmoob, use_CG, use_CG_outer, &
            &                       overrelax, L4_strength, ord_laplacian, ord_laplacian_outer, ord_time_extrap, &
            &                       base_no_fft, fft_patient, &
-           &                       lmax, mmax, ord_prolong_mpole, mpole_solver, interp_pt2mom, interp_mom2pot, multidim_code_3D, &
+           &                       lmax, mmax, ord_prolong_mpole, mpole_solver, level_3D, interp_pt2mom, interp_mom2pot, multidim_code_3D, &
            &                       grav_bnd_str, preconditioner
 
       if (.not.frun) call die("[multigrid_gravity:multigrid_grav_par] Called more than once.")
@@ -157,6 +158,7 @@ contains
 
       lmax                   = 16
       mmax                   = -1 ! will be automatically set to lmax unless explicitly limited in problem.par
+      level_3D               = 1
       max_cycles             = 20
       nsmool                 = -1  ! best to set it to dom%nb or its multiply
       nsmoob                 = 10000
@@ -239,6 +241,7 @@ contains
          rbuff(5)  = L4_strength
          rbuff(6)  = coarsest_tol
 
+         ibuff( 1) = level_3D
          ibuff( 2) = lmax
          ibuff( 3) = mmax
          ibuff( 4) = max_cycles
@@ -276,6 +279,7 @@ contains
          L4_strength    = rbuff(5)
          coarsest_tol   = rbuff(6)
 
+         level_3D          = ibuff( 1)
          lmax              = ibuff( 2)
          mmax              = ibuff( 3)
          max_cycles        = ibuff( 4)

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -129,7 +129,8 @@ contains
       use multigrid_Laplace,  only: ord_laplacian, ord_laplacian_outer
       use multigrid_Laplace4, only: L4_strength
       use multigrid_old_soln, only: nold_max, ord_time_extrap
-      use multipole,          only: use_point_monopole, lmax, mmax, ord_prolong_mpole, interp_pt2mom, interp_mom2pot
+      use multipole,          only: use_point_monopole, lmax, mmax, ord_prolong_mpole
+      use multipole_array,    only: interp_pt2mom, interp_mom2pot
       use pcg,                only: use_CG, use_CG_outer, preconditioner, default_preconditioner, pcg_init
 
       implicit none

--- a/src/gravity/multigridmultipole.F90
+++ b/src/gravity/multigridmultipole.F90
@@ -418,8 +418,7 @@ contains
          cg => cgl%cg
          do lh = LO, HI
             if (cg%ext_bnd(xdim, lh)) then
-               d = 1
-               if (lh == HI) d = cg%n_b(xdim)
+               d = cg%ijkse(xdim, lh)
                dsum(imass)     =        sum( cg%mg%bnd_x(cg%js:cg%je, cg%ks:cg%ke, lh), mask=cg%leafmap(d, :, :) )
                dsum(xdim:zdim) = [ dsum(imass) * cg%fbnd(xdim, lh), &
                     &              sum( sum( cg%mg%bnd_x(cg%js:cg%je, cg%ks:cg%ke, lh), mask=cg%leafmap(d, :, :), dim=2) * cg%y(cg%js:cg%je) ), &
@@ -427,8 +426,7 @@ contains
                lsum(:)         = lsum(:) + dsum(:) * cg%dyz
             endif
             if (cg%ext_bnd(ydim, lh)) then
-               d = 1
-               if (lh == HI) d = cg%n_b(ydim)
+               d = cg%ijkse(ydim, lh)
                dsum(imass)     =        sum( cg%mg%bnd_y(cg%is:cg%ie, cg%ks:cg%ke, lh), mask=cg%leafmap(:, d, :) )
                dsum(xdim:zdim) = [ sum( sum( cg%mg%bnd_y(cg%is:cg%ie, cg%ks:cg%ke, lh), mask=cg%leafmap(:, d, :), dim=2) * cg%x(cg%is:cg%ie) ), &
                     &              dsum(imass) * cg%fbnd(ydim, lh), &
@@ -436,8 +434,7 @@ contains
                lsum(:)         = lsum(:) + dsum(:) * cg%dxz
             endif
             if (cg%ext_bnd(zdim, lh)) then
-               d = 1
-               if (lh == HI) d = cg%n_b(zdim)
+               d = cg%ijkse(zdim, lh)
                dsum(imass)     =        sum( cg%mg%bnd_z(cg%is:cg%ie, cg%js:cg%je, lh), mask=cg%leafmap(:, :, d) )
                dsum(xdim:zdim) = [ sum( sum( cg%mg%bnd_z(cg%is:cg%ie, cg%js:cg%je, lh), mask=cg%leafmap(:, :, d), dim=2) * cg%x(cg%is:cg%ie) ), &
                     &              sum( sum( cg%mg%bnd_z(cg%is:cg%ie, cg%js:cg%je, lh), mask=cg%leafmap(:, :, d), dim=1) * cg%y(cg%js:cg%je) ), &

--- a/src/gravity/multipole_array.F90
+++ b/src/gravity/multipole_array.F90
@@ -30,6 +30,7 @@
 !> \brief This module implements an array containing radial distribution of multipole moments
 
 module multipole_array
+! pulled by MULTIGRID && SELF_GRAV
 
    implicit none
 

--- a/src/gravity/multipole_array.F90
+++ b/src/gravity/multipole_array.F90
@@ -1,0 +1,569 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+
+#include "piernik.h"
+
+!> \brief This module implements an array containing radial distribution of multipole moments
+
+module multipole_array
+
+   implicit none
+
+   private
+   public :: mpole_container
+   public :: interp_pt2mom, interp_mom2pot  ! initialized in multigrid_gravity
+
+   ! namelist parameters for MULTIGRID_GRAVITY
+   logical :: interp_pt2mom  !< Distribute contribution from a cell between two adjacent radial bins (linear interpolation in radius)
+   logical :: interp_mom2pot !< Compute the potential from moments from two adjacent radial bins (linear interpolation in radius)
+
+   type :: mpole_container
+
+      real, dimension(:,:,:), allocatable          :: Q       !< The whole moment array with dependence on radius
+      integer(kind=4),                     private :: lmax    !< Maximum l-order of multipole moments
+      integer(kind=4),                     private :: mmax    !< Maximum m-order of multipole moments. Equal to lmax by default.
+
+      ! auxiliary factors
+      real, dimension(:,:,:), allocatable, private :: k12     !< array of Legendre recurrence factors
+      real, dimension(:),     allocatable, private :: sfac    !< 0..m_max sized array of azimuthal sine factors
+      real, dimension(:),     allocatable, private :: cfac    !< 0..m_max sized array of azimuthal cosine factors
+      real, dimension(:),     allocatable, private :: ofact   !< arrays of Legendre normalization factor (compressed)
+      ! radial discretization
+      integer,                             private :: irmin   !< minimum Q(:, :, r) index in use
+      integer,                             private :: irmax   !< maximum Q(:, :, r) index in use
+      integer,                             private :: rqbin   !< number of radial samples of multipoles
+      real,                                private :: drq     !< radial resolution of multipoles
+      real,                                private :: rscale  !< scaling factor that limits risk of floating poin
+      real, dimension(:),     allocatable, private :: rn      !< 0..l_max sized array of positive powers of r
+      real, dimension(:),     allocatable, private :: irn     !< 0..l_max sized array of negative powers of r
+
+   contains
+
+      procedure          :: init_once
+      procedure          :: refresh
+      procedure          :: reset
+      procedure          :: red_int_norm
+      procedure          :: cleanup
+      procedure          :: point2moments
+      procedure          :: moments2pot
+      procedure, private :: lm
+      procedure, private :: geomfac4moments
+
+   end type mpole_container
+
+   enum, bind(C)
+      enumerator :: INSIDE = 1, OUTSIDE  !< indices for interior and exterior multipole expansion, respectively
+   end enum
+
+contains
+
+   subroutine init_once(this, lmax, mmax)
+
+      use dataio_pub, only: die
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+      integer(kind=4),        intent(in)    :: lmax  !< Maximum l-order of multipole moments
+      integer(kind=4),        intent(in)    :: mmax  !< Maximum m-order of multipole moments. Equal to lmax by default.
+
+      integer :: l, m
+
+      if (lmax < 0) call die("[multipole_array:init_once] lmax < 0")
+      if (mmax < 0) call die("[multipole_array:init_once] mmax < 0")
+      if (mmax > lmax) call die("[multipole_array:init_once] mmax > lmax")
+
+      this%lmax = lmax
+      this%mmax = mmax
+
+      if (allocated(this%k12) .or. allocated(this%ofact)) call die("[multipole_array:init_once] k12 or ofact already allocated")
+      allocate(this%k12(2, 1:lmax, 0:mmax), this%ofact(0:this%lm(int(lmax), int(2*mmax))))
+
+      if (allocated(this%sfac) .or. allocated(this%cfac)) call die("[multipole_array:init_once] sfac or cfac already allocated")
+      allocate(this%sfac(0:mmax), this%cfac(0:mmax))
+
+      if (allocated(this%rn) .or. allocated(this%irn)) call die("[multipole_array:init_once] rn or irn already allocated")
+      allocate(this%rn(0:lmax), this%irn(0:lmax))
+
+      this%ofact(:) = 0. ! prevent spurious FP exceptions in multipole:img_mass2moments
+      do l = 1, this%lmax
+         do m = 0, min(l, int(this%mmax))
+            if (m == 0) then
+               this%ofact(l) = 2. ! this%lm(l,0)
+            else                     ! this%ofact(l, 2*m) = ((-1)^m (2m-1)!!)**2 (l-m)! / (l+m)! ; Should work up to m=512 and even beyond
+               this%ofact(this%lm(l, 2*m))   = this%ofact(this%lm(l, 2*(m-1))) * real(1 - 2*m)**2 / real((l+m) * (l-m+1))
+               this%ofact(this%lm(l, 2*m-1)) = this%ofact(this%lm(l, 2*m))
+            endif
+            if (l>m) then
+               this%k12(1, l, m) = real(2 * l - 1) / real(l - m)
+               this%k12(2, l, m) = real(l + m - 1) / real(l - m)
+            endif
+         enddo
+      enddo
+      this%ofact(0:this%lmax) = 1. ! this%lm(0:this%lmax,0)
+
+      this%cfac(0) = 1.e0
+      this%sfac(0) = 0.e0
+
+   end subroutine init_once
+
+   subroutine refresh(this)
+
+      use cg_level_finest, only: finest
+      use constants,       only: xdim, zdim, GEO_XYZ, GEO_RPZ, HI, pMIN
+      use dataio_pub,      only: die
+      use domain,          only: dom
+      use mpisetup,        only: piernik_MPI_Allreduce
+      use particle_pub,    only: pset
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+
+      integer :: i
+
+      if (associated(finest%level%first)) then
+         select case (dom%geometry_type)
+            case (GEO_XYZ)
+               this%drq = minval(finest%level%first%cg%dl(:), mask=dom%has_dir(:)) / 2.
+            case (GEO_RPZ)
+               this%drq = min(finest%level%first%cg%dx, dom%C_(xdim)*finest%level%first%cg%dy, finest%level%first%cg%dz) / 2.
+            case default
+               call die("[multipole_array:refresh] Unsupported geometry.")
+         end select
+      else
+         this%drq = maxval(dom%L_(:))
+      endif
+      call piernik_MPI_Allreduce(this%drq, pMIN)
+
+      select case (dom%geometry_type)
+         case (GEO_XYZ)
+            this%rqbin = int(sqrt(sum(dom%L_(:)**2))/this%drq) + 1
+            ! arithmetic average of the closest and farthest points of computational domain with respect to its center
+            !>
+            !!\todo check what happens if there are points that are really close to the domain center (maybe we should use a harmonic average?)
+            !! Issue a warning or error if it is known that given lmax leads to FP overflows in rn(:) and irn(:)
+            !<
+            this%rscale = ( minval(dom%L_(:)) + sqrt(sum(dom%L_(:)**2)) )/4.
+         case (GEO_RPZ)
+            this%rqbin = int(sqrt((2.*dom%edge(xdim, HI))**2 + dom%L_(zdim)**2)/this%drq) + 1
+            this%rscale = ( min(2.*dom%edge(xdim, HI), dom%L_(zdim)) + sqrt((2.*dom%edge(xdim, HI))**2 + dom%L_(zdim)**2) )/4.
+         case default
+            call die("[multipole_array:refresh] Unsupported geometry.")
+      end select
+
+      do i = lbound(pset%p, dim=1), ubound(pset%p, dim=1)
+         !> \warning this is not optimal, when domain is placed far away form the origin
+         !> \warning a factor of up to 2 may be required if we use CoM as the origin
+         if (pset%p(i)%outside) this%rqbin = max(this%rqbin, int(sqrt(sum(pset%p(i)%pos**2))/this%drq) + 1)
+      enddo
+
+      if (allocated(this%Q)) deallocate(this%Q)
+      allocate(this%Q(0:this%lm(int(this%lmax), int(2*this%mmax)), INSIDE:OUTSIDE, 0:this%rqbin))
+
+   end subroutine refresh
+
+!> \brief reset the multipole data
+
+   subroutine reset(this)
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+
+      this%Q = 0.
+      this%irmax = 0
+      this%irmin = this%rqbin
+
+   end subroutine reset
+
+!> \brief Integrate radially and apply normalization factor (the (4 \pi)/(2 l  + 1) terms cancel out)
+
+   subroutine red_int_norm(this)
+
+      use constants, only: pSUM, pMIN, pMAX
+      use mpisetup,  only: piernik_MPI_Allreduce
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+
+      integer :: r, rr
+
+      call piernik_MPI_Allreduce(this%irmin, pMIN)
+      call piernik_MPI_Allreduce(this%irmax, pMAX)
+
+      ! integrate radially and apply normalization factor (the (4 \pi)/(2 l  + 1) terms cancel out)
+      rr = max(1, this%irmin)
+      this%Q(:, INSIDE, rr-1) = this%Q(:, INSIDE, rr-1) * this%ofact(:)
+      do r = rr, this%irmax
+         this%Q(:, INSIDE, r) = this%Q(:, INSIDE, r) * this%ofact(:) + this%Q(:, INSIDE, r-1)
+      enddo
+
+      this%Q(:, OUTSIDE, this%irmax+1) = this%Q(:, OUTSIDE, this%irmax+1) * this%ofact(:)
+      do r = this%irmax, rr, -1
+         this%Q(:, OUTSIDE, r) = this%Q(:, OUTSIDE, r) * this%ofact(:) + this%Q(:, OUTSIDE, r+1)
+      enddo
+
+      call piernik_MPI_Allreduce(this%Q(:, :, this%irmin:this%irmax), pSUM)
+
+   end subroutine red_int_norm
+
+   subroutine cleanup(this)
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+
+      if (allocated(this%rn))    deallocate(this%rn)
+      if (allocated(this%irn))   deallocate(this%irn)
+      if (allocated(this%sfac))  deallocate(this%sfac)
+      if (allocated(this%cfac))  deallocate(this%cfac)
+      if (allocated(this%Q))     deallocate(this%Q)
+      if (allocated(this%k12))   deallocate(this%k12)
+      if (allocated(this%ofact)) deallocate(this%ofact)
+
+   end subroutine cleanup
+
+
+!>
+!! \brief This function returns array index for "compressed" this%Q(:, inout, r) array replacing "plain" this%Q(l, m, inout, r) array
+!! \details Originally there were separate indices for l and m multipole numbers in Q and ofact arrays. Since there are no Y_{l,m} harmonics for l<|m|, approximately half of the Q array
+!! was left unused. For each m there is only lmax-|m|+1 valid Y_{l,m} harmonic contributions (for l = |m| .. lmax). The function lm(l, m) converts each valid (l,m) pair into an
+!! unique index leaving no unused entries in the Q array.
+!! Assume that real Y_{l,m} harmonic was stored in this%Q(l, 2*|m|, :, :) for even (cosine, positive-m) harmonic, or in this%Q(l, 2*|m|-1, :, :) for odd (sine, negative-m) harmonic.
+!! Then consecutive entries in compressed this%Q(:, inout, r) array should be related to Y_{l,m} harmonics, starting from index 0 as follows
+!! Y_{0,0}, Y_{1,0}, ..., Y_{lmax, 0}, Y_{1,-1}, Y_{2,-1}, ..., Y_{lmax,-1}, Y_{1,1}, Y_{2,1}, ..., Y_{lmax,1}, Y_{2,-2}, Y_{3,-2}, ..., Y_{lmax,-2},
+!! Y_{2,2}, Y_{3,2}, ..., Y_{lmax,2}, ..., Y(lmax-1,-(mmax-1)), Y(lmax,-(mmax-1)), Y(lmax-1,mmax-1), Y(lmax,mmax-1), Y(lmax,-mmax), Y(lmax,mmax)
+!! Does it looks a bit cryptic? I agree.
+!<
+
+   elemental integer function lm(this, l, m)
+
+      implicit none
+
+      class(mpole_container), intent(in) :: this  !< object invoking type-bound procedure
+      integer, intent(in) :: l, m
+
+      lm = l + m * this%lmax - int((m-1)/2)*int(m/2)
+
+   end function lm
+
+!>
+!! \brief Compute multipole moments for a single point
+!!
+!! \todo try to improve accuracy with linear interpolation over radius
+!<
+
+   subroutine point2moments(this, mass, x, y, z)
+
+      use constants, only: zero
+      use func,      only: operator(.notequals.)
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+      real, intent(in) :: mass    !< mass of the contributing point
+      real, intent(in) :: x       !< x coordinate of the contributing point
+      real, intent(in) :: y       !< y coordinate of the contributing point
+      real, intent(in) :: z       !< z coordinate of the contributing point
+
+      real    :: sin_th, cos_th, del
+      real    :: Ql, Ql1, Ql2
+      integer :: l, m, ir, m2s, m2c
+
+      call this%geomfac4moments(mass, x, y, z, sin_th, cos_th, ir, del)
+
+      if (.not. interp_pt2mom) del = 0.
+
+      ! monopole, the (0,0) moment; P_0 = 1.
+      this%Q(0, INSIDE,  ir)   = this%Q(0, INSIDE,  ir)   +  this%rn(0) * (1.-del)
+      this%Q(0, OUTSIDE, ir)   = this%Q(0, OUTSIDE, ir)   + this%irn(0) * (1.-del)
+      if (del .notequals. zero) then
+         this%Q(0, INSIDE,  ir+1) = this%Q(0, INSIDE,  ir+1) +  this%rn(0) * del
+         this%Q(0, OUTSIDE, ir+1) = this%Q(0, OUTSIDE, ir+1) + this%irn(0) * del
+      endif
+
+      ! axisymmetric (l,0) moments
+      ! Legendre polynomial recurrence: l P_l = x (2l-1) P_{l-1} - (l-1) P_{l-2}, x \eqiv \cos(\theta)
+      Ql2 = 0.
+      Ql1 = 1.
+      do l = 1, this%lmax
+         Ql = cos_th * this%k12(1, l, 0) * Ql1 - this%k12(2, l, 0) * Ql2
+         this%Q(l, INSIDE,  ir)   = this%Q(l, INSIDE,  ir)   +  this%rn(l) * Ql * (1.-del)
+         this%Q(l, OUTSIDE, ir)   = this%Q(l, OUTSIDE, ir)   + this%irn(l) * Ql * (1.-del)
+         if (del .notequals. zero) then
+            this%Q(l, INSIDE,  ir+1) = this%Q(l, INSIDE,  ir+1) +  this%rn(l) * Ql * del
+            this%Q(l, OUTSIDE, ir+1) = this%Q(l, OUTSIDE, ir+1) + this%irn(l) * Ql * del
+         endif
+         Ql2 = Ql1
+         Ql1 = Ql
+      enddo
+
+      ! non-axisymmetric (l,m) moments for 1 <= m <= this%mmax, m <= l <= this%lmax.
+      do m = 1, this%mmax
+
+         m2s = this%lm(0, 2*m-1)
+         m2c = this%lm(0, 2*m)
+         ! The (m,m) moment
+         ! Associated Legendre polynomial: P_m^m = (-1)^m (2m-1)!! (1-x^2)^{m/2}
+         ! The (2m-1)!! factor is integrated in ofact(:) array, where it mostly cancels out, note that (2m-1)!! \simeq m! exp(m/sqrt(2)) so it grows pretty fast with m
+         Ql1 = sin_th ** m
+         this%Q(m2s+m, INSIDE,  ir)   = this%Q(m2s+m, INSIDE,  ir)   +  this%rn(m) * Ql1 * this%sfac(m) * (1.-del)
+         this%Q(m2c+m, INSIDE,  ir)   = this%Q(m2c+m, INSIDE,  ir)   +  this%rn(m) * Ql1 * this%cfac(m) * (1.-del)
+         this%Q(m2s+m, OUTSIDE, ir)   = this%Q(m2s+m, OUTSIDE, ir)   + this%irn(m) * Ql1 * this%sfac(m) * (1.-del)
+         this%Q(m2c+m, OUTSIDE, ir)   = this%Q(m2c+m, OUTSIDE, ir)   + this%irn(m) * Ql1 * this%cfac(m) * (1.-del)
+         if (del .notequals. zero) then
+            this%Q(m2s+m, INSIDE,  ir+1) = this%Q(m2s+m, INSIDE,  ir+1) +  this%rn(m) * Ql1 * this%sfac(m) * del
+            this%Q(m2c+m, INSIDE,  ir+1) = this%Q(m2c+m, INSIDE,  ir+1) +  this%rn(m) * Ql1 * this%cfac(m) * del
+            this%Q(m2s+m, OUTSIDE, ir+1) = this%Q(m2s+m, OUTSIDE, ir+1) + this%irn(m) * Ql1 * this%sfac(m) * del
+            this%Q(m2c+m, OUTSIDE, ir+1) = this%Q(m2c+m, OUTSIDE, ir+1) + this%irn(m) * Ql1 * this%cfac(m) * del
+         endif
+
+         !>
+         !! \deprecated BEWARE: most of computational cost of multipoles is here
+         !! from (m+1,m) to (this%lmax,m)
+         !! Associated Legendre polynomial: P_{m+1}^m = x (2m+1) P_m^m
+         !! Associated Legendre polynomial recurrence: (l-m) P_l^m = x (2l-1) P_{l-1}^m - (l+m-1) P_{l-2}^m
+         !<
+         Ql2 = 0.
+         do l = m + 1, this%lmax
+            Ql = cos_th * this%k12(1, l, m) * Ql1 - this%k12(2, l, m) * Ql2
+            this%Q(m2s+l, INSIDE,  ir)   = this%Q(m2s+l, INSIDE,  ir)   +  this%rn(l) * Ql * this%sfac(m) * (1.-del)
+            this%Q(m2c+l, INSIDE,  ir)   = this%Q(m2c+l, INSIDE,  ir)   +  this%rn(l) * Ql * this%cfac(m) * (1.-del)
+            this%Q(m2s+l, OUTSIDE, ir)   = this%Q(m2s+l, OUTSIDE, ir)   + this%irn(l) * Ql * this%sfac(m) * (1.-del)
+            this%Q(m2c+l, OUTSIDE, ir)   = this%Q(m2c+l, OUTSIDE, ir)   + this%irn(l) * Ql * this%cfac(m) * (1.-del)
+            if (del .notequals. zero) then
+               this%Q(m2s+l, INSIDE,  ir+1) = this%Q(m2s+l, INSIDE,  ir+1) +  this%rn(l) * Ql * this%sfac(m) * del
+               this%Q(m2c+l, INSIDE,  ir+1) = this%Q(m2c+l, INSIDE,  ir+1) +  this%rn(l) * Ql * this%cfac(m) * del
+               this%Q(m2s+l, OUTSIDE, ir+1) = this%Q(m2s+l, OUTSIDE, ir+1) + this%irn(l) * Ql * this%sfac(m) * del
+               this%Q(m2c+l, OUTSIDE, ir+1) = this%Q(m2c+l, OUTSIDE, ir+1) + this%irn(l) * Ql * this%cfac(m) * del
+            endif
+            Ql2 = Ql1
+            Ql1 = Ql
+         enddo
+
+      enddo
+
+   end subroutine point2moments
+
+!>
+!! \brief Compute potential from multipole moments at a single point
+!!
+!! \todo improve accuracy with linear interpolation over radius
+!<
+
+   real function moments2pot(this, x, y, z) result(potential)
+
+      use constants, only: zero
+      use func,      only: operator(.notequals.)
+      use units,     only: newtong
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+      real, intent(in)  :: x         !< x coordinate of the contributing point
+      real, intent(in)  :: y         !< y coordinate of the contributing point
+      real, intent(in)  :: z         !< z coordinate of the contributing point
+
+      real :: sin_th, cos_th, del
+      real :: Ql, Ql1, Ql2
+      integer :: l, m, ir, m2s, m2c
+
+      call this%geomfac4moments(-newtong, x, y, z, sin_th, cos_th, ir, del)
+
+      if (.not. interp_mom2pot) del = 0.
+
+      ! monopole, the (0,0) moment; P_0 = 1.
+      potential = (1.-del) * ( &
+           this%Q(0, INSIDE,  ir)   * this%irn(0) + &
+           this%Q(0, OUTSIDE, ir+1) *  this%rn(0) )
+      if (del .notequals. zero) potential = potential + del * ( &
+           this%Q(0, INSIDE,  ir-1) * this%irn(0) + &
+           this%Q(0, OUTSIDE, ir)   *  this%rn(0) )
+      ! ir+1 to prevent duplicate accounting contributions from ir bin; alternatively one can modify radial integration
+
+      ! axisymmetric (l,0) moments
+      Ql2 = 0.
+      Ql1 = 1.
+      do l = 1, this%lmax
+         Ql = cos_th * this%k12(1, l, 0) * Ql1 - this%k12(2, l, 0) * Ql2
+         potential = potential + Ql * (1.-del) * ( &
+              &      this%Q(l, INSIDE,  ir)   * this%irn(l) + &
+              &      this%Q(l, OUTSIDE, ir+1) *  this%rn(l) )
+         if (del .notequals. zero) potential = potential + Ql  * del * ( &
+              &      this%Q(l, INSIDE,  ir-1) * this%irn(l) + &
+              &      this%Q(l, OUTSIDE, ir)   *  this%rn(l) )
+         Ql2 = Ql1
+         Ql1 = Ql
+      enddo
+
+      ! non-axisymmetric (l,m) moments for 1 <= m <= this%mmax, m <= l <= this%lmax.
+      do m = 1, this%mmax
+         m2s = this%lm(0, 2*m-1)
+         m2c = this%lm(0, 2*m)
+         ! The (m,m) moment
+         Ql1 = sin_th ** m
+         potential = potential + Ql1 * (1.-del) * ( &
+              &      (this%Q(m2c+m, INSIDE,  ir)   * this%irn(m) + &
+              &       this%Q(m2c+m, OUTSIDE, ir+1) *  this%rn(m) ) * this%cfac(m) + &
+              &      (this%Q(m2s+m, INSIDE,  ir)   * this%irn(m) + &
+              &       this%Q(m2s+m, OUTSIDE, ir+1) *  this%rn(m) ) * this%sfac(m) )
+         if (del .notequals. zero) potential = potential + Ql1 * del * ( &
+              &      (this%Q(m2c+m, INSIDE,  ir-1) * this%irn(m) + &
+              &       this%Q(m2c+m, OUTSIDE, ir)   *  this%rn(m) ) * this%cfac(m) + &
+              &      (this%Q(m2s+m, INSIDE,  ir-1) * this%irn(m) + &
+              &       this%Q(m2s+m, OUTSIDE, ir)   *  this%rn(m) ) * this%sfac(m) )
+
+         !> \deprecated BEWARE: lots of computational cost of multipoles is here
+         ! from (m+1,m) to (this%lmax,m)
+         Ql2 = 0.
+         do l = m+1, this%lmax
+            Ql = cos_th * this%k12(1, l, m) * Ql1 - this%k12(2, l, m) * Ql2
+            potential = potential + Ql * (1.-del) * ( &
+                 &      (this%Q(m2c+l, INSIDE,  ir)   * this%irn(l) + &
+                 &       this%Q(m2c+l, OUTSIDE, ir+1) *  this%rn(l) ) * this%cfac(m) + &
+                 &      (this%Q(m2s+l, INSIDE,  ir)   * this%irn(l) + &
+                 &       this%Q(m2s+l, OUTSIDE, ir+1) *  this%rn(l) ) * this%sfac(m) )
+            if (del .notequals. zero) potential = potential + Ql * del * ( &
+                 &      (this%Q(m2c+l, INSIDE,  ir-1) * this%irn(l) + &
+                 &       this%Q(m2c+l, OUTSIDE, ir)   *  this%rn(l) ) * this%cfac(m) + &
+                 &      (this%Q(m2s+l, INSIDE,  ir-1) * this%irn(l) + &
+                 &       this%Q(m2s+l, OUTSIDE, ir)   *  this%rn(l) ) * this%sfac(m) )
+            Ql2 = Ql1
+            Ql1 = Ql
+         enddo
+      enddo
+
+   end function moments2pot
+
+!>
+!! \brief This routine calculates various geometrical numbers required for multipole evaluation
+!!
+!! \details It modifies the this%rn(:), this%irn(:), this%cfac(:) and this%sfac(:) arrays. Scalars are passed through argument list.
+!<
+
+   subroutine geomfac4moments(this, factor, x, y, z, sin_th, cos_th, ir, delta)
+
+      use constants,  only: GEO_XYZ, GEO_RPZ, zero
+      use dataio_pub, only: die, msg
+      use domain,     only: dom
+      use func,       only: operator(.notequals.)
+
+      implicit none
+
+      class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
+      real,    intent(in)  :: factor         !< scaling factor (e.g. mass) of the contributing point
+      real,    intent(in)  :: x              !< x coordinate of the contributing point
+      real,    intent(in)  :: y              !< x coordinate of the contributing point
+      real,    intent(in)  :: z              !< x coordinate of the contributing point
+      real,    intent(out) :: sin_th         !< sine of the theta angle
+      real,    intent(out) :: cos_th         !< cosine of the theta angle
+      integer, intent(out) :: ir             !< radial index for the this%Q(:, :, r) array
+      real,    intent(out) :: delta          !< fraction of the radial cell for interpolation between ir and ir+1
+
+      real    :: rxy, r, rinv
+      real    :: sin_ph, cos_ph
+      integer :: l, m
+
+      ! radius and its projection onto XY plane
+      select case (dom%geometry_type)
+         case (GEO_XYZ)
+            rxy = x**2 + y**2
+         case (GEO_RPZ)
+            rxy = x**2
+         case default
+            call die("[multipole_array:geomfac4moments] Unsupported geometry.")
+            rxy = 0.
+      end select
+      r    = sqrt(rxy + z**2)
+      rxy  = sqrt(rxy)
+      if (r .notequals. zero) then
+         rinv = 1. / r
+      else
+         rinv = 0.
+      endif
+
+      !radial index for the this%Q(:, :, r) array
+      ir = int(r / this%drq)
+      if (ir < this%rqbin) then
+         delta = r/this%drq - ir
+      else
+         delta = 0
+      endif
+      if (ir > this%rqbin .or. ir < 0) then
+         write(msg,'(2(a,i7),a)')"[multipole_array:geomfac4moments] radial index = ", ir, " outside this%Q(:, :, ", this%rqbin, ") range"
+         call die(msg)
+      endif
+      this%irmax = max(this%irmax, ir)
+      this%irmin = min(this%irmin, ir)
+
+      ! azimuthal angle sine and cosine tables
+      ! ph = atan2(y, x); this%cfac(m) = cos(m * ph); this%sfac(m) = sin(m * ph)
+      ! this%cfac(0) and this%sfac(0) are set in init_multigrid
+      if (rxy .notequals. zero) then
+         select case (dom%geometry_type)
+            case (GEO_XYZ)
+               cos_ph = x / rxy
+               sin_ph = y / rxy
+            case (GEO_RPZ)
+               cos_ph = cos(y)
+               sin_ph = sin(y)
+            case default
+               call die("[multipole_array:geomfac4moments] Unsupported geometry.")
+               cos_ph = 0. ; sin_ph = 0.
+         end select
+      else
+         cos_ph = 1.
+         sin_ph = 0.
+      endif
+!> \todo Possible optimization: number of computed elements can be doubled on each loop iteration (should give better pipelining)
+      do m = 1, this%mmax
+         this%cfac(m) = cos_ph * this%cfac(m-1) - sin_ph * this%sfac(m-1)
+         this%sfac(m) = cos_ph * this%sfac(m-1) + sin_ph * this%cfac(m-1)
+      enddo
+
+      ! vertical angle
+      cos_th = z   * rinv
+      sin_th = rxy * rinv
+
+!> \todo check how much it would degrade solution and improve performance to move the multiplications by this%rn(:) and this%irn(:) to img_mass2moments (before and after integration)
+      ! this%rn(l) = factor * r ** l; this%irn(l) = factor * r ** -(l+1)
+      this%rn(0)  = factor
+      this%irn(0) = factor * rinv
+      ! scale r to reduce risk of occurring a Floating Point Overflow for high l_max and large r values. Leave the original value of r only in this%irn(0)
+      r = r / this%rscale
+      rinv = rinv * this%rscale
+!> \todo Possible optimization: number of computed elements can be doubled on each loop iteration (should give better pipelining)
+      do l = 1, this%lmax
+         this%rn(l)  =  this%rn(l-1) * r
+         this%irn(l) = this%irn(l-1) * rinv
+      enddo
+
+   end subroutine geomfac4moments
+
+end module multipole_array

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -559,7 +559,7 @@ contains
                      call die("[cg_level_connected:restrict_q_1var] Unknown geometry (1)")
                end select
             else
-               ! OPT: Split the problem into the core that can be done by array arithmetic and finish the edges whetre necessary
+               ! OPT: Split the problem into the core that can be done by array arithmetic and finish the edges where necessary
                do k = fse(zdim, LO), fse(zdim, HI)
                   kc = (k-fse(zdim, LO)+off1(zdim))/refinement_factor + 1
                   do j = fse(ydim, LO), fse(ydim, HI)


### PR DESCRIPTION
Continuation of #317 
* Some small manual optimisations
* Added 3D multipole solver that can be used on coarsened levels for quite accurate results and allows to use only one pass of multigrid for isolated boundaries.