### PR TITLE
NO_FFT: FFTW-less multigrid

### DIFF
--- a/doc/Doxyfile.stable
+++ b/doc/Doxyfile.stable
@@ -1545,7 +1545,6 @@ PREDEFINED             = COLLISIONS \
                          NEUTRAL \
                          PERFMON \
                          PGPLOT \
-                         POISSON_FFT \
                          RESISTIVE \
                          SELF_GRAV \
                          SHEAR \

--- a/doc/general/precompiler.F90
+++ b/doc/general/precompiler.F90
@@ -61,8 +61,6 @@
 !!
 !! \b \#define \b "MULTIGRID" - to include self–gravity (multigrid solver, uses FFT when possible, recommended)
 !!
-!! \b \#define \b "POISSON_FFT" - to include self–gravity (pure FFT solver)
-!!
 !! \b \#define \b "FFTW"
 !!
 !! \b \#define \b "SHEAR" - to include Coriolis and tidal forces in gas equation of motion and use  <a href="http://cdsads.u-strasbg.fr/abs/1995ApJ...440..742H">Hawley, Gammie and Balbus (1995)</a> type approach for shearing BCS

--- a/doc/general/precompiler.F90
+++ b/doc/general/precompiler.F90
@@ -80,6 +80,8 @@
 !!
 !! \b \#define \b "PGPLOT"
 !!
+!! \b \#define \b "NO_FFT" - don't use FFTW libraries at all (may be useful on some restricted environments)
+!!
 !! \b \#define \b "JEANS_PROBLEM" - switch on jeans problem-specific quirks
 !!
 !! \b \#define \b "INDEPENDENT_ATOUTB" - switch to independent (instead of collective) write to files (restart files) for arrays with outer boundary area type

--- a/piernik.doxy
+++ b/piernik.doxy
@@ -2060,7 +2060,6 @@ PREDEFINED             = COLLISIONS \
                          NEUTRAL \
                          PERFMON \
                          PGPLOT \
-                         POISSON_FFT \
                          RESISTIVE \
                          SELF_GRAV \
                          SHEAR \

--- a/python/piernik_setup.py
+++ b/python/piernik_setup.py
@@ -530,7 +530,8 @@ def setup_piernik(data=None):
     if("PGPLOT" in our_defs):
         m.write("LIBS += -lpgplot\n")
     if("SHEAR" in our_defs or "MULTIGRID" in our_defs):
-        m.write("LIBS += $(shell pkg-config --libs fftw3)\n")
+        if ("NO_FFT" not in our_defs):
+            m.write("LIBS += $(shell pkg-config --libs fftw3)\n")
     if("PIERNIK_OPENCL" in our_defs):
         m.write("LIBS += $(shell pkg-config --libs fortrancl)\n")
         m.write("F90FLAGS += $(shell pkg-config --cflags fortrancl)\n")

--- a/python/piernik_setup.py
+++ b/python/piernik_setup.py
@@ -532,6 +532,7 @@ def setup_piernik(data=None):
     if("SHEAR" in our_defs or "MULTIGRID" in our_defs):
         if ("NO_FFT" not in our_defs):
             m.write("LIBS += $(shell pkg-config --libs fftw3)\n")
+        m.write("CPPFLAGS += $(shell pkg-config --libs fftw3 2> /dev/null || echo '-DNO_FFT')\n")
     if("PIERNIK_OPENCL" in our_defs):
         m.write("LIBS += $(shell pkg-config --libs fortrancl)\n")
         m.write("F90FLAGS += $(shell pkg-config --cflags fortrancl)\n")

--- a/python/piernik_setup.py
+++ b/python/piernik_setup.py
@@ -531,8 +531,6 @@ def setup_piernik(data=None):
         m.write("LIBS += -lpgplot\n")
     if("SHEAR" in our_defs or "MULTIGRID" in our_defs):
         m.write("LIBS += $(shell pkg-config --libs fftw3)\n")
-    if("POISSON_FFT" in our_defs):
-        m.write("LIBS += $(shell pkg-config --libs fftw3 lapack)\n")
     if("PIERNIK_OPENCL" in our_defs):
         m.write("LIBS += $(shell pkg-config --libs fortrancl)\n")
         m.write("F90FLAGS += $(shell pkg-config --cflags fortrancl)\n")

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -398,6 +398,12 @@ contains
 
       if (base_no_fft .and. (cnt /= 1) .and. master) call warn("[multigrid_gravity:init_multigrid_grav] Cannot use FFT solver on coarsest level")
       base_no_fft = base_no_fft .or. (cnt /= 1)
+#ifdef NO_FFT
+      if (.not. base_no_fft) then
+         call warn("[multigrid_gravity:init_multigrid_grav] Forced base_no_fft due to NO_FFT")
+         base_no_fft = .true.
+      endif
+#endif /* NO_FFT */
 
       cnt_max = cnt
       call piernik_MPI_Allreduce(cnt_max, pMAX)
@@ -444,6 +450,9 @@ contains
       enddo
 
       if (require_FFT) then
+#ifdef NO_FFT
+         call die("[multigrid_gravity:init_multigrid_grav] require_FFT conflicts with NO_FFT")
+#endif /* NO_FFT */
          curl => coarsest%level
          do while (associated(curl))
             cgl => curl%first

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -54,7 +54,10 @@ module multigrid_gravity
    public :: write_oldsoln_to_restart, read_oldsoln_from_restart
 #endif
 
+#ifndef NO_FFT
    include "fftw3.f"
+#endif /* !NO_FFT */
+
    ! constants from fftw3.f
    !   integer, parameter :: FFTW_MEASURE=0, FFTW_PATIENT=32, FFTW_ESTIMATE=64
    !   integer, parameter :: FFTW_RODFT01=8, FFTW_RODFT10=9
@@ -68,7 +71,9 @@ module multigrid_gravity
    logical            :: fft_patient                                  !< Spend more time in init_multigrid to find faster fft plan
    character(len=cbuff_len) :: grav_bnd_str                           !< Type of gravitational boundary conditions.
    logical            :: require_FFT                                  !< .true. if we use FFT solver anywhere (and need face prolongation)
+#ifndef NO_FFT
    integer            :: fftw_flags = FFTW_MEASURE                    !< or FFTW_PATIENT on request
+#endif /* !NO_FFT */
 
    ! solution recycling
    type(soln_history), target :: inner, outer                         !< storage for recycling the inner and outer potentials
@@ -346,7 +351,9 @@ contains
          if (any([ord_laplacian, ord_laplacian_outer] /= O_I2)) call warn("[multigrid_gravity:multigrid_grav_par] Overrelaxation is implemented only for RBGS relaxation")
       endif
 
+#ifndef NO_FFT
       if (fft_patient) fftw_flags = FFTW_PATIENT
+#endif /* !NO_FFT */
 
       if (grav_bnd == bnd_isolated) call init_multipole
 

--- a/src/gravity/multigrid_gravity_helper.F90
+++ b/src/gravity/multigrid_gravity_helper.F90
@@ -97,11 +97,13 @@ contains
    subroutine fft_solve_level(curl, src, soln)
 
       use cg_level_connected,  only: cg_level_connected_T
+      use dataio_pub,          only: die
+#ifndef NO_FFT
       use cg_list,             only: cg_list_element
       use constants,           only: fft_none, fft_rcr, fft_dst
-      use dataio_pub,          only: die
       use grid_cont,           only: grid_container
       use named_array,         only: p3
+#endif /* !NO_FFT */
 
       implicit none
 
@@ -109,15 +111,19 @@ contains
       integer(kind=4),                     intent(in)    :: src  !< index of source in cg%q(:)
       integer(kind=4),                     intent(in)    :: soln !< index of solution in cg%q(:)
 
+#ifdef NO_FFT
+      call die("[multigrid_gravity_helper:fft_solve_level] NO_FFT")
+      if (.false.) curl%fft_type = src + soln  ! suppress compiler warning
+#else /* !NO_FFT */
       type(cg_list_element), pointer :: cgl
       type(grid_container), pointer :: cg
 
+      !> Check if there is one and only one cg on app processes, die if not
       if (associated(curl%first)) then
          if (associated(curl%first%nxt)) call die("[multigrid_gravity_helper:fft_solve_level] multicg not possible")
       else
          return
       endif
-      !> \todo Check if there is one and only one cg on app processes, die if not
 
       if (curl%fft_type == fft_none) call die("[multigrid_gravity_helper:fft_solve_level] FFT type not set")
 
@@ -128,7 +134,7 @@ contains
          p3 => cg%q(src)%span(cg%ijkse)
          cg%mg%src(:, :, :) = p3
 
-         ! do the convolution in Fourier space; cg%mg%src(:,:,:) -> cg%mg%fft{r}(:,:,:)
+         ! do the convolution in Fourier space; cg%mg%src(:,:,:) -> cg%mg%fft{,r}(:,:,:)
          call dfftw_execute(cg%mg%planf)
 
          select case (curl%fft_type)
@@ -140,13 +146,14 @@ contains
                call die("[multigrid_gravity_helper:fft_solve_level] Unknown FFT type.")
          end select
 
-         call dfftw_execute(cg%mg%plani) ! cg%mg%fft{r}(:,:,:) -> cg%mg%src(:,:,:)
+         call dfftw_execute(cg%mg%plani) ! cg%mg%fft{,r}(:,:,:) -> cg%mg%src(:,:,:)
 
          p3 => cg%q(soln)%span(cg%ijkse)
          p3 = cg%mg%src(:, :, :)
 
          cgl => cgl%nxt
       enddo
+#endif /* !NO_FFT */
 
    end subroutine fft_solve_level
 


### PR DESCRIPTION
Use -d NO_FFT during setup to force multigrid to not use any FFTW calls.