### PR TITLE
Keep non negative dens

### DIFF
--- a/problems/mcrtest/problem.par.build2
+++ b/problems/mcrtest/problem.par.build2
@@ -50,6 +50,7 @@
     smallei= 1.e-5
     integration_order = 2
     limiter= 'vanleer'
+    disallow_negatives = .false.
  /
 
  $FLUID_IONIZED

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -39,7 +39,7 @@ module global
 
    private
    public :: cleanup_global, init_global, &
-        &    cfl, cfl_max, cflcontrol, cfl_violated, dn_negative, ei_negative, cr_negative, tstep_attempt, &
+        &    cfl, cfl_max, cflcontrol, cfl_violated, disallow_negatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, &
         &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, repeat_step, skip_sweep, geometry25D, &
@@ -50,6 +50,7 @@ module global
    logical         :: dn_negative = .false.
    logical         :: ei_negative = .false.
    logical         :: cr_negative = .false.
+   logical         :: disallow_negatives
    logical         :: dirty_debug              !< Allow initializing arrays with some insane values and checking if these values can propagate
    integer(kind=4) :: show_n_dirtys            !< use to limit the amount of printed messages on dirty values found
    logical         :: do_ascii_dump            !< to dump, or not to dump: that is a question (ascii)
@@ -103,7 +104,7 @@ module global
    integer(kind=4)               :: ord_mag_prolong   !< prolongation order for B and psi
    logical                       :: ord_fc_eq_mag     !< when .true. enforce ord_mag_prolong order of prolongation of f/c guardcells for fluid and everything (EXPERIMENTAL)
 
-   namelist /NUMERICAL_SETUP/ cfl, cflcontrol, cfl_max, use_smalld, use_smallei, smalld, smallei, smallc, smallp, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, &
+   namelist /NUMERICAL_SETUP/ cfl, cflcontrol, disallow_negatives, cfl_max, use_smalld, use_smallei, smalld, smallei, smallc, smallp, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, &
         &                     repeat_step, limiter, limiter_b, relax_time, integration_order, cfr_smooth, skip_sweep, geometry25D, sweeps_mgu, print_divB, &
         &                     use_fargo, divB_0, glm_alpha, use_eglm, cfl_glm, ch_grid, interpol_str, w_epsilon, psi_bnd_str, ord_mag_prolong, ord_fc_eq_mag
 
@@ -197,6 +198,7 @@ contains
       cfr_smooth  = 0.0
       smallp      = big_float
       smalld      = big_float
+      disallow_negatives = .true.
       use_smalld  = .true.
       use_smallei = .true.
       smallc      = 1.e-10
@@ -289,6 +291,7 @@ contains
          lbuff(10)  = use_eglm
          lbuff(11)  = ch_grid
          lbuff(12)  = ord_fc_eq_mag
+         lbuff(13)  = disallow_negatives
 
       endif
 
@@ -299,44 +302,45 @@ contains
 
       if (slave) then
 
-         use_smalld    = lbuff(1)
-         use_smallei   = lbuff(2)
-         repeat_step   = lbuff(3)
-         skip_sweep    = lbuff(4:6)
-         geometry25D   = lbuff(7)
-         sweeps_mgu    = lbuff(8)
-         use_fargo     = lbuff(9)
-         use_eglm      = lbuff(10)
-         ch_grid       = lbuff(11)
-         ord_fc_eq_mag = lbuff(12)
+         use_smalld         = lbuff(1)
+         use_smallei        = lbuff(2)
+         repeat_step        = lbuff(3)
+         skip_sweep         = lbuff(4:6)
+         geometry25D        = lbuff(7)
+         sweeps_mgu         = lbuff(8)
+         use_fargo          = lbuff(9)
+         use_eglm           = lbuff(10)
+         ch_grid            = lbuff(11)
+         ord_fc_eq_mag      = lbuff(12)
+         disallow_negatives = lbuff(13)
 
-         smalld      = rbuff( 1)
-         smallc      = rbuff( 2)
-         smallp      = rbuff( 3)
-         smallei     = rbuff( 4)
-         cfl         = rbuff( 5)
-         cfr_smooth  = rbuff( 6)
-         dt_initial  = rbuff( 7)
-         dt_max_grow = rbuff( 8)
-         dt_min      = rbuff( 9)
-         dt_max      = rbuff(10)
-         cfl_max     = rbuff(11)
-         relax_time  = rbuff(12)
-         glm_alpha   = rbuff(13)
-         cfl_glm     = rbuff(14)
-         w_epsilon   = rbuff(15)
-         dt_shrink   = rbuff(16)
+         smalld             = rbuff( 1)
+         smallc             = rbuff( 2)
+         smallp             = rbuff( 3)
+         smallei            = rbuff( 4)
+         cfl                = rbuff( 5)
+         cfr_smooth         = rbuff( 6)
+         dt_initial         = rbuff( 7)
+         dt_max_grow        = rbuff( 8)
+         dt_min             = rbuff( 9)
+         dt_max             = rbuff(10)
+         cfl_max            = rbuff(11)
+         relax_time         = rbuff(12)
+         glm_alpha          = rbuff(13)
+         cfl_glm            = rbuff(14)
+         w_epsilon          = rbuff(15)
+         dt_shrink          = rbuff(16)
 
-         limiter    = cbuff(1)
-         limiter_b  = cbuff(2)
-         cflcontrol = cbuff(3)
-         divB_0     = cbuff(5)
-         interpol_str = cbuff(6)
-         psi_bnd_str = cbuff(7)
+         limiter            = cbuff(1)
+         limiter_b          = cbuff(2)
+         cflcontrol         = cbuff(3)
+         divB_0             = cbuff(5)
+         interpol_str       = cbuff(6)
+         psi_bnd_str        = cbuff(7)
 
-         integration_order = ibuff(1)
-         print_divB        = ibuff(2)
-         ord_mag_prolong   = ibuff(3)
+         integration_order  = ibuff(1)
+         print_divB         = ibuff(2)
+         ord_mag_prolong    = ibuff(3)
 
       endif
 

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -39,7 +39,7 @@ module global
 
    private
    public :: cleanup_global, init_global, &
-        &    cfl, cfl_max, cflcontrol, cfl_violated, tstep_attempt, &
+        &    cfl, cfl_max, cflcontrol, cfl_violated, dn_negative, ei_negative, cr_negative, tstep_attempt, &
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, &
         &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, repeat_step, skip_sweep, geometry25D, &
@@ -47,6 +47,9 @@ module global
         &    divB_0_method, force_cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fc_eq_mag
 
    logical         :: cfl_violated             !< True when cfl condition is violated
+   logical         :: dn_negative = .false.
+   logical         :: ei_negative = .false.
+   logical         :: cr_negative = .false.
    logical         :: dirty_debug              !< Allow initializing arrays with some insane values and checking if these values can propagate
    integer(kind=4) :: show_n_dirtys            !< use to limit the amount of printed messages on dirty values found
    logical         :: do_ascii_dump            !< to dump, or not to dump: that is a question (ascii)

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -41,7 +41,7 @@ module global
    public :: cleanup_global, init_global, &
         &    cfl, cfl_max, cflcontrol, cfl_violated, tstep_attempt, &
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, &
-        &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, interpol_str, &
+        &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, repeat_step, skip_sweep, geometry25D, &
         &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, &
         &    divB_0_method, force_cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fc_eq_mag
@@ -68,6 +68,7 @@ module global
    real    :: cfl                      !< desired Courant–Friedrichs–Lewy number
    real    :: cfl_max                  !< warning threshold for the effective CFL number achieved
    logical :: use_smalld               !< correct density when it gets lower than smalld
+   logical :: use_smallei              !< correct internal energy density when it gets lower then smallei
    logical :: geometry25D              !< include source terms in reduced dimension for 2D simulations
    real    :: smallp                   !< artificial infimum for pressure
    real    :: smalld                   !< artificial infimum for density
@@ -99,7 +100,7 @@ module global
    integer(kind=4)               :: ord_mag_prolong   !< prolongation order for B and psi
    logical                       :: ord_fc_eq_mag     !< when .true. enforce ord_mag_prolong order of prolongation of f/c guardcells for fluid and everything (EXPERIMENTAL)
 
-   namelist /NUMERICAL_SETUP/ cfl, cflcontrol, cfl_max, use_smalld, smalld, smallei, smallc, smallp, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, &
+   namelist /NUMERICAL_SETUP/ cfl, cflcontrol, cfl_max, use_smalld, use_smallei, smalld, smallei, smallc, smallp, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, &
         &                     repeat_step, limiter, limiter_b, relax_time, integration_order, cfr_smooth, skip_sweep, geometry25D, sweeps_mgu, print_divB, &
         &                     use_fargo, divB_0, glm_alpha, use_eglm, cfl_glm, ch_grid, interpol_str, w_epsilon, psi_bnd_str, ord_mag_prolong, ord_fc_eq_mag
 
@@ -194,6 +195,7 @@ contains
       smallp      = big_float
       smalld      = big_float
       use_smalld  = .true.
+      use_smallei = .true.
       smallc      = 1.e-10
       smallei     = 1.e-10
       dt_initial  = -1.              !< -1. indicates automatic choice of initial timestep, -0.5 would give half of that
@@ -275,14 +277,15 @@ contains
          rbuff(16) = dt_shrink
 
          lbuff(1)   = use_smalld
-         lbuff(2)   = repeat_step
-         lbuff(3:5) = skip_sweep
-         lbuff(6)   = geometry25D
-         lbuff(7)   = sweeps_mgu
-         lbuff(8)   = use_fargo
-         lbuff(9)   = use_eglm
-         lbuff(10)  = ch_grid
-         lbuff(11)  = ord_fc_eq_mag
+         lbuff(2)   = use_smallei
+         lbuff(3)   = repeat_step
+         lbuff(4:6) = skip_sweep
+         lbuff(7)   = geometry25D
+         lbuff(8)   = sweeps_mgu
+         lbuff(9)   = use_fargo
+         lbuff(10)  = use_eglm
+         lbuff(11)  = ch_grid
+         lbuff(12)  = ord_fc_eq_mag
 
       endif
 
@@ -294,14 +297,15 @@ contains
       if (slave) then
 
          use_smalld    = lbuff(1)
-         repeat_step   = lbuff(2)
-         skip_sweep    = lbuff(3:5)
-         geometry25D   = lbuff(6)
-         sweeps_mgu    = lbuff(7)
-         use_fargo     = lbuff(8)
-         use_eglm      = lbuff(9)
-         ch_grid       = lbuff(10)
-         ord_fc_eq_mag = lbuff(11)
+         use_smallei   = lbuff(2)
+         repeat_step   = lbuff(3)
+         skip_sweep    = lbuff(4:6)
+         geometry25D   = lbuff(7)
+         sweeps_mgu    = lbuff(8)
+         use_fargo     = lbuff(9)
+         use_eglm      = lbuff(10)
+         ch_grid       = lbuff(11)
+         ord_fc_eq_mag = lbuff(12)
 
          smalld      = rbuff( 1)
          smallc      = rbuff( 2)

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -215,7 +215,7 @@ contains
 
       use dataio_pub,     only: warn
       use fluidtypes,     only: var_numbers
-      use global,         only: cflcontrol, cfl_violated, dt_old, dn_negative, ei_negative
+      use global,         only: cflcontrol, cfl_violated, dt_old, dn_negative, ei_negative, disallow_negatives
       use mpisetup,       only: piernik_MPI_Bcast, master
       use timestep_pub,   only: c_all, c_all_old
       use timestep_retry, only: reset_freezing_speed
@@ -243,18 +243,18 @@ contains
       call piernik_MPI_Bcast(cr_negative)
       if (cr_negative) then
          if (master) call warn('[timestep:check_cfl_violation] Possible violation of CFL: negatives in CRS')
-         cfl_violated = .true.
+         if (disallow_negatives) cfl_violated = .true.
          cr_negative  = .false.
       endif
 #endif /* COSM_RAYS */
       if (dn_negative) then
          if (master) call warn('[timestep:check_cfl_violation] Possible violation of CFL: negative density')
-         cfl_violated = .true.
+         if (disallow_negatives) cfl_violated = .true.
          dn_negative  = .false.
       endif
       if (ei_negative) then
          if (master) call warn('[timestep:check_cfl_violation] Possible violation of CFL: negative internal energy')
-         cfl_violated = .true.
+         if (disallow_negatives) cfl_violated = .true.
          ei_negative  = .false.
       endif
       if (cfl_violated) call reset_freezing_speed

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -213,10 +213,15 @@ contains
 !<
    subroutine check_cfl_violation(dt, flind)
 
+      use dataio_pub,     only: warn
       use fluidtypes,     only: var_numbers
-      use global,         only: cflcontrol, cfl_violated, dt_old
+      use global,         only: cflcontrol, cfl_violated, dt_old, dn_negative, ei_negative
+      use mpisetup,       only: piernik_MPI_Bcast, master
       use timestep_pub,   only: c_all, c_all_old
       use timestep_retry, only: reset_freezing_speed
+#ifdef COSM_RAYS
+      use global,         only: cr_negative
+#endif /* COSM_RAYS */
 
       implicit none
 
@@ -232,6 +237,26 @@ contains
       bck = [dt_old, c_all_old, c_all]
 
       call time_step(checkdt, flind)
+      call piernik_MPI_Bcast(dn_negative)
+      call piernik_MPI_Bcast(ei_negative)
+#ifdef COSM_RAYS
+      call piernik_MPI_Bcast(cr_negative)
+      if (cr_negative) then
+         if (master) call warn('[timestep:check_cfl_violation] Possible violation of CFL: negatives in CRS')
+         cfl_violated = .true.
+         cr_negative  = .false.
+      endif
+#endif /* COSM_RAYS */
+      if (dn_negative) then
+         if (master) call warn('[timestep:check_cfl_violation] Possible violation of CFL: negative density')
+         cfl_violated = .true.
+         dn_negative  = .false.
+      endif
+      if (ei_negative) then
+         if (master) call warn('[timestep:check_cfl_violation] Possible violation of CFL: negative internal energy')
+         cfl_violated = .true.
+         ei_negative  = .false.
+      endif
       if (cfl_violated) call reset_freezing_speed
 
       dt_old = bck(1) ; c_all_old = bck(2) ; c_all = bck(3) !> \todo check if this backup is necessary

--- a/src/fluids/cosmicrays/initcosmicrays.F90
+++ b/src/fluids/cosmicrays/initcosmicrays.F90
@@ -52,7 +52,8 @@ module initcosmicrays
    real                                :: smallecr     !< floor value for CR energy density
    real                                :: cr_active    !< parameter specifying whether CR pressure gradient is (when =1.) or isn't (when =0.) included in the gas equation of motion
    real                                :: cr_eff       !< conversion rate of SN explosion energy to CR energy (default = 0.1)
-   logical                             :: use_CRsplit    !< apply all diffusion operators at once (.false.) or use directional splittiong (.true.)
+   logical                             :: use_CRsplit  !< apply all diffusion operators at once (.false.) or use directional splittiong (.true.)
+   logical                             :: use_smallecr !< correct CR energy density when it gets lower than smallecr
    real, dimension(ncr_max)            :: gamma_crn    !< array containing adiabatic indexes of all CR nuclear components
    real, dimension(ncr_max)            :: K_crn_paral  !< array containing parallel diffusion coefficients of all CR nuclear components
    real, dimension(ncr_max)            :: K_crn_perp   !< array containing perpendicular diffusion coefficients of all CR nuclear components
@@ -120,7 +121,7 @@ contains
       integer(kind=4) :: nn, icr, jcr
       integer         :: ne
 
-      namelist /COSMIC_RAYS/ cfl_cr, smallecr, cr_active, cr_eff, use_CRsplit, &
+      namelist /COSMIC_RAYS/ cfl_cr, use_smallecr, smallecr, cr_active, cr_eff, use_CRsplit, &
            &                 ncrn, gamma_crn, K_crn_paral, K_crn_perp, &
            &                 ncre, gamma_cre, K_cre_paral, K_cre_perp, &
            &                 divv_scheme, crn_gpcr_ess, cre_gpcr_ess
@@ -134,6 +135,7 @@ contains
       ncre       = 0
 
       use_CRsplit    = .true.
+      use_smallecr   = .true.
 
       gamma_crn(:)   = 4./3.
       K_crn_paral(:) = 0.0
@@ -170,28 +172,29 @@ contains
 
 #ifndef MULTIGRID
       if (.not. use_CRsplit) call warn("[initcosmicrays:init_cosmicrays] No multigrid solver compiled in: use_CRsplit reset to .true.")
-      use_CRsplit   = .true.
+      use_CRsplit = .true.
 #endif /* !MULTIGRID */
 
-      rbuff(:)      = huge(1.)                         ! mark unused entries to allow automatic determination of nn
+      rbuff(:) = huge(1.)                         ! mark unused entries to allow automatic determination of nn
 
       if (master) then
 
-         ibuff(1)   = ncrn
-         ibuff(2)   = ncre
+         ibuff(1) = ncrn
+         ibuff(2) = ncre
 
-         rbuff(1)   = cfl_cr
-         rbuff(2)   = smallecr
-         rbuff(3)   = cr_active
-         rbuff(4)   = cr_eff
+         rbuff(1) = cfl_cr
+         rbuff(2) = smallecr
+         rbuff(3) = cr_active
+         rbuff(4) = cr_eff
 
-         lbuff(1)   = use_CRsplit
+         lbuff(1) = use_CRsplit
+         lbuff(2) = use_smallecr
 
-         cbuff(1)   = divv_scheme
+         cbuff(1) = divv_scheme
 
-         nn         = count(rbuff(:) < huge(1.), kind=4)    ! this must match the last rbuff() index above
+         nn       = count(rbuff(:) < huge(1.), kind=4)    ! this must match the last rbuff() index above
          ibuff(ubound(ibuff, 1)) = nn
-         ne         = nn + 3 * ncrn
+         ne       = nn + 3 * ncrn
          if (ne + 3 * ncre > ubound(rbuff, 1)) call die("[initcosmicrays:init_cosmicrays] rbuff size exceeded.")
 
          if (ncrn > 0) then
@@ -219,20 +222,21 @@ contains
 
       if (slave) then
 
-         ncrn        = int(ibuff(1), kind=4)
-         ncre        = int(ibuff(2), kind=4)
+         ncrn         = int(ibuff(1), kind=4)
+         ncre         = int(ibuff(2), kind=4)
 
-         cfl_cr      = rbuff(1)
-         smallecr    = rbuff(2)
-         cr_active   = rbuff(3)
-         cr_eff      = rbuff(4)
+         cfl_cr       = rbuff(1)
+         smallecr     = rbuff(2)
+         cr_active    = rbuff(3)
+         cr_eff       = rbuff(4)
 
-         use_CRsplit = lbuff(1)
+         use_CRsplit  = lbuff(1)
+         use_smallecr = lbuff(2)
 
-         nn          = ibuff(ubound(ibuff, 1))    ! this must match the last rbuff() index above
-         ne          = nn + 3 * ncrn
+         nn           = ibuff(ubound(ibuff, 1))    ! this must match the last rbuff() index above
+         ne           = nn + 3 * ncrn
 
-         divv_scheme = cbuff(1)
+         divv_scheme  = cbuff(1)
 
          if (ncrn > 0) then
             gamma_crn  (1:ncrn) = rbuff(nn+1       :nn+  ncrn)

--- a/src/fluids/sources.F90
+++ b/src/fluids/sources.F90
@@ -420,15 +420,15 @@ contains
 #if defined COSM_RAYS && defined IONIZED
    subroutine limit_minimal_ecr(n, u1)
 
-      use fluidindex,       only: flind
-      use initcosmicrays,   only: iarr_crs, smallecr
+      use fluidindex,     only: flind
+      use initcosmicrays, only: iarr_crs, smallecr, use_smallecr
 
       implicit none
 
       integer(kind=4),               intent(in)    :: n                  !< array size
       real, dimension(n, flind%all), intent(inout) :: u1                 !< updated vector of conservative variables (after one timestep in second order scheme)
 
-      u1(:, iarr_crs(:)) = max(smallecr, u1(:, iarr_crs(:)))
+      if (use_smallecr) u1(:, iarr_crs(:)) = max(smallecr, u1(:, iarr_crs(:)))
 
    end subroutine limit_minimal_ecr
 #endif /* COSM_RAYS && IONIZED */

--- a/src/fluids/sources.F90
+++ b/src/fluids/sources.F90
@@ -289,8 +289,8 @@ contains
 !==========================================================================================
    subroutine care_for_positives(n, u1, bb, cg, sweep, i1, i2)
 
-      use fluidindex,       only: flind, nmag
-      use grid_cont,        only: grid_container
+      use fluidindex, only: flind, nmag
+      use grid_cont,  only: grid_container
 
       implicit none
 
@@ -308,9 +308,9 @@ contains
 
       call limit_minimal_density(n, u1, cg, sweep, i1, i2)
       call limit_minimal_intener(n, bb, u1)
-#if defined COSM_RAYS && defined IONIZED
+#ifdef COSM_RAYS
       if (full_dim) call limit_minimal_ecr(n, u1)
-#endif /* COSM_RAYS && IONIZED */
+#endif /* COSM_RAYS */
 
    end subroutine care_for_positives
 
@@ -417,7 +417,7 @@ contains
 
    end subroutine limit_minimal_intener
 
-#if defined COSM_RAYS && defined IONIZED
+#ifdef COSM_RAYS
    subroutine limit_minimal_ecr(n, u1)
 
       use fluidindex,     only: flind
@@ -431,7 +431,7 @@ contains
       if (use_smallecr) u1(:, iarr_crs(:)) = max(smallecr, u1(:, iarr_crs(:)))
 
    end subroutine limit_minimal_ecr
-#endif /* COSM_RAYS && IONIZED */
+#endif /* COSM_RAYS */
 
 !==========================================================================================
 end module sources

--- a/src/fluids/sources.F90
+++ b/src/fluids/sources.F90
@@ -429,7 +429,7 @@ contains
       integer(kind=4),               intent(in)    :: n                  !< array size
       real, dimension(n, flind%all), intent(inout) :: u1                 !< updated vector of conservative variables (after one timestep in second order scheme)
 
-      ecr_negative = ecr_negative .or. (any(u1(:, iarr_crs(:)) < zero))
+      cr_negative = cr_negative .or. (any(u1(:, iarr_crs(:)) < zero))
       if (use_smallecr) u1(:, iarr_crs(:)) = max(smallecr, u1(:, iarr_crs(:)))
 
    end subroutine limit_minimal_ecr

--- a/src/fluids/sources.F90
+++ b/src/fluids/sources.F90
@@ -34,9 +34,6 @@ module sources
 
    private
    public :: all_sources, care_for_positives, init_sources, prepare_sources, timestep_sources
-#if defined COSM_RAYS && defined IONIZED
-   public :: limit_minimal_ecr
-#endif /* COSM_RAYS && IONIZED */
 
 contains
 
@@ -233,9 +230,9 @@ contains
 !*/
    subroutine get_updates_from_acc(n, u, usrc, acc)
 
-      use fluidindex,       only: iarr_all_dn, iarr_all_mx, flind
+      use fluidindex, only: iarr_all_dn, iarr_all_mx, flind
 #ifndef ISO
-      use fluidindex,       only: iarr_all_en
+      use fluidindex, only: iarr_all_en
 #endif /* !ISO */
 
       implicit none

--- a/src/fluids/sources.F90
+++ b/src/fluids/sources.F90
@@ -379,11 +379,11 @@ contains
 !==========================================================================================
    subroutine limit_minimal_intener(n, bb, u1)
 
-      use constants,        only: xdim, ydim, zdim
-      use fluidindex,       only: flind, nmag
-      use fluidtypes,       only: component_fluid
-      use func,             only: emag, ekin
-      use global,           only: smallei
+      use constants,  only: xdim, ydim, zdim
+      use fluidindex, only: flind, nmag
+      use fluidtypes, only: component_fluid
+      use func,       only: emag, ekin
+      use global,     only: smallei, use_smallei
 
       implicit none
 
@@ -394,9 +394,8 @@ contains
 !locals
 
       real, dimension(n)              :: kin_ener, int_ener, mag_ener
-
       class(component_fluid), pointer :: pfl
-      integer :: ifl
+      integer                         :: ifl
 
       do ifl = 1, flind%fluids
          pfl => flind%all_fluids(ifl)%fl
@@ -409,7 +408,7 @@ contains
                int_ener = u1(:, pfl%ien) - kin_ener
             endif
 
-            int_ener = max(int_ener, smallei)
+            if (use_smallei) int_ener = max(int_ener, smallei)
 
             u1(:, pfl%ien) = int_ener + kin_ener
             if (pfl%is_magnetized) u1(:, pfl%ien) = u1(:, pfl%ien) + mag_ener

--- a/src/scheme/Riemann_Solver/solve_cg.F90
+++ b/src/scheme/Riemann_Solver/solve_cg.F90
@@ -117,10 +117,7 @@ contains
       use global,           only: dt, force_cc_mag
       use grid_cont,        only: grid_container
       use named_array_list, only: wna, qna
-      use sources,          only: all_sources
-#ifdef COSM_RAYS
-      use sources,          only: limit_minimal_ecr
-#endif /* COSM_RAYS */
+      use sources,          only: all_sources, care_for_positives
 
       implicit none
 
@@ -198,9 +195,7 @@ contains
             call all_sources(size(u, 1, kind=4), u, u1, b, cg, istep, ddim, i1, i2, rk_coef(istep) * dt, vx)
             ! See the results of Jeans test with RTVD and RIEMANN for estimate of accuracy.
 
-#if defined COSM_RAYS && defined IONIZED
-            if (size(u, 1) > 1) call limit_minimal_ecr(size(u, 1), u)
-#endif /* COSM_RAYS && IONIZED */
+            call care_for_positives(size(u, 1, kind=4), u1, b, cg, ddim, i1, i2)
 
             call cg%save_outfluxes(ddim, i1, i2, eflx)
             pu(:,:) = transpose(u1(:, iarr_all_swp(ddim,:)))
@@ -219,10 +214,7 @@ contains
       use global,           only: dt
       use grid_cont,        only: grid_container
       use named_array_list, only: wna
-      use sources,          only: all_sources
-#ifdef COSM_RAYS
-      use sources,          only: limit_minimal_ecr
-#endif /* COSM_RAYS */
+      use sources,          only: all_sources, care_for_positives
 
       implicit none
 
@@ -262,9 +254,7 @@ contains
             call all_sources(size(u, 1, kind=4), u, u1, b, cg, istep, ddim, i1, i2, rk_coef(istep) * dt, vx)
             ! See the results of Jeans test with RTVD and RIEMANN for estimate of accuracy.
 
-#if defined COSM_RAYS && defined IONIZED
-            if (size(u, 1) > 1) call limit_minimal_ecr(size(u, 1), u)
-#endif /* COSM_RAYS && IONIZED */
+            call care_for_positives(size(u, 1, kind=4), u1, b, cg, ddim, i1, i2)
 
             call cg%save_outfluxes(ddim, i1, i2, eflx)
             pu(:,:) = transpose(u1(:, iarr_all_swp(ddim,:)))


### PR DESCRIPTION
Allow user to decide:
* whether to use_smalld, use_smallei, use_smallecr,
* whether to repeat step if negatives in density, internal energy density or CR energy density are detected.
These functionalities are available in both schemes: RTVD and RIEMANN.