### PR TITLE
[multigrid_gravity] BUGFIX for an empty space

### DIFF
--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -964,6 +964,7 @@ contains
       norm_lowest = norm_rhs
 
       if (norm_rhs.equals.zero) then ! empty domain => potential == 0.
+         call leaves%set_q_value(solution, 0.)
          if (master .and. .not. norm_was_zero) call warn("[multigrid_gravity:vcycle_hg] No gravitational potential for an empty space.")
          norm_was_zero = .true.
          return


### PR DESCRIPTION
explicitly set up the potential for an empty space (relevant for some particle setups)