### PR TITLE
Timestep routines cg-independent

### DIFF
--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -106,9 +106,9 @@ contains
       use constants,          only: one, two, zero, half, pMIN, pMAX
       use dataio,             only: write_crashed
       use dataio_pub,         only: tend, msg, warn
-      use fargo,              only: timestep_fargo, fargo_mean_omega
+      use fargo,              only: timestep_fargo
       use fluidtypes,         only: var_numbers
-      use global,             only: t, dt_old, dt_max_grow, dt_initial, dt_min, dt_max, nstep, use_fargo, cfl_violated
+      use global,             only: t, dt_old, dt_max_grow, dt_initial, dt_min, dt_max, nstep, cfl_violated
       use grid_cont,          only: grid_container
       use mpisetup,           only: master, piernik_MPI_Allreduce
       use sources,            only: timestep_sources
@@ -140,8 +140,6 @@ contains
       c_all = zero
       dt = huge(1.)
 
-      if (use_fargo) call fargo_mean_omega
-
       cgl => leaves%first
       do while (associated(cgl))
          cg => cgl%cg
@@ -157,7 +155,6 @@ contains
          dt = min(dt, dt_crs)
 #endif /* COSM_RAYS */
 
-         if (use_fargo) dt = min(dt, timestep_fargo(cg, dt))
          cgl => cgl%nxt
       enddo
 
@@ -167,6 +164,7 @@ contains
 #endif /* RESISTIVE */
 
       call timestep_sources(dt)
+      call timestep_fargo(dt)
 
       call piernik_MPI_Allreduce(dt,    pMIN)
       call piernik_MPI_Allreduce(c_all, pMAX)

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -117,7 +117,7 @@ contains
       use timestepcosmicrays, only: timestep_crs, dt_crs
 #endif /* COSM_RAYS */
 #ifdef RESISTIVE
-      use resistivity,        only: dt_resist, timestep_resist
+      use resistivity,        only: timestep_resist
 #endif /* RESISTIVE */
 #ifdef DEBUG
       use dataio_pub,         only: printinfo
@@ -159,8 +159,7 @@ contains
       enddo
 
 #ifdef RESISTIVE
-         call timestep_resist
-         dt = min(dt, dt_resist)
+         call timestep_resist(dt)
 #endif /* RESISTIVE */
 
       call timestep_sources(dt)

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -114,7 +114,7 @@ contains
       use sources,            only: timestep_sources
       use timestep_pub,       only: c_all, c_all_old
 #ifdef COSM_RAYS
-      use timestepcosmicrays, only: timestep_crs, dt_crs
+      use timestepcosmicrays, only: timestep_crs
 #endif /* COSM_RAYS */
 #ifdef RESISTIVE
       use resistivity,        only: timestep_resist
@@ -150,16 +150,14 @@ contains
             c_all = max(c_all, c_)
          enddo
 
-#ifdef COSM_RAYS
-         call timestep_crs(cg)
-         dt = min(dt, dt_crs)
-#endif /* COSM_RAYS */
-
          cgl => cgl%nxt
       enddo
 
+#ifdef COSM_RAYS
+      call timestep_crs(dt)
+#endif /* COSM_RAYS */
 #ifdef RESISTIVE
-         call timestep_resist(dt)
+      call timestep_resist(dt)
 #endif /* RESISTIVE */
 
       call timestep_sources(dt)

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -100,28 +100,28 @@ contains
 !<
    subroutine time_step(dt, flind)
 
-      use cg_leaves,            only: leaves
-      use cg_list,              only: cg_list_element
-      use cmp_1D_mpi,           only: compare_array1D
-      use constants,            only: one, two, zero, half, pMIN, pMAX
-      use dataio,               only: write_crashed
-      use dataio_pub,           only: tend, msg, warn
-      use fargo,                only: timestep_fargo, fargo_mean_omega
-      use fluidtypes,           only: var_numbers
-      use global,               only: t, dt_old, dt_max_grow, dt_initial, dt_min, dt_max, nstep, use_fargo, cfl_violated
-      use grid_cont,            only: grid_container
-      use mpisetup,             only: master, piernik_MPI_Allreduce
-      use sources,              only: timestep_sources
-      use timestep_pub,         only: c_all, c_all_old
+      use cg_leaves,          only: leaves
+      use cg_list,            only: cg_list_element
+      use cmp_1D_mpi,         only: compare_array1D
+      use constants,          only: one, two, zero, half, pMIN, pMAX
+      use dataio,             only: write_crashed
+      use dataio_pub,         only: tend, msg, warn
+      use fargo,              only: timestep_fargo, fargo_mean_omega
+      use fluidtypes,         only: var_numbers
+      use global,             only: t, dt_old, dt_max_grow, dt_initial, dt_min, dt_max, nstep, use_fargo, cfl_violated
+      use grid_cont,          only: grid_container
+      use mpisetup,           only: master, piernik_MPI_Allreduce
+      use sources,            only: timestep_sources
+      use timestep_pub,       only: c_all, c_all_old
 #ifdef COSM_RAYS
-      use timestepcosmicrays,   only: timestep_crs, dt_crs
+      use timestepcosmicrays, only: timestep_crs, dt_crs
 #endif /* COSM_RAYS */
 #ifdef RESISTIVE
-      use resistivity,          only: dt_resist, timestep_resist
+      use resistivity,        only: dt_resist, timestep_resist
 #endif /* RESISTIVE */
 #ifdef DEBUG
-      use dataio_pub,           only: printinfo
-      use piernikdebug,         only: has_const_dt, constant_dt
+      use dataio_pub,         only: printinfo
+      use piernikdebug,       only: has_const_dt, constant_dt
 #endif /* DEBUG */
       implicit none
 
@@ -157,8 +157,6 @@ contains
          dt = min(dt, dt_crs)
 #endif /* COSM_RAYS */
 
-         call timestep_sources(dt, cg)
-
          if (use_fargo) dt = min(dt, timestep_fargo(cg, dt))
          cgl => cgl%nxt
       enddo
@@ -167,6 +165,8 @@ contains
          call timestep_resist
          dt = min(dt, dt_resist)
 #endif /* RESISTIVE */
+
+      call timestep_sources(dt)
 
       call piernik_MPI_Allreduce(dt,    pMIN)
       call piernik_MPI_Allreduce(c_all, pMAX)

--- a/src/fluids/cosmicrays/initcosmicrays.F90
+++ b/src/fluids/cosmicrays/initcosmicrays.F90
@@ -74,6 +74,8 @@ module initcosmicrays
    real,    allocatable, dimension(:)  :: K_crs_paral  !< array containing parallel diffusion coefficients of all CR components
    real,    allocatable, dimension(:)  :: K_crs_perp   !< array containing perpendicular diffusion coefficients of all CR components
    !> \deprecated BEWARE Possible confusion: *_perp coefficients are not "perpendicular" but rather isotropic
+   real                                :: def_dtcrs    !< default dt limitation due to diffusion
+   logical                             :: K_crs_valid  !< condition to use dt_crs
 
 contains
 
@@ -107,7 +109,7 @@ contains
 !<
    subroutine init_cosmicrays
 
-      use constants,       only: cbuff_len, I_ONE
+      use constants,       only: cbuff_len, I_ONE, big, half
       use diagnostics,     only: ma1d, my_allocate
       use dataio_pub,      only: nh   ! QA_WARN required for diff_nml
       use dataio_pub,      only: die, warn
@@ -304,6 +306,9 @@ contains
             gpcr_essential(jcr) = icr + ncrn
          endif
       enddo
+
+      K_crs_valid = (maxval(K_crs_paral+K_crs_perp) > 0)
+      def_dtcrs = cfl_cr * half/maxval(K_crs_paral+K_crs_perp)
 
    end subroutine init_cosmicrays
 

--- a/src/fluids/cosmicrays/initcosmicrays.F90
+++ b/src/fluids/cosmicrays/initcosmicrays.F90
@@ -109,7 +109,7 @@ contains
 !<
    subroutine init_cosmicrays
 
-      use constants,       only: cbuff_len, I_ONE, big, half
+      use constants,       only: cbuff_len, I_ONE, half
       use diagnostics,     only: ma1d, my_allocate
       use dataio_pub,      only: nh   ! QA_WARN required for diff_nml
       use dataio_pub,      only: die, warn

--- a/src/fluids/sources.F90
+++ b/src/fluids/sources.F90
@@ -256,9 +256,8 @@ contains
 !! \brief Subroutine collects dt limits estimations from sources
 !<
 !*/
-   subroutine timestep_sources(dt, cg)
+   subroutine timestep_sources(dt)
 
-      use grid_cont,            only: grid_container
 #ifndef BALSARA
       use timestepinteractions, only: timestep_interactions
 #endif /* !BALSARA */
@@ -268,18 +267,17 @@ contains
 
       implicit none
 
-      real,                          intent(inout) :: dt
-      type(grid_container), pointer, intent(in)    :: cg
+      real, intent(inout) :: dt
 
 #ifndef BALSARA
-         dt = min(dt,timestep_interactions(cg))
+         dt = min(dt, timestep_interactions())
 #endif /* !BALSARA */
 #ifdef THERM
-         dt = min(dt,timestep_thermal(cg))
+         dt = min(dt, timestep_thermal())
 #endif /* THERM */
 
       return
-      if (.false.) write(0,*) dt, cg%inv_x(1)
+      if (.false. .and. dt < 0) return
 
    end subroutine timestep_sources
 

--- a/src/fluids/thermal/timestepthermal.F90
+++ b/src/fluids/thermal/timestepthermal.F90
@@ -43,24 +43,34 @@ contains
 !>
 !! \brief Routine that computes upper limit of %timestep due to cooling or heating processes.
 !<
-   real function timestep_thermal(cg) result(dt_coolheat)
+   real function timestep_thermal() result(dt_coolheat)
 
-      use constants, only: small
+      use cg_leaves, only: leaves
+      use cg_list,   only: cg_list_element
+      use constants, only: big, pMIN, small
       use grid_cont, only: grid_container
+      use mpisetup,  only: piernik_MPI_Allreduce
       use thermal,   only: maxdeint, cfl_coolheat, thermal_active
 
       implicit none
 
-      type(grid_container), pointer, intent(in) :: cg
+      type(cg_list_element), pointer :: cgl
+      type(grid_container),  pointer :: cg
+      real                           :: mxdeint
 
-      real :: mxdeint
+      dt_coolheat = big
+      if (.not.thermal_active) return
 
-      if (thermal_active) then
+      cgl => leaves%first
+      do while (associated(cgl))
+         cg => cgl%cg
+
          call maxdeint(cg, mxdeint)
-         dt_coolheat = cfl_coolheat*abs(1./(mxdeint+small))
-      else
-         dt_coolheat = huge(1.)
-      endif
+         dt_coolheat = min(dt_coolheat, cfl_coolheat*abs(1./(mxdeint+small)))
+
+         cgl => cgl%nxt
+      enddo
+      call piernik_MPI_Allreduce(dt_coolheat, pMIN)
 
    end function timestep_thermal
 


### PR DESCRIPTION
Make routines limiting dt independent of cg to be able to reduce individual dt ingredients over processes in case of following them in log files