### PR TITLE
Piernik Precise Profiling

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ For typical desktop Linux installation you may need to add few packages to be ab
 For Ubuntu try:
 
     sudo apt install git make mpich libhdf5-mpich-dev libfftw3-dev\
-    pkg-config python pep8 python-numpy gfortran python3-magic
+    pkg-config python pep8 python-numpy gfortran
 
 If the above complains that `E: Unable to locate package mpich` then do:
 
@@ -20,7 +20,7 @@ and try again to install the pacages mentioned above. You may use `libhdf5-openm
 For Fedora try:
 
     sudo dnf install make hdf5-mpich-devel fftw-devel python\
-    environment-modules python-pep8 python2-numpy python3-magic
+    environment-modules python-pep8 python2-numpy
 
 You may use `hdf5-openmpi-devel` if you prefer OpenMPI over MPICH.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ For typical desktop Linux installation you may need to add few packages to be ab
 For Ubuntu try:
 
     sudo apt install git make mpich libhdf5-mpich-dev libfftw3-dev\
-    pkg-config python pep8 python-numpy gfortran
+    pkg-config python pep8 python-numpy gfortran python3-magic
 
 If the above complains that `E: Unable to locate package mpich` then do:
 
@@ -20,7 +20,7 @@ and try again to install the pacages mentioned above. You may use `libhdf5-openm
 For Fedora try:
 
     sudo dnf install make hdf5-mpich-devel fftw-devel python\
-    environment-modules python-pep8 python2-numpy
+    environment-modules python-pep8 python2-numpy python3-magic
 
 You may use `hdf5-openmpi-devel` if you prefer OpenMPI over MPICH.
 

--- a/doc/general/namelists.F90
+++ b/doc/general/namelists.F90
@@ -26,6 +26,7 @@
 !! \copydetails multigrid::init_multigrid
 !! \copydetails multigrid_diffusion::init_multigrid_diff
 !! \copydetails multigrid_gravity::init_multigrid_grav
+!! \copydetails ppp::init_profiling
 !!
 !! @n @n
 !! There is a list of precompiler directives to choose unit system used in simulation:

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -426,6 +426,7 @@ contains
       use func,             only: operator(.equals.), operator(.notequals.)
       use mpisetup,         only: master
       use named_array_list, only: qna
+      use ppp,              only: ppp_main
       use units,            only: newtong
 
       implicit none
@@ -436,6 +437,9 @@ contains
       real, parameter                :: small_e = 1e-3
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg
+      character(len=*), parameter :: cmp_label = "compute_maclaurin_potential"
+
+      call ppp_main%start(cmp_label)
 
       AA1 = 2./3. ; AA3 = 2./3.
       if (e < 0. .and. master) call warn("[initproblem:compute_maclaurin_potential] e<0. not fully implemented yet!")
@@ -536,6 +540,8 @@ contains
 
          cgl => cgl%nxt
       enddo
+
+      call ppp_main%stop(cmp_label)
 
    end subroutine compute_maclaurin_potential
 

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -419,7 +419,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: pi, GEO_XYZ, GEO_RPZ
+      use constants,        only: pi, GEO_XYZ, GEO_RPZ, PPP_PROB
       use dataio_pub,       only: warn, die
       use domain,           only: dom
       use grid_cont,        only: grid_container
@@ -439,7 +439,7 @@ contains
       type(grid_container),  pointer :: cg
       character(len=*), parameter :: cmp_label = "compute_maclaurin_potential"
 
-      call ppp_main%start(cmp_label)
+      call ppp_main%start(cmp_label, PPP_PROB)
 
       AA1 = 2./3. ; AA3 = 2./3.
       if (e < 0. .and. master) call warn("[initproblem:compute_maclaurin_potential] e<0. not fully implemented yet!")
@@ -541,7 +541,7 @@ contains
          cgl => cgl%nxt
       enddo
 
-      call ppp_main%stop(cmp_label)
+      call ppp_main%stop(cmp_label, PPP_PROB)
 
    end subroutine compute_maclaurin_potential
 

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -211,6 +211,7 @@ class PPPset:
         self.out = ""
         if otype == "tree":
             for _ in self.run:
+                print("")
                 self.run[_].print()
         elif otype == "gnu":
             self.print_gnuplot()
@@ -367,6 +368,7 @@ plot profile without the identified too-often called timer (e.g. "Loechner_mark"
 same as above but don't filter out timers that are contributing less than 0.1%%:
     ppp_plot.py file.ascii -e Loechner_mark -% 0 | gnuplot
 """)
+
 parser.add_argument("filename", nargs='+', help="PPP ascii file(s) to process")
 parser.add_argument("-o", "--output", nargs=1, help="processed output file (gnuplot only)")
 parser.add_argument("-%", "--cutsmall", nargs=1, default=[.1], type=float, help="skip contributions below CUTSMALL%% (default = 0.1%%)")

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -125,29 +125,32 @@ class PPP:
 
     def print_gnuplot(self):
         ev = {}
+        np = 0  # number of processes
         bigbang = self.get_bigbang_from_master()
         for p in self.trees:
+            if p > np:
+                np = p
             evlist = []
             for r in self.trees[p].root:
                 evlist += self.trees[p].root[r].get_all_ev()
             for e in evlist:
-                if e[0] not in ev:
-                    ev[e[0]] = {}
-                if p not in ev[e[0]]:
-                    ev[e[0]][p] = e[1:]
-                else:
-                    sys.stderr.write("Warning: repeated event '" + e[0] + "' @ " + str(p) + "\n")
-        i = 1
+                e_base = e[0].split()[0]
+                if e_base not in ev:
+                    ev[e_base] = {}
+                if p not in ev[e_base]:
+                    ev[e_base][p] = []
+                ev[e_base][p].append(e[1:])
         for e in ev:
-            print("#%d " % i + "'" + e + "'")
+            depth = e.count("/")
+            print("# " + e.split("/")[-1] + " '" + e + "'")
             for p in ev[e]:
                 for t in range(len(ev[e][p])):
                     try:
-                        print(e.count("/"), p, "%.6f" % (ev[e][p][t] - bigbang), i)
+                        print("0. 0. %.6f %.6f %.6f %.6f" % (ev[e][p][t][0] - bigbang, ev[e][p][t][1] - bigbang,
+                                                             depth + float(p + 1) / (np + 1), depth + float(p) / (np + 1)), depth, p)
                     except TypeError:
-                        print(e.count("/"), p, "NaN", i)
+                        sys.stderr.write("Warning: inclomplete event '" + e + "' @" + p + " #" + t + ev[e][p][t])
                 print("")
-            i += 1
             print("")
 
     def decode(self, fname):

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -60,7 +60,10 @@ class PPP_Node:
         return ("" if self.parent is None else self.parent.shortpath() + "/") + self.label
 
     def print(self, bigbang, indent=1):
-        print("  " * indent + "'" + self.label + "' %.6f %.6f" % (self.start - bigbang, self.stop - self.start))
+        try:
+            print("  " * indent + "'" + self.label + "' %.6f %.6f" % (self.start - bigbang, self.stop - self.start))
+        except TypeError:
+            print("  " * indent + "'" + self.label + "' TypeError: ", self.start, self.stop)
         for i in self.children:
             self.children[i].print(bigbang, indent=indent + 1)
 
@@ -107,15 +110,22 @@ class PPP:
         self.name = name
         self.trees = {}
 
+    def get_bigbang_from_master(self):
+        try:
+            bigbang = self.trees[0].get_bigbang()
+        except KeyError:
+            bigbang = 0.
+        return bigbang
+
     def print(self):
         print(self.name)
+        bigbang = self.get_bigbang_from_master()
         for i in sorted(self.trees):
-            bigbang = self.trees[0].get_bigbang()
             self.trees[i].print(bigbang)
 
     def print_gnuplot(self):
         ev = {}
-        bigbang = self.trees[0].get_bigbang()
+        bigbang = self.get_bigbang_from_master()
         for p in self.trees:
             evlist = []
             for r in self.trees[p].root:
@@ -132,7 +142,10 @@ class PPP:
             print("#%d " % i + "'" + e + "'")
             for p in ev[e]:
                 for t in range(len(ev[e][p])):
-                    print(e.count("/"), p, "%.6f" % (ev[e][p][t] - bigbang), i)
+                    try:
+                        print(e.count("/"), p, "%.6f" % (ev[e][p][t] - bigbang), i)
+                    except TypeError:
+                        print(e.count("/"), p, "NaN", i)
                 print("")
             i += 1
             print("")

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -133,7 +133,13 @@ class PPP_Tree:
         self.newroot = PPP_Node("/")
         self.newroot.proc = self.thread
         for r in self.root.root_matches():
-            self.newroot.children[r.parent.path() if r != self.root else "/"] = r
+            nn = r.parent.path() if r != self.root else "/"
+            newname = nn
+            i = 1
+            while newname in self.newroot.children:  # find some unique label
+                newname = nn + " %d" % i
+                i += 1
+            self.newroot.children[newname] = r
         self.root = self.newroot
 
 
@@ -339,7 +345,7 @@ class PPPset:
                     npat = int(i / gp_colors)
                     if npat >= 3:  # pattern #3 does not show borders
                         npat += 1
-                        fs = "pat %d" % npat
+                    fs = "pat %d" % npat
             self.out += pline + "\n"
             if len(ndel) > 0:
                 self.out += 'print "Timers below threshold: ' + " ".join(ndel) + '"\n'

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -107,12 +107,12 @@ class PPP:
         for i in sorted(self.trees):
             self.trees[i].print()
 
-    def _decode_text(self, fname):
+    def _decode_text(self):
         self.descr = ""
         self.nthr = 0
         self.bigbang = None
         try:
-            file = open(fname, 'r')
+            file = open(self.name, 'r')
             for line in file:
                 l = line.split()
                 if self.bigbang is None:
@@ -120,9 +120,9 @@ class PPP:
                 self._add(int(l[0]), line[line.index(l[2]):].strip(), float(l[1]) + self.bigbang * (-1. if float(l[1]) > 0. else 1.))  # proc, label, time
                 if int(l[0]) >= self.nthr:
                     self.nthr = int(l[0]) + 1
-            self.descr = "'%s' (%d thread%s)" % (fname, self.nthr, "s" if self.nthr > 1 else "")
+            self.descr = "'%s' (%d thread%s)" % (self.name, self.nthr, "s" if self.nthr > 1 else "")
         except IOError:
-            sys.stderr.write("Error: cannot open '" + fname + "'\n")
+            sys.stderr.write("Error: cannot open '" + self.name + "'\n")
             exit(4)
 
     def _add(self, proc, label, time):
@@ -142,7 +142,7 @@ class PPPset:
 
         for fname in fnamelist:
             self.evt.append(PPP(fname))
-            self.evt[-1]._decode_text(fname)
+            self.evt[-1]._decode_text()
 
     def print(self, otype):
         self.out = ""
@@ -173,9 +173,10 @@ class PPPset:
                             for t in range(len(e[1])):
                                 ed[e_base][1] += e[2][t] - e[1][t]
                 ml = len(max(ed, key=len))
-                print("# %-*s %20s %10s" % (ml - 2, "label", "CPU time (s)", "occurred"))
+                print("# %-*s %20s %10s" % (ml - 2, "label", "avg. CPU time (s)", "occurred (avg."))
+                print("# %-*s %20s %10s" % (ml - 2, "", "(per thread)", "per thread)"))
                 for e in sorted(ed.items(), key=lambda x: x[1][1], reverse=True):
-                    print("%-*s %20.6f %10d" % (ml, e[0], e[1][1], e[1][0]))
+                    print("%-*s %20.6f %10d%s" % (ml, e[0], e[1][1] / self.evt[f].nthr, e[1][0] / self.evt[f].nthr, "" if e[1][0] % self.evt[f].nthr == 0 else "+"))
             # ToDo: merged summary with data presented side-by-side
 
     def print_gnuplot(self):

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -61,7 +61,7 @@ class PPP_Node:
     def print(self, indent=0):  # need to filter through parent range
         try:
             for _ in range(min(len(self.start), len(self.stop))):
-                print("  " * indent + "'" + self.label + "' %.6f %.6f" % (self.start[_], self.stop[_] - self.start[_]))
+                print("  " * indent + "'" + self.label + "' %.6f %.6f" % (self.start[_] - t_bias, self.stop[_] - self.start[_]))
         except TypeError:
             print("  " * indent + "'" + self.label + "' TypeError: ", self.start, self.stop)
         for i in self.children:

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -299,7 +299,7 @@ class PPPset:
                     for _ in range(min(len(ev[e][p][t][i_s]), len(ev[e][p][t][i_e]))):
                         try:
                             if (ev[e][p][t][i_e][_] - ev[e][p][t][i_s][_]) > 0.:
-                                self.out += "%.6f %.6f %.6f %.6f %.6f %.6f %d %d\n" % (ev[e][p][t][i_s][_] - t_bias, depth,
+                                self.out += "%.7f %.7f %.7f %.7f %.7f %.7f %d %d\n" % (ev[e][p][t][i_s][_] - t_bias, depth,
                                                                                        ev[e][p][t][i_s][_] - t_bias, ev[e][p][t][i_e][_] - t_bias,
                                                                                        depth + float(p) / peff, depth + float(p + 1) / peff, depth, p)
                         except TypeError:
@@ -335,10 +335,30 @@ class PPPset:
         else:
             self.out += 'show title; print "No data to plot"'
 
-parser = argparse.ArgumentParser(description="Piernik Precise Profiling Presenter")
+parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                 description="Piernik Precise Profiling Presenter", epilog="""
+examples:
+
+plot profile of 64th step from file.ascii with gnuplot (hopefully in the interactive mode):
+    ppp_plot.py file.ascii -r 'step 64'| gnuplot
+    ppp_plot.py file.ascii -r 'step 64'-o file.gnu; gnuplot file.gnu
+
+print list of top-lefel timers (steps) present in file.ascii:
+    ppp_plot.py file.ascii -t -d 1
+(the atep names are followed by their time offset and length)
+
+find most time-consuming timers:
+    ppp_plot.py file.ascii -s
+(this also helps to identify most often called timers to be excluded in case of performance problems with gnuplot)
+
+plot profile without the identified too-often called timer (e.g. "Loechner_mark") that makes interactive gnuplot to choke:
+    ppp_plot.py file.ascii -e Loechner_mark | gnuplot
+same as above but don't filter out timers that are contributing less than 0.1%%:
+    ppp_plot.py file.ascii -e Loechner_mark -% 0 | gnuplot
+""")
 parser.add_argument("filename", nargs='+', help="PPP ascii file(s) to process")
 parser.add_argument("-o", "--output", nargs=1, help="processed output file")
-parser.add_argument("-%", "--cutsmall", nargs=1, default=[.1], type=float, help="skip contributions below CUTSMALL%% (default = .1%%)")
+parser.add_argument("-%", "--cutsmall", nargs=1, default=[.1], type=float, help="skip contributions below CUTSMALL%% (default = 0.1%%)")
 parser.add_argument("-e", "--exclude", nargs='+', help="do not show EXCLUDEd timer(s)")  # multiple excudes
 parser.add_argument("-r", "--root", nargs='+', help="show only ROOT and their children")
 parser.add_argument("-d", "--maxdepth", type=int, help="limit output to MAXDEPTH")

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import magic
 import argparse
 
 
@@ -178,8 +177,10 @@ class PPP:
         print(pline)
         print("pause mouse close")
 
-    def decode(self, fname):
+    def decode_magic(self, fname):  # It seems that magic may work in a bit different way on different versions. We should fix it when we start to use HDF5 data for real.
         """Try to extract the data from a given file"""
+        import magic
+
         try:
             ftype = magic.detect_from_filename(fname).mime_type
         except:
@@ -192,6 +193,10 @@ class PPP:
         else:
             sys.stderr.write("Error: don't know what to do with " + ftype + "\n")
             exit(3)
+
+    def decode(self, fname):
+        """Let's focus on ASCII decoding for a while. Don't bother with HDF5 unltil we implement this type of PPP dump"""
+        self._decode_text(fname)
 
     def _decode_text(self, fname):
         self.name += " of text events"

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -158,11 +158,11 @@ class PPPset:
                 ofile.write(self.out)
                 ofile.close()
         elif otype == "summary":
-            # ToDo: add own time and "called from"
+            # ToDo: add own time, %time and "called from"
             print("ARGS: ", args)
-            ed = {}
             for f in range(len(self.evt)):
-                print("File: '%s', %d threads, bigbang = %.7f" % (self.evt[f].name, self.evt[f].nthr, self.evt[f].bigbang))
+                ed = {}
+                print("\n## File: '%s', %d threads, bigbang = %.7f" % (self.evt[f].name, self.evt[f].nthr, self.evt[f].bigbang))
                 for p in self.evt[f].trees:
                     for r in self.evt[f].trees[p].root:
                         for e in self.evt[f].trees[p].root[r].get_all_ev():
@@ -172,10 +172,11 @@ class PPPset:
                             ed[e_base][0] += len(e[1])
                             for t in range(len(e[1])):
                                 ed[e_base][1] += e[2][t] - e[1][t]
-            ml = len(max(ed, key=len))
-            print("\n#%-*s %20s %10s" % (ml - 1, "label", "time spent (s)", "calls"))
-            for e in sorted(ed.items(), key=lambda x: x[1][1], reverse=True):
-                print("%-*s %20.6f %10d" % (ml, e[0], e[1][1], e[1][0]))
+                ml = len(max(ed, key=len))
+                print("# %-*s %20s %10s" % (ml - 2, "label", "CPU time (s)", "occurred"))
+                for e in sorted(ed.items(), key=lambda x: x[1][1], reverse=True):
+                    print("%-*s %20.6f %10d" % (ml, e[0], e[1][1], e[1][0]))
+            # ToDo: merged summary with data presented side-by-side
 
     def print_gnuplot(self):
         self.descr = ""
@@ -245,6 +246,8 @@ parser.add_argument("-o", "--output", nargs=1, help="processed output file")
 # parser.add_argument("-e", "--exclude", help="do not show TIMER(s)")  # multiple excudes
 # parser.add_argument("--root", help="show only ROOT and its children")
 # parser.add_argument("-m", "--maxoutput", nargs=1, default=50000, help="limit output to MAXOUTPUT enries")
+# parser.add_argument("-c", "--check", help="do a formal check only")
+# parser.add_argument("-d", "--maxdepth", help="limit output to MAXDEPTH")
 
 pgroup = parser.add_mutually_exclusive_group()
 pgroup.add_argument("-g", "--gnuplot", action="store_const", dest="otype", const="gnu", default="gnu", help="gnuplot output (default)")

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -64,6 +64,12 @@ class PPP_Node:
         for i in self.children:
             self.children[i].print(bigbang, indent=indent + 1)
 
+    def get_all_ev(self):
+        evl = [[self.shortpath(), self.start, self.stop]]
+        for i in self.children:
+            evl += self.children[i].get_all_ev()
+        return evl
+
 
 class PPP_Tree:
     """An event tree for one Piernik process"""
@@ -106,6 +112,30 @@ class PPP:
         for i in sorted(self.trees):
             bigbang = self.trees[0].get_bigbang()
             self.trees[i].print(bigbang)
+
+    def print_gnuplot(self):
+        ev = {}
+        bigbang = self.trees[0].get_bigbang()
+        for p in self.trees:
+            evlist = []
+            for r in self.trees[p].root:
+                evlist += self.trees[p].root[r].get_all_ev()
+            for e in evlist:
+                if e[0] not in ev:
+                    ev[e[0]] = {}
+                if p not in ev[e[0]]:
+                    ev[e[0]][p] = e[1:]
+                else:
+                    sys.stderr.write("Warning: repeated event '" + e[0] + "' @ " + str(p) + "\n")
+        i = 1
+        for e in ev:
+            print("#%d " % i + "'" + e + "'")
+            for p in ev[e]:
+                for t in range(len(ev[e][p])):
+                    print(e.count("/"), p, "%.6f" % (ev[e][p][t] - bigbang), i)
+                print("")
+            i += 1
+            print("")
 
     def decode(self, fname):
         """Try to extract the data from a given file"""
@@ -151,7 +181,8 @@ if (len(sys.argv) != 2):
 
 evt = PPP("Collection")
 evt.decode(sys.argv[1])
-evt.print()
+# evt.print()
+evt.print_gnuplot()
 
 # collect ev_tree[] into ev_summary
 # ev_summary.print()

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -2,6 +2,7 @@
 
 import sys
 import magic
+import argparse
 
 
 class PPP_Node:
@@ -214,15 +215,30 @@ class PPP:
         self.trees[proc]._add(label, time)
 
 
-if (len(sys.argv) != 2):
-    sys.stderr.write("Error: need exactly one file to process\n")
-    exit(1)
+parser = argparse.ArgumentParser(description="Piernik Precise Profiling Presenter")
+parser.add_argument("filename", nargs=1, help="PPP ascii file to process")
+parser.add_argument("-o", "--output", nargs=1, help="processed output file")
 
+# parser.add_argument("-e", "--exclude", help="do not show TIMER(s)")  # multiple excudes
+# parser.add_argument("--root", help="show only ROOT and its children")
+# parser.add_argument("-m", "--maxoutput", nargs=1, default=50000, help="limit output to MAXOUTPUT enries")
+
+pgroup = parser.add_mutually_exclusive_group()
+pgroup.add_argument("-g", "--gnuplot", action="store_const", dest="otype", const="gnu", default="gnu", help="gnuplot output (default)")
+pgroup.add_argument("-t", "--tree", action="store_const", dest="otype", const="tree", help="tree output")
+
+# pgroup.add_argument("-r", "--reduced_tree", action="store_const", dest="otype", const="rtree", help="reduced tree output")
+# pgroup.add_argument("-s", "--summary", action="store_const", dest="otype", const="summary", help="short summary")
+
+args = parser.parse_args()
 
 evt = PPP("Collection")
-evt.decode(sys.argv[1])
-# evt.print()
-evt.print_gnuplot()
+evt.decode(args.filename[0])
+if args.otype == "tree":
+    evt.print()
+elif args.otype == "gnu":
+    evt.print_gnuplot()
+
 
 # collect ev_tree[] into ev_summary
 # ev_summary.print()

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -8,17 +8,18 @@ t_bias = 10  # I'd prefer to reduce the timers initially to 0, but sometimes sla
 
 
 class PPP_Node:
-    """A single event and links"""
+    """A single node on tree of events with all event enties and links"""
 
     parent = None
     proc = None
     label = ""
 
-    def __init__(self, label, time):
+    def __init__(self, label, time=None):
         self.label = label
         self.start = []
         self.stop = []
-        self._set_time(time)
+        if time is not None:
+            self._set_time(time)
         self.children = {}  # this flattens the tree a bit ut we can recontruct it from timings anyway, if needed
         self.parent = None
 
@@ -55,9 +56,9 @@ class PPP_Node:
         return (str(self.proc) if self.parent is None else self.parent.path()) + "/" + self.label
 
     def shortpath(self):
-        return ("" if self.parent is None else self.parent.shortpath() + "/") + self.label
+        return "" if self.parent is None else self.parent.shortpath() + "/" + self.label
 
-    def print(self, indent=1):  # need to filter through parent range
+    def print(self, indent=0):  # need to filter through parent range
         try:
             for _ in range(min(len(self.start), len(self.stop))):
                 print("  " * indent + "'" + self.label + "' %.6f %.6f" % (self.start[_], self.stop[_] - self.start[_]))
@@ -67,7 +68,7 @@ class PPP_Node:
             self.children[i].print(indent=indent + 1)
 
     def get_all_ev(self):
-        evl = [[self.shortpath(), self.start, self.stop, self.own_time, self.child_time]]
+        evl = [[self.shortpath(), self.start, self.stop, self.own_time, self.child_time]] if len(self.start) > 0 else []
         for i in self.children:
             evl += self.children[i].get_all_ev()
         return evl
@@ -94,33 +95,24 @@ class PPP_Tree:
 
     def __init__(self, name):
         self.thread = name
-        self._last = None
-        self.root = {}
+        self.root = PPP_Node("/")  # root node is special and does not have time
+        self.root.proc = self.thread
+        self._last = self.root
 
     def _add(self, label, time):
-        if self._last is None:
-            self.root[label] = PPP_Node(label, time)
-            self.root[label].proc = self.thread
-            self._last = self.root[label]
-        else:
-            self._last = self._last._add(label, time)
+        self._last = self._last._add(label, time)
 
     def print(self):
         print("Process: " + str(self.thread))
-        for i in self.root:
-            self.root[i].print()
-
-    def calculate_time(self):
-        for _ in self.root:
-            self.root[_].calculate_time()
+        self.root.print()
 
 
 class PPP:
-    """A collection of event trees from one or many Piernik processes"""
+    """A collection of event trees from one or many Piernik processes from a single run"""
 
     def __init__(self, name):
         self.name = name
-        self.trees = {}
+        self.trees = {}  # separate event tree for each process
 
     def print(self):
         print(self.name)
@@ -128,22 +120,17 @@ class PPP:
             self.trees[i].print()
 
     def _decode_text(self):
-        self.descr = ""
         self.nthr = 0
         self.bigbang = None
-        try:
-            file = open(self.name, 'r')
-            for line in file:
-                l = line.split()
-                if self.bigbang is None:
-                    self.bigbang = float(l[1]) - t_bias
-                self._add(int(l[0]), line[line.index(l[2]):].strip(), float(l[1]) + self.bigbang * (-1. if float(l[1]) > 0. else 1.))  # proc, label, time
-                if int(l[0]) >= self.nthr:
-                    self.nthr = int(l[0]) + 1
-            self.descr = "'%s' (%d thread%s)" % (self.name, self.nthr, "s" if self.nthr > 1 else "")
-        except IOError:
-            sys.stderr.write("Error: cannot open '" + self.name + "'\n")
-            exit(4)
+        file = open(self.name, 'r')
+        for line in file:
+            l = line.split()
+            if self.bigbang is None:
+                self.bigbang = float(l[1]) - t_bias
+            self._add(int(l[0]), line[line.index(l[2]):].strip(), float(l[1]) + self.bigbang * (-1. if float(l[1]) > 0. else 1.))  # proc, label, time
+            if int(l[0]) >= self.nthr:
+                self.nthr = int(l[0]) + 1
+        self.descr = "'%s' (%d thread%s)" % (self.name, self.nthr, "s" if self.nthr > 1 else "")
 
     def _add(self, proc, label, time):
         if proc not in self.trees:
@@ -153,40 +140,33 @@ class PPP:
     def calculate_time(self):
         self.total_time = 0.
         for _ in self.trees:
-            self.trees[_].calculate_time()
-            for r in self.trees[_].root:
-                self.total_time += self.trees[_].root[r].own_time
+            self.trees[_].root.calculate_time()
+            self.total_time += self.trees[_].root.child_time  # root does not have time
 
     def apply_exclusions(self):
         if args.exclude is not None:
             for p in self.trees:
-                for r in list(self.trees[p].root.keys()):
-                    if self.trees[p].root[r].label in args.exclude:
-                        del self.trees[p].root[r]
-                    else:
-                        self.trees[p].root[r].apply_exclusions()
+                self.trees[p].root.apply_exclusions()
 
 
 class PPPset:
     """A collection of event trees from one or many Piernik runs"""
 
-    def __init__(self):
-        self.evt = []
-
-    def decode(self, fnamelist):
-        """Let's focus on ASCII decoding for a while. Don't bother with HDF5 unltil we implement this type of PPP dump"""
-
+    def __init__(self, fnamelist):
+        """Let's focus on ASCII decoding for a while. Don't bother with HDF5 until we implement such type of PPP dump"""
+        self.run = {}
         for fname in fnamelist:
-            self.evt.append(PPP(fname))
-            self.evt[-1]._decode_text()
-            self.evt[-1].apply_exclusions()
-            self.evt[-1].calculate_time()
+            self.run[fname] = PPP(fname)
+        for _ in self.run:
+            self.run[_]._decode_text()
+            self.run[_].apply_exclusions()
+            self.run[_].calculate_time()
 
     def print(self, otype):
         self.out = ""
         if otype == "tree":
-            for _ in range(len(self.evt)):
-                self.evt[_].print()
+            for _ in self.run:
+                self.run[_].print()
         elif otype == "gnu":
             self.print_gnuplot()
             if args.output is None:
@@ -198,57 +178,52 @@ class PPPset:
         elif otype == "summary":
             # ToDo: add own time, %time and "called from"
             print("ARGS: ", args)
-            for f in range(len(self.evt)):
+            for f in self.run:
                 ed = {}
-                print("\n## File: '%s', %d threads, bigbang = %.7f" % (self.evt[f].name, self.evt[f].nthr, self.evt[f].bigbang))
-                total_time = 0.
-                for p in self.evt[f].trees:
-                    for r in self.evt[f].trees[p].root:
-                        for e in self.evt[f].trees[p].root[r].get_all_ev():
-                            e_base = e[0].split('/')[-1]
-                            if e_base not in ed:
-                                ed[e_base] = [0, 0., 0.]  # calls, cumul. own time, cumul. child. time
-                            ed[e_base][0] += len(e[1])
-                            ed[e_base][1] += e[3]
-                            ed[e_base][2] += e[4]
-                            total_time += e[3] - e[4]
+                print("\n## File: '%s', %d threads, bigbang = %.7f" % (self.run[f].name, self.run[f].nthr, self.run[f].bigbang))
+                for p in self.run[f].trees:
+                    for e in self.run[f].trees[p].root.get_all_ev():
+                        e_base = e[0].split('/')[-1]
+                        if e_base not in ed:
+                            ed[e_base] = [0, 0., 0.]  # calls, cumul. own time, cumul. child. time
+                        ed[e_base][0] += len(e[1])
+                        ed[e_base][1] += e[3]
+                        ed[e_base][2] += e[4]
                 ml = len(max(ed, key=len))
                 print("# %-*s %20s %8s %15s \033[97m%20s\033[0m %10s" % (ml - 2, "label", "avg. CPU time (s)", "%time", "avg. occurred", "avg. non-child", "% of total"))
                 print("# %-*s %20s %8s %15s \033[97m%20s\033[0m %10s" % (ml - 2, "", "(per thread)", "in child", "(per thread)", "time (s)", "time"))
                 skipped = [0, 0.]
                 for e in sorted(ed.items(), key=lambda x: x[1][1] - x[1][2], reverse=True):
-                    if (e[1][1] - e[1][2]) / total_time > args.cutsmall[0] / 100.:
-                        print("%-*s %20.6f %8s %15d%s \033[97m%20.6f\033[0m %10.2f" % (ml, e[0], e[1][1] / self.evt[f].nthr,
+                    if (e[1][1] - e[1][2]) / self.run[f].total_time > args.cutsmall[0] / 100.:
+                        print("%-*s %20.6f %8s %15d%s \033[97m%20.6f\033[0m %10.2f" % (ml, e[0], e[1][1] / self.run[f].nthr,
                                                                                        ("" if e[1][2] == 0. else "%8.2f" % ((100 * e[1][2] / e[1][1]) if e[1][1] > 0. else 0.)),
-                                                                                       e[1][0] / self.evt[f].nthr,
-                                                                                       "" if e[1][0] % self.evt[f].nthr == 0 else "+",
-                                                                                       (e[1][1] - e[1][2]) / self.evt[f].nthr, 100. * (e[1][1] - e[1][2]) / total_time))
+                                                                                       e[1][0] / self.run[f].nthr,
+                                                                                       "" if e[1][0] % self.run[f].nthr == 0 else "+",
+                                                                                       (e[1][1] - e[1][2]) / self.run[f].nthr, 100. * (e[1][1] - e[1][2]) / self.run[f].total_time))
                     else:
                         skipped[0] += 1
-                        skipped[1] += (e[1][1] - e[1][2]) / self.evt[f].nthr
+                        skipped[1] += (e[1][1] - e[1][2]) / self.run[f].nthr
                 if skipped[0] > 0:
-                    print("# (skipped %d timers that contributed %.6f seconds of non-child time = %.2f%% of total time)" % (skipped[0], skipped[1], 100. * self.evt[f].nthr * skipped[1] / total_time))
+                    print("# (skipped %d timers that contributed %.6f seconds of non-child time = %.2f%% of total time)" % (skipped[0], skipped[1], 100. * self.run[f].nthr * skipped[1] / self.run[f].total_time))
             # ToDo: merged summary with data presented side-by-side
 
     def print_gnuplot(self):
         self.descr = ""
         ev = {}
         peff = 0
-        for f in range(len(self.evt)):
-            for p in self.evt[f].trees:
-                evlist = []
-                for r in self.evt[f].trees[p].root:
-                    evlist += self.evt[f].trees[p].root[r].get_all_ev()
+        for f in self.run:
+            for p in self.run[f].trees:
+                evlist = self.run[f].trees[p].root.get_all_ev()
                 for e in evlist:
                     e_base = e[0].split('/')[-1].split()[0]
                     if e_base not in ev:
                         ev[e_base] = {}
                     if p + peff not in ev[e_base]:
                         ev[e_base][p + peff] = []
-                    if e[3] > args.cutsmall[0] / 100. * self.evt[f].total_time / self.evt[f].nthr:
+                    if e[3] > args.cutsmall[0] / 100. * self.run[f].total_time / self.run[f].nthr:
                         ev[e_base][p + peff].append(e)
-            peff = peff + self.evt[f].nthr + (1 if len(self.evt) > 1 else 0)  # spacing only when we have multiple files
-            self.descr = self.evt[f].descr + ("\\n" if len(self.descr) > 0 else "") + self.descr
+            peff = peff + self.run[f].nthr + (1 if len(self.run) > 1 else 0)  # spacing only when we have multiple files
+            self.descr = self.run[f].descr + ("\\n" if len(self.descr) > 0 else "") + self.descr
 
         ndel = []
         for e in ev:
@@ -276,7 +251,7 @@ class PPPset:
             self.out += "# __" + e + "__ '" + ftname + "'\n"
             for p in ev[e]:
                 for t in range(len(ev[e][p])):
-                    depth = ev[e][p][t][0].count("/")
+                    depth = ev[e][p][t][0].count("/") - 1
                     for _ in range(min(len(ev[e][p][t][i_s]), len(ev[e][p][t][i_e]))):
                         try:
                             if (ev[e][p][t][i_e][_] - ev[e][p][t][i_s][_]) > 0.:
@@ -332,12 +307,9 @@ pgroup.add_argument("-g", "--gnuplot", action="store_const", dest="otype", const
 pgroup.add_argument("-t", "--tree", action="store_const", dest="otype", const="tree", help="tree output")
 pgroup.add_argument("-s", "--summary", action="store_const", dest="otype", const="summary", help="short summary")
 
-
 args = parser.parse_args()
-
-evt = PPPset()
-evt.decode(args.filename)
-evt.print(args.otype)
+all_events = PPPset(args.filename)
+all_events.print(args.otype)
 
 # for j  in *.ppprofile.ascii ; do for i in `awk '{print $2}' $j |  sort |  uniq` ; do in=`grep "$i *  -" $j | wc -l` ; out=`grep "$i *  [1-9]" $j | wc -l` ; [ $in != $out ] && echo $j $i $in $out ; done |  column -t ; done
 

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -228,7 +228,7 @@ class PPPset:
                         ev[e_base] = {}
                     if p + peff not in ev[e_base]:
                         ev[e_base][p + peff] = []
-                    if e[3] / self.evt[f].nthr > args.cutsmall[0] / 100.:
+                    if e[3] > args.cutsmall[0] / 100. * self.evt[f].total_time / self.evt[f].nthr:
                         ev[e_base][p + peff].append(e)
             peff = peff + self.evt[f].nthr + (1 if len(self.evt) > 1 else 0)  # spacing only when we have multiple files
             self.descr = self.evt[f].descr + ("\\n" if len(self.descr) > 0 else "") + self.descr
@@ -243,7 +243,7 @@ class PPPset:
         for i in ndel:
             del(ev[i])
         if len(ndel) > 0:
-            self.descr += "\\n(omitted %d timers below %g%% threshold)" % (len(ndel), args.cutsmall[0])
+            self.descr += "\\n(omitted %d timer%s below %g%% threshold)" % (len(ndel), "" if len(ndel) == 1 else "s", args.cutsmall[0])
 
         self.out += "#!/usr/bin/gnuplot\n$PPPdata << EOD\n\n"
         i_s = 1
@@ -263,8 +263,9 @@ class PPPset:
                     for _ in range(min(len(ev[e][p][t][i_s]), len(ev[e][p][t][i_e]))):
                         try:
                             if (ev[e][p][t][i_e][_] - ev[e][p][t][i_s][_]) > 0.:
-                                self.out += "0. 0. %.6f %.6f %.6f %.6f %d %d\n" % (ev[e][p][t][i_s][_] - t_bias, ev[e][p][t][i_e][_] - t_bias,
-                                                                                   depth + float(p) / peff, depth + float(p + 1) / peff, depth, p)
+                                self.out += "%.6f %.6f %.6f %.6f %.6f %.6f %d %d\n" % (ev[e][p][t][i_s][_] - t_bias, depth,
+                                                                                       ev[e][p][t][i_s][_] - t_bias, ev[e][p][t][i_e][_] - t_bias,
+                                                                                       depth + float(p) / peff, depth + float(p + 1) / peff, depth, p)
                         except TypeError:
                             sys.stderr.write("Warning: inclomplete event '", e, "' @", p, " #", str(t), ev[e][p][t])
                     self.out += "\n"
@@ -293,7 +294,7 @@ class PPPset:
                         fs = "pat %d" % npat
             self.out += pline + "\n"
             if len(ndel) > 0:
-                self.out += 'print "Timers below threshold:' + " ".join(ndel) + '"\n'
+                self.out += 'print "Timers below threshold: ' + " ".join(ndel) + '"\n'
             self.out += "pause mouse close\n"
         else:
             self.out += 'show title; print "No data to plot"'

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+import sys
+import magic
+
+
+class PPP_Node:
+    """A single event and links"""
+
+    start = None
+    stop = None
+
+    def __init__(self, label, time):
+        self.label = label
+        self._set_time(time)
+        self.children = {}
+        self.parent = None
+
+    def _set_time(self, time):
+        if time > 0:
+            self._set_start(time)
+        elif time < 0:
+            self._set_stop(-time)
+        else:
+            sys.stderr.write("Warning: time == 0 for '" + self.path() + "'\n")
+
+    def _set_start(self, time):
+        if self.start is None:
+            self.start = time
+        else:
+            sys.stderr.write("Warning: self.start already set for '" + self.path() + "' " + str(time) + " vs " + str(self.start) + "\n")
+
+    def _set_stop(self, time):  # a bit of spaghetti here (see _set_start)
+        if self.stop is None:
+            self.stop = time
+        else:
+            sys.stderr.write("Warning: self.stop already set for '" + self.path() + "' " + str(time) + " vs " + str(self.stop) + "\n")
+
+    def _add(self, label, time):
+        if label == self.label:
+            self._set_time(time)
+            return self.parent if self.stop is not None else self
+        else:
+            if time > 0:  # create/update child
+                if label not in self.children:
+                    self.children[label] = PPP_Node(label, time)
+                    self.children[label].parent = self
+                    return self.children[label]
+                else:
+                    return self.children[label]._add(label, time)
+            else:
+                if self.stop is None:
+                    sys.stderr.write("Warning: unfinished for '" + self.path() + "' " + str(time) + "\n")
+                return self.parent._add(label, time)
+
+    def path(self):
+        return (str(self.proc) if self.parent is None else self.parent.path()) + "/" + self.label
+
+    def shortpath(self):
+        return ("" if self.parent is None else self.parent.shortpath() + "/") + self.label
+
+    def print(self, bigbang, indent=1):
+        print("  " * indent + "'" + self.label + "' %.6f %.6f" % (self.start - bigbang, self.stop - self.start))
+        for i in self.children:
+            self.children[i].print(bigbang, indent=indent + 1)
+
+
+class PPP_Tree:
+    """An event tree for one Piernik process"""
+
+    def __init__(self, name):
+        self.label = name
+        self._last = None
+        self.root = {}
+
+    def _add(self, label, time):
+        if self._last is None:
+            self.root[label] = PPP_Node(label, time)
+            self.root[label].proc = self.label
+            self._last = self.root[label]
+        else:
+            self._last = self._last._add(label, time)
+
+    def get_bigbang(self):
+        bigbang = None
+        for i in self.root:
+            bb = self.root[i].start
+            bigbang = bb if bigbang is None else min(bb, bigbang)
+        return bigbang
+
+    def print(self, bigbang):
+        print("Process: " + str(self.label))
+        for i in self.root:
+            self.root[i].print(bigbang)
+
+
+class PPP:
+    """A collection of event trees from one or many Piernik processes"""
+
+    def __init__(self, name):
+        self.name = name
+        self.trees = {}
+
+    def print(self):
+        print(self.name)
+        for i in sorted(self.trees):
+            bigbang = self.trees[0].get_bigbang()
+            self.trees[i].print(bigbang)
+
+    def decode(self, fname):
+        """Try to extract the data from a given file"""
+        try:
+            ftype = magic.detect_from_filename(fname).mime_type
+        except:
+            sys.stderr.write("Error: cannot determine file type or file cannot be read\n")
+            exit(2)
+        if (ftype == "text/plain"):
+            self._decode_text(fname)
+        elif (ftype == "application/x-hdf"):
+            self._decode_hdf5(fname)
+        else:
+            sys.stderr.write("Error: don't know what to do with " + ftype + "\n")
+            exit(3)
+
+    def _decode_text(self, fname):
+        self.name += " of text events"
+        try:
+            file = open(fname, 'r')
+            for line in file:
+                l = line.split()
+                self._add(int(l[0]), line[line.index(l[1]):line.index(l[-1])].strip(), float(l[-1]))  # proc, label, time
+        except IOError:
+            sys.stderr.write("Error: cannot open '" + fname + "'\n")
+            exit(4)
+
+    def _decode_hdf5(self, fname):
+        self.name += " of HDF5 events"
+        sys.stderr.write("Error: don't know how to decode HDF5 yet\n")
+        exit(5)
+
+    def _add(self, proc, label, time):
+        if proc not in self.trees:
+            self.trees[proc] = PPP_Tree(proc)
+        self.trees[proc]._add(label, time)
+
+
+if (len(sys.argv) != 2):
+    sys.stderr.write("Error: need exactly one file to process\n")
+    exit(1)
+
+
+evt = PPP("Collection")
+evt.decode(sys.argv[1])
+evt.print()
+
+# collect ev_tree[] into ev_summary
+# ev_summary.print()
+# ev_summary.make_image()  # dump an .SVG
+# ev_summary.browse()  # create browsable image with zoom

--- a/python/ppp_plot.py
+++ b/python/ppp_plot.py
@@ -198,8 +198,8 @@ class PPP:
                 for line in file:
                     l = line.split()
                     if bigbang is None:
-                        bigbang = float(l[-1]) - t_bias
-                    self._add(poff + int(l[0]), line[line.index(l[1]):line.index(l[-1])].strip(), float(l[-1]) + bigbang * (-1. if float(l[-1]) > 0. else 1.))  # proc, label, time
+                        bigbang = float(l[1]) - t_bias
+                    self._add(poff + int(l[0]), line[line.index(l[2]):].strip(), float(l[1]) + bigbang * (-1. if float(l[1]) > 0. else 1.))  # proc, label, time
                     if int(l[0]) > nthr:
                         nthr = int(l[0])
                 poff += 2 + nthr

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -1682,11 +1682,11 @@ contains
 
       subroutine print_memory_usage
 
-         use constants,  only: I_ONE
-         use dataio_pub, only: msg, printinfo
-         use global,     only: system_mem_usage
-         use mpi,        only: MPI_INTEGER
-         use mpisetup,   only: master, FIRST, LAST, comm, mpi_err
+         use constants,    only: I_ONE
+         use dataio_pub,   only: msg, printinfo
+         use memory_usage, only: system_mem_usage
+         use mpi,          only: MPI_INTEGER
+         use mpisetup,     only: master, FIRST, LAST, comm, mpi_err
 
          implicit none
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -860,7 +860,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: xdim, DST, pSUM, GEO_XYZ, GEO_RPZ, ndims, LO, HI, I_ONE, INVALID
+      use constants,        only: xdim, DST, pSUM, GEO_XYZ, GEO_RPZ, ndims, LO, HI, I_ONE, INVALID, PPP_IO
       use dataio_pub,       only: log_wr, tsl_file, tsl_lun
 #if defined(__INTEL_COMPILER)
       use dataio_pub,       only: io_blocksize, io_buffered, io_buffno
@@ -928,7 +928,7 @@ contains
       integer(kind=4), dimension(ndims, LO:HI) :: ijkse
       character(len=*), parameter :: tsl_label = "write_timeslice"
 
-      call ppp_main%start(tsl_label)
+      call ppp_main%start(tsl_label, PPP_IO)
 
       if (has_ion) then
          cs_iso2 = flind%ion%cs2
@@ -1125,7 +1125,7 @@ contains
          deallocate(tsl_vars)
       endif
 
-      call ppp_main%stop(tsl_label)
+      call ppp_main%stop(tsl_label, PPP_IO)
 
    end subroutine write_timeslice
 
@@ -1456,7 +1456,7 @@ contains
 
       use cg_leaves,          only: leaves
       use cg_list,            only: cg_list_element
-      use constants,          only: idlen, small, MAXL
+      use constants,          only: idlen, small, MAXL, PPP_IO
       use dataio_pub,         only: printinfo
       use fluidindex,         only: flind
       use fluids_pub,         only: has_dst, has_ion, has_neu
@@ -1518,7 +1518,7 @@ contains
       character(len=idlen)                       :: id
       character(len=*), parameter :: log_label = "write_log"
 
-      call ppp_main%start(log_label)
+      call ppp_main%start(log_label, PPP_IO)
 
       id = '' ! suppress compiler warnings if none of the modules requiring the id variable are switched on.
 
@@ -1694,7 +1694,7 @@ contains
 
       if (.not.present(tsl)) call print_memory_usage
 
-      call ppp_main%stop(log_label)
+      call ppp_main%stop(log_label, PPP_IO)
 
    contains
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -871,6 +871,7 @@ contains
       use mass_defect,      only: update_tsl_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: wna
+      use ppp,              only: ppp_main
 #ifdef GRAV
       use constants,        only: gpot_n
       use named_array_list, only: qna
@@ -919,6 +920,9 @@ contains
       integer(kind=4)                        :: i, ii
       real                                   :: drvol
       integer(kind=4), dimension(ndims, LO:HI) :: ijkse
+      character(len=*), parameter :: tsl_label = "write_timeslice"
+
+      call ppp_main%start(tsl_label)
 
       if (has_ion) then
          cs_iso2 = flind%ion%cs2
@@ -1114,6 +1118,8 @@ contains
          ! some quantities computed in "write_log".One can add more, or change.
          deallocate(tsl_vars)
       endif
+
+      call ppp_main%stop(tsl_label)
 
    end subroutine write_timeslice
 
@@ -1452,6 +1458,7 @@ contains
       use interactions,       only: has_interactions, collfaq
       use mpisetup,           only: master
       use named_array_list,   only: qna
+      use ppp,                only: ppp_main
       use types,              only: value
 #ifdef COSM_RAYS
       use fluidindex,         only: iarr_all_crs
@@ -1503,6 +1510,9 @@ contains
       real, dimension(:,:,:), pointer            :: p
 #endif /* VARIABLE_GP || MAGNETIC */
       character(len=idlen)                       :: id
+      character(len=*), parameter :: log_label = "write_log"
+
+      call ppp_main%start(log_label)
 
       id = '' ! suppress compiler warnings if none of the modules requiring the id variable are switched on.
 
@@ -1677,6 +1687,8 @@ contains
       endif
 
       if (.not.present(tsl)) call print_memory_usage
+
+      call ppp_main%stop(log_label)
 
    contains
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -579,6 +579,7 @@ contains
 
       use dataio_pub,   only: msg, printinfo, warn
       use mpisetup,     only: master, piernik_MPI_Bcast
+      use ppp,          only: umsg_request
       use timer,        only: walltime_end
 #ifdef HDF5
       use data_hdf5,    only: write_hdf5
@@ -611,6 +612,10 @@ contains
                call write_log
             case ('tsl')
                call write_timeslice
+            case ('ppp')
+               umsg_request = max(1, int(umsg_param))
+               write(msg,'(a,i8,a)') "[dataio:user_msg_handler] enable PPP for ", umsg_request, " step" // trim(merge("s", " ", umsg_request == 1))
+               if (master) call printinfo(msg)
             case ('wend')
                wend = umsg_param
                if (master) tn = walltime_end%time_left(wend)
@@ -648,6 +653,7 @@ contains
                   &"  hdf      - dumps a plotfile",char(10),&
                   &"  log      - update logfile",char(10),&
                   &"  tsl      - write a timeslice",char(10),&
+                  &"  ppp [N]  - start ppp_main profiling for N timesteps (default 1)",char(10),&
                   &"  wleft    - show how much walltime is left",char(10),&
                   &"  wresleft - show how much walltime is left till next restart",char(10),&
                   &"  sleep <number> - wait <number> seconds",char(10),&

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -458,7 +458,7 @@ contains
    subroutine h5_write_to_single_file
 
       use common_hdf5, only: set_common_attributes
-      use constants,   only: cwdlen, I_ONE, tmr_hdf
+      use constants,   only: cwdlen, I_ONE, tmr_hdf, PPP_IO
       use dataio_pub,  only: printio, printinfo, nhdf, thdf, wd_wr, piernik_hdf5_version, piernik_hdf5_version2, &
          &                   msg, run_id, problem_name, use_v2_io, last_hdf_time
       use mpisetup,    only: master, piernik_MPI_Bcast, report_to_master, report_string_to_master
@@ -475,7 +475,7 @@ contains
       real                  :: phv
       character(len=*), parameter :: wrd_label = "IO_write_datafile_v1"
 
-      call ppp_main%start(wrd_label)
+      call ppp_main%start(wrd_label, PPP_IO)
       thdf = set_timer(tmr_hdf,.true.)
       nhdf = nhdf + I_ONE
       ! Initialize HDF5 library and Fortran interfaces.
@@ -505,11 +505,13 @@ contains
       endif
       call report_to_master(sig%hdf_written, only_master=.True.)
       call report_string_to_master(fname, only_master=.True.)
-      call ppp_main%stop(wrd_label)
+      call ppp_main%stop(wrd_label, PPP_IO)
 
    end subroutine h5_write_to_single_file
 
    subroutine h5_write_to_single_file_v2(fname)
+
+      use constants,   only: PPP_IO
       use common_hdf5, only: write_to_hdf5_v2, O_OUT
       use gdf,         only: gdf_create_root_group
       use mpisetup,    only: master, piernik_MPI_Barrier
@@ -520,7 +522,7 @@ contains
       character(len=*), intent(in) :: fname
       character(len=*), parameter :: wrd_label = "IO_write_datafile_v2"
 
-      call ppp_main%start(wrd_label)
+      call ppp_main%start(wrd_label, PPP_IO)
 
       call write_to_hdf5_v2(fname, O_OUT, create_empty_cg_datasets_in_output, write_cg_to_output)
 
@@ -530,7 +532,7 @@ contains
       endif
       call piernik_MPI_Barrier
 
-      call ppp_main%stop(wrd_label)
+      call ppp_main%stop(wrd_label, PPP_IO)
 
    end subroutine h5_write_to_single_file_v2
 
@@ -541,7 +543,7 @@ contains
       use cg_leaves,   only: leaves
       use cg_list,     only: cg_list_element
       use common_hdf5, only: get_nth_cg, hdf_vars, cg_output, hdf_vars, hdf_vars_avail, enable_all_hdf_var
-      use constants,   only: xdim, ydim, zdim, ndims, FP_REAL
+      use constants,   only: xdim, ydim, zdim, ndims, FP_REAL, PPP_IO, PPP_CG
       use dataio_pub,  only: die, nproc_io, can_i_write, h5_64bit
       use grid_cont,   only: grid_container
       use hdf5,        only: HID_T, HSIZE_T, H5T_NATIVE_REAL, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
@@ -567,7 +569,7 @@ contains
       type(cg_output)                                      :: cg_desc
       character(len=*), parameter :: wrdc_label = "IO_write_data_v2_cg", wrdc1s_label = "IO_write_data_v2_1cg_(serial)", wrdc1p_label = "IO_write_data_v2_1cg_(parallel)"
 
-      call ppp_main%start(wrdc_label)
+      call ppp_main%start(wrdc_label, PPP_IO)
 
       call enable_all_hdf_var  ! just in case things have changed meanwhile
 
@@ -583,7 +585,7 @@ contains
       if (nproc_io == 1) then ! perform serial write
          ! write all cg, one by one
          do ncg = 1, cg_desc%tot_cg_n
-            call ppp_main%start(wrdc1s_label)
+            call ppp_main%start(wrdc1s_label, PPP_IO + PPP_CG)
             dims(:) = [ cg_all_n_b(xdim, ncg), cg_all_n_b(ydim, ncg), cg_all_n_b(zdim, ncg) ]
             call recycle_data(dims, cg_all_n_b, ncg, data_dbl)
 
@@ -613,7 +615,7 @@ contains
                   enddo
                endif
             endif
-            call ppp_main%stop(wrdc1s_label)
+            call ppp_main%stop(wrdc1s_label, PPP_IO + PPP_CG)
          enddo
       else ! perform parallel write
          ! This piece will be a generalization of the serial case. It should work correctly also for nproc_io == 1 so it should replace the serial code
@@ -622,7 +624,7 @@ contains
             n = 0
             cgl => leaves%first
             do while (associated(cgl))
-               call ppp_main%start(wrdc1p_label)
+               call ppp_main%start(wrdc1p_label, PPP_IO + PPP_CG)
                n = n + 1
                ncg = cg_desc%offsets(proc) + n
                dims(:) = [ cg_all_n_b(xdim, ncg), cg_all_n_b(ydim, ncg), cg_all_n_b(zdim, ncg) ]
@@ -639,7 +641,7 @@ contains
                enddo
 
                cgl => cgl%nxt
-               call ppp_main%stop(wrdc1p_label)
+               call ppp_main%stop(wrdc1p_label, PPP_IO + PPP_CG)
             enddo
 
             ! Behold the MAGIC in its purest form!
@@ -697,7 +699,7 @@ contains
       if (associated(data_dbl)) deallocate(data_dbl)
       call cg_desc%clean()
 
-      call ppp_main%stop(wrdc_label)
+      call ppp_main%stop(wrdc_label, PPP_IO)
 
       if (.false.) i = size(cg_all_n_o) ! suppress compiler warning
 

--- a/src/IO/hdf5/restart_hdf5.F90
+++ b/src/IO/hdf5/restart_hdf5.F90
@@ -46,7 +46,7 @@ contains
    subroutine write_restart_hdf5
 
       use common_hdf5,     only: set_common_attributes, output_fname
-      use constants,       only: I_ONE, cwdlen, WR, tmr_hdf
+      use constants,       only: I_ONE, cwdlen, WR, tmr_hdf, PPP_IO
       use dataio_pub,      only: msg, printio, printinfo, thdf, use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
       use mpisetup,        only: master, piernik_MPI_Barrier
       use ppp,             only: ppp_main
@@ -63,7 +63,7 @@ contains
       real                  :: phv
       character(len=*), parameter :: wrr_label = "IO_write_restart"
 
-      call ppp_main%start(wrr_label)
+      call ppp_main%start(wrr_label, PPP_IO)
 
       nres = nres + I_ONE
 
@@ -96,7 +96,7 @@ contains
          call printinfo(msg, .true.)
       endif
 
-      call ppp_main%stop(wrr_label)
+      call ppp_main%stop(wrr_label, PPP_IO)
 
    end subroutine write_restart_hdf5
 

--- a/src/IO/hdf5/restart_hdf5.F90
+++ b/src/IO/hdf5/restart_hdf5.F90
@@ -49,6 +49,7 @@ contains
       use constants,       only: I_ONE, cwdlen, WR, tmr_hdf
       use dataio_pub,      only: msg, printio, printinfo, thdf, use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
       use mpisetup,        only: master, piernik_MPI_Barrier
+      use ppp,             only: ppp_main
       use restart_hdf5_v1, only: write_restart_hdf5_v1
       use restart_hdf5_v2, only: write_restart_hdf5_v2
       use timer,           only: set_timer
@@ -60,6 +61,9 @@ contains
 
       character(len=cwdlen) :: filename  ! File name
       real                  :: phv
+      character(len=*), parameter :: wrr_label = "IO_write_restart"
+
+      call ppp_main%start(wrr_label)
 
       nres = nres + I_ONE
 
@@ -91,6 +95,8 @@ contains
          write(msg,'(a6,f10.2,a2)') ' done ', thdf, ' s'
          call printinfo(msg, .true.)
       endif
+
+      call ppp_main%stop(wrr_label)
 
    end subroutine write_restart_hdf5
 

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -128,7 +128,7 @@ contains
    subroutine create_empty_cg_datasets_in_restart(cg_g_id, cg_n_b, cg_n_o, Z_avail)
 
       use common_hdf5,      only: create_empty_cg_dataset, O_RES
-      use constants,        only: AT_IGNORE, AT_OUT_B, I_ONE
+      use constants,        only: AT_IGNORE, AT_OUT_B, I_ONE, PPP_IO, PPP_CG
       use dataio_pub,       only: die
       use hdf5,             only: HID_T, HSIZE_T
       use named_array_list, only: qna, wna
@@ -146,7 +146,7 @@ contains
       character(len=*), parameter :: wrce_label = "IO_write_empty_dset"
 
       if (size(cg_n_b) /= size(cg_n_o)) call die("[restart_hdf5_v2:create_empty_cg_datasets_in_restart] size(cg_n_b) /= size(cg_n_o)")
-      call ppp_main%start(wrce_label)
+      call ppp_main%start(wrce_label, PPP_IO + PPP_CG)
 
       allocate(d_size(size(cg_n_b)))
       if (allocated(qna%lst)) then
@@ -176,7 +176,7 @@ contains
       endif
       deallocate(d_size)
 
-      call ppp_main%stop(wrce_label)
+      call ppp_main%stop(wrce_label, PPP_IO + PPP_CG)
 
    end subroutine create_empty_cg_datasets_in_restart
 
@@ -187,7 +187,7 @@ contains
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
       use common_hdf5,      only: get_nth_cg, cg_output
-      use constants,        only: xdim, ydim, zdim, ndims, dsetnamelen, I_ONE
+      use constants,        only: xdim, ydim, zdim, ndims, dsetnamelen, I_ONE, PPP_IO, PPP_CG
       use dataio_pub,       only: die, nproc_io, can_i_write
       use grid_cont,        only: grid_container
       use hdf5,             only: HID_T, HSIZE_T, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
@@ -221,7 +221,7 @@ contains
       integer(kind=4), dimension(ndims)                     :: n_b
       character(len=*), parameter :: wrcg_label = "IO_write_restart_v2_all_cg", wrcg1s_label = "IO_write_restart_v2_1cg_(serial)", wrcg1p_label = "IO_write_restart_v2_1cg_(parallel)"
 
-      call ppp_main%start(wrcg_label)
+      call ppp_main%start(wrcg_label, PPP_IO)
 
       call qna%get_reslst(qr_lst)
       call wna%get_reslst(wr_lst)
@@ -245,7 +245,7 @@ contains
       if (nproc_io == 1) then ! perform serial write
          ! write all cg, one by one
          do ncg = 1, cg_desc%tot_cg_n
-            call ppp_main%start(wrcg1s_label)
+            call ppp_main%start(wrcg1s_label, PPP_IO + PPP_CG)
 
             if (master) then
                if (.not. can_i_write) call die("[restart_hdf5_v2:write_cg_to_restart] Master can't write")
@@ -306,7 +306,7 @@ contains
                   endif
                endif
             endif
-            call ppp_main%stop(wrcg1s_label)
+            call ppp_main%stop(wrcg1s_label, PPP_IO + PPP_CG)
          enddo
       else ! perform parallel write
          ! This piece will be a generalization of the serial case. It should work correctly also for nproc_io == 1 so it should replace the serial code
@@ -315,7 +315,7 @@ contains
             n = 0
             cgl => leaves%first
             do while (associated(cgl))
-               call ppp_main%start(wrcg1p_label)
+               call ppp_main%start(wrcg1p_label, PPP_IO + PPP_CG)
                n = n + 1
                ncg = cg_desc%offsets(proc) + n
                cg => cgl%cg
@@ -342,7 +342,7 @@ contains
                   deallocate(dims)
                endif
                cgl => cgl%nxt
-               call ppp_main%stop(wrcg1p_label)
+               call ppp_main%stop(wrcg1p_label, PPP_IO + PPP_CG)
             enddo
 
             ! Parallel HDF calls have to be matched on each process, so we're doing some calls on non-existing data here.
@@ -400,7 +400,7 @@ contains
       call cg_desc%clean()
       deallocate(qr_lst, wr_lst, dsets)
 
-      call ppp_main%stop(wrcg_label)
+      call ppp_main%stop(wrcg_label, PPP_IO)
 
    contains
 
@@ -514,7 +514,7 @@ contains
       use common_hdf5,        only: d_gname, dir_pref, n_cg_name, d_size_aname, d_fc_aname, d_edge_apname, d_bnd_apname, &
            &                        cg_size_aname, cg_offset_aname, cg_lev_aname, base_d_gname, cg_cnt_aname, data_gname, &
            &                        output_fname, STAT_OK
-      use constants,          only: cwdlen, dsetnamelen, cbuff_len, ndims, xdim, zdim, INVALID, RD, LO, HI
+      use constants,          only: cwdlen, dsetnamelen, cbuff_len, ndims, xdim, zdim, INVALID, RD, LO, HI, PPP_IO
       use dataio_pub,         only: die, warn, printio, msg, last_hdf_time, last_res_time, last_log_time, last_tsl_time, problem_name, res_id, domain_dump, &
            &                        require_problem_IC, piernik_hdf5_version2, nres, nhdf, fix_string
       use dataio_user,        only: user_reg_var_restart, user_attrs_rd
@@ -584,7 +584,7 @@ contains
       type(cg_level_connected_t), pointer               :: curl
       character(len=*), parameter :: rdr_label = "IO_read_restart_v2", rdrc_label = "IO_read_restart_v2_cg"
 
-      call ppp_main%start(rdr_label)
+      call ppp_main%start(rdr_label, PPP_IO)
       if (master) call warn("[restart_hdf5_v2:read_restart_hdf5_v2] Experimental implementation")
 
       filename = output_fname(RD, '.res', nres, bcast=.true.)
@@ -812,7 +812,7 @@ contains
          curl => curl%finer
       enddo
 
-      call ppp_main%start(rdrc_label)
+      call ppp_main%start(rdrc_label, PPP_IO)
       ! On each process determine which parts of the restart cg have to be read and where
       do ia = lbound(cg_res, dim=1), ubound(cg_res, dim=1)
          my_box(:,LO) = cg_res(ia)%off(:)
@@ -831,7 +831,7 @@ contains
             curl => curl%finer
          enddo
       enddo
-      call ppp_main%stop(rdrc_label)
+      call ppp_main%stop(rdrc_label, PPP_IO)
 
       ! Use leafmap to check if all existing grids were initialized
       curl => base%level
@@ -858,7 +858,7 @@ contains
 
       if (status_v2 /= STAT_OK) nres = nres_old ! let's hope read_restart_hdf5_v1 will fix what could possibly got broken here
       call piernik_MPI_Barrier
-      call ppp_main%stop(rdr_label)
+      call ppp_main%stop(rdr_label, PPP_IO)
 
    end subroutine read_restart_hdf5_v2
 

--- a/src/base/all_boundaries.F90
+++ b/src/base/all_boundaries.F90
@@ -64,14 +64,20 @@ contains
 
       use cg_leaves,        only: leaves
       use named_array_list, only: qna
+      use ppp,              only: ppp_main
 
       implicit none
 
       integer(kind=4) :: iq
+      character(len=*), parameter :: abq_label = "all_boundaries_vital_q"
+
+      call ppp_main%start(abq_label)
 
       do iq = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
          if (qna%lst(iq)%vital) call leaves%leaf_arr3d_boundaries(iq)
       enddo
+
+      call ppp_main%stop(abq_label)
 
    end subroutine all_bnd_vital_q
 
@@ -82,6 +88,7 @@ contains
       use constants,          only: xdim, zdim
       use domain,             only: dom
       use named_array_list,   only: wna
+      use ppp,                only: ppp_main
 
       implicit none
 
@@ -89,10 +96,13 @@ contains
       logical,         optional, intent(in) :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       integer(kind=4)                     :: d
+      character(len=*), parameter :: abf_label = "all_fluid_boundaries"
 
       if (present(dir)) then
          if (.not. dom%has_dir(dir)) return
       endif
+
+      call ppp_main%start(abf_label)
 
 !      call finest%level%restrict_to_base
 
@@ -106,6 +116,8 @@ contains
          enddo
       endif
 
+      call ppp_main%stop(abf_label)
+
    end subroutine all_fluid_boundaries
 
 #ifdef MAGNETIC
@@ -117,10 +129,14 @@ contains
       use domain,           only: dom
       use global,           only: psi_bnd
       use named_array_list, only: wna, qna
+      use ppp,              only: ppp_main
 
       implicit none
 
       integer(kind=4) :: dir
+      character(len=*), parameter :: abm_label = "all_mag_boundaries"
+
+      call ppp_main%start(abm_label)
 
 !!$      do dir = xdim, zdim
 !!$         if (dom%has_dir(dir)) then
@@ -143,6 +159,8 @@ contains
             call leaves%external_boundaries(qna%ind(psi_n), bnd_type=psi_bnd)
          endif
       endif
+
+      call ppp_main%stop(abm_label)
 
    end subroutine all_mag_boundaries
 #endif /* MAGNETIC */

--- a/src/base/all_boundaries.F90
+++ b/src/base/all_boundaries.F90
@@ -125,7 +125,7 @@ contains
 
       use cg_leaves,        only: leaves
 !!$      use cg_list_global,   only: all_cg
-      use constants,        only: xdim, zdim, psi_n, BND_INVALID
+      use constants,        only: xdim, zdim, psi_n, BND_INVALID, PPP_MAG
       use domain,           only: dom
       use global,           only: psi_bnd
       use named_array_list, only: wna, qna
@@ -136,7 +136,7 @@ contains
       integer(kind=4) :: dir
       character(len=*), parameter :: abm_label = "all_mag_boundaries"
 
-      call ppp_main%start(abm_label)
+      call ppp_main%start(abm_label, PPP_MAG)
 
 !!$      do dir = xdim, zdim
 !!$         if (dom%has_dir(dir)) then
@@ -160,7 +160,7 @@ contains
          endif
       endif
 
-      call ppp_main%stop(abm_label)
+      call ppp_main%stop(abm_label, PPP_MAG)
 
    end subroutine all_mag_boundaries
 #endif /* MAGNETIC */

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -334,4 +334,20 @@ module constants
    integer(kind=4), dimension(ndims,ndims,LO:HI), parameter :: idm2 = reshape([idm,idm],[ndims,ndims,2_INT4])                             !< auxiliary matrix 3x3x2 based on identity matrix
    integer(kind=4), dimension(ndims),             parameter :: uv   = int([1,1,1], kind=4)                                                !< unity vector
 
+   ! PPP timer categories
+   enum, bind(C)                                      ! Event related to:
+      !enumerator :: PPP_MAIN  = int(B"000000000000")  ! general, unmasked, always enabled
+      enumerator :: PPP_IO    = int(B"000000000001")  ! I/O
+      enumerator :: PPP_MG    = int(B"000000000010")  ! multigrid
+      enumerator :: PPP_GRAV  = int(B"000000000100")  ! gravity
+      enumerator :: PPP_CR    = int(B"000000001000")  ! cosmic rays
+      enumerator :: PPP_PART  = int(B"000000010000")  ! particles
+      enumerator :: PPP_MPI   = int(B"000000100000")  ! MPI
+      enumerator :: PPP_AMR   = int(B"000001000000")  ! refinement
+      enumerator :: PPP_CG    = int(B"000010000000")  ! single cg
+      enumerator :: PPP_MAG   = int(B"000100000000")  ! magnetic field
+      enumerator :: PPP_PROB  = int(B"001000000000")  ! problem
+      enumerator :: PPP_DEBUG = int(B"010000000000")  ! debug
+      enumerator :: PPP_AUX   = int(B"100000000000")  ! auxiliary (unused by default)
+   end enum
 end module constants

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -336,18 +336,18 @@ module constants
 
    ! PPP timer categories
    enum, bind(C)                                      ! Event related to:
-      !enumerator :: PPP_MAIN  = int(B"000000000000")  ! general, unmasked, always enabled
-      enumerator :: PPP_IO    = int(B"000000000001")  ! I/O
-      enumerator :: PPP_MG    = int(B"000000000010")  ! multigrid
-      enumerator :: PPP_GRAV  = int(B"000000000100")  ! gravity
-      enumerator :: PPP_CR    = int(B"000000001000")  ! cosmic rays
-      enumerator :: PPP_PART  = int(B"000000010000")  ! particles
-      enumerator :: PPP_MPI   = int(B"000000100000")  ! MPI
-      enumerator :: PPP_AMR   = int(B"000001000000")  ! refinement
-      enumerator :: PPP_CG    = int(B"000010000000")  ! single cg
-      enumerator :: PPP_MAG   = int(B"000100000000")  ! magnetic field
-      enumerator :: PPP_PROB  = int(B"001000000000")  ! problem
-      enumerator :: PPP_DEBUG = int(B"010000000000")  ! debug
-      enumerator :: PPP_AUX   = int(B"100000000000")  ! auxiliary (unused by default)
+      !enumerator :: PPP_MAIN  = int(B"000000000000", kind=4)  ! general, unmasked, always enabled
+      enumerator :: PPP_IO    = int(B"000000000001", kind=4)  ! I/O
+      enumerator :: PPP_MG    = int(B"000000000010", kind=4)  ! multigrid
+      enumerator :: PPP_GRAV  = int(B"000000000100", kind=4)  ! gravity
+      enumerator :: PPP_CR    = int(B"000000001000", kind=4)  ! cosmic rays
+      enumerator :: PPP_PART  = int(B"000000010000", kind=4)  ! particles
+      enumerator :: PPP_MPI   = int(B"000000100000", kind=4)  ! MPI
+      enumerator :: PPP_AMR   = int(B"000001000000", kind=4)  ! refinement
+      enumerator :: PPP_CG    = int(B"000010000000", kind=4)  ! single cg
+      enumerator :: PPP_MAG   = int(B"000100000000", kind=4)  ! magnetic field
+      enumerator :: PPP_PROB  = int(B"001000000000", kind=4)  ! problem
+      enumerator :: PPP_DEBUG = int(B"010000000000", kind=4)  ! debug
+      enumerator :: PPP_AUX   = int(B"100000000000", kind=4)  ! auxiliary (unused by default)
    end enum
 end module constants

--- a/src/base/finalizepiernik.F90
+++ b/src/base/finalizepiernik.F90
@@ -52,7 +52,6 @@ contains
       use grid_container_ext,    only: cg_extptrs
       use initfluids,            only: cleanup_fluids
       use interactions,          only: cleanup_interactions
-      use mpisetup,              only: cleanup_mpi
       use sortable_list,         only: cleanup_sortable_list
       use tag_pool,              only: t_pool
       use timer,                 only: cleanup_timers
@@ -76,45 +75,44 @@ contains
 
       implicit none
 
-      if (associated(cleanup_problem)) call cleanup_problem; call nextdot(.false.)
-      call urc_list%cleanup;       call nextdot(.false.)
-      call t_pool%cleanup;         call nextdot(.false.)
-      call cleanup_interactions;   call nextdot(.false.)
-      call cleanup_dataio;         call nextdot(.false.)
-      call cleanup_fargo;          call nextdot(.false.)
+      if (associated(cleanup_problem)) call cleanup_problem; call nextdot
+      call urc_list%cleanup;       call nextdot
+      call t_pool%cleanup;         call nextdot
+      call cleanup_interactions;   call nextdot
+      call cleanup_dataio;         call nextdot
+      call cleanup_fargo;          call nextdot
 #ifdef RESISTIVE
-      call cleanup_resistivity;    call nextdot(.false.)
+      call cleanup_resistivity;    call nextdot
 #endif /* RESISTIVE */
-      call cleanup_grid;           call nextdot(.false.)
+      call cleanup_grid;           call nextdot
 #ifdef MULTIGRID
-      call cleanup_multigrid;      call nextdot(.false.)
+      call cleanup_multigrid;      call nextdot
 #endif /* MULTIGRID */
-      call cleanup_sortable_list;  call nextdot(.false.)
-      call cleanup_fluids;         call nextdot(.false.)
+      call cleanup_sortable_list;  call nextdot
+      call cleanup_fluids;         call nextdot
 #ifdef GRAV
-      call cleanup_particles;      call nextdot(.false.)
+      call cleanup_particles;      call nextdot
 #endif /* GRAV */
-      call cleanup_global;         call nextdot(.false.)
-      call cleanup_decomposition;  call nextdot(.false.)
-      call cleanup_domain;         call nextdot(.false.)
-      call cleanup_fluidindex;     call nextdot(.false., print_t = .true.)
-      call cleanup_timers;         call nextdot(.false.)
-      call cleanup_diagnostics;    call nextdot(.false.)
-      call cg_extptrs%epa_cleanup; call nextdot(.false.)
+      call cleanup_global;         call nextdot
+      call cleanup_decomposition;  call nextdot
+      call cleanup_domain;         call nextdot
+      call cleanup_fluidindex;     call nextdot(print_t = .true.)
+      call cleanup_timers;         call nextdot
+      call cleanup_diagnostics;    call nextdot
+      call cg_extptrs%epa_cleanup; call nextdot
 #ifdef PIERNIK_OPENCL
-      call cleanup_opencl;         call nextdot(.false.)
+      call cleanup_opencl;         call nextdot
 #endif /* PIERNIK_OPENCL */
 #ifdef RANDOMIZE
-      call cleanup_randomization;  call nextdot(.false.)
+      call cleanup_randomization;  call nextdot
 #endif /* RANDOMIZE */
-      call cleanup_mpi;            call nextdot(.true.)
 
    end subroutine cleanup_piernik
 
 !>
 !! Just print a dot on the screen, do not put a newline unless asked to do so.
 !<
-   subroutine nextdot(advance, print_t)
+   subroutine nextdot(print_t)
 
       use mpisetup,  only: master
       use constants, only: stdout, tmr_fu
@@ -122,19 +120,13 @@ contains
 
       implicit none
 
-      logical, intent(in) :: advance
       logical, optional, intent(in) :: print_t
 
       if (master) then
          if (present(print_t)) then
-            if (print_t) &
-               write(stdout,'(f7.2,a)',advance='no') set_timer(tmr_fu), " s "
+            if (print_t) write(stdout,'(f7.2,a)',advance='no') set_timer(tmr_fu), " s "
          endif
-         if (advance) then
-            write(stdout,'(a)')"."
-         else
-            write(stdout,'(a)',advance='no')"."
-         endif
+         write(stdout,'(a)',advance='no')"."
       endif
 
    end subroutine nextdot

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -38,7 +38,7 @@ module global
    implicit none
 
    private
-   public :: cleanup_global, init_global, system_mem_usage, check_mem_usage, &
+   public :: cleanup_global, init_global, &
         &    cfl, cfl_max, cflcontrol, cfl_violated, disallow_negatives, disallow_CRnegatives, unwanted_negatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, &
         &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
@@ -106,11 +106,10 @@ module global
    logical                       :: ord_fc_eq_mag     !< when .true. enforce ord_mag_prolong order of prolongation of f/c guardcells for fluid and everything (EXPERIMENTAL)
    logical                       :: do_external_corners  !< when .true. then perform boundary exchanges inside external guardcells
    character(len=cbuff_len)      :: solver_str        !< allow to switch between RIEMANN and RTVD without recompilation
-   integer(kind=4)               :: max_mem           !< MAximum allowed RSS memory per thread (in kiB)
 
    namelist /NUMERICAL_SETUP/ cfl, cflcontrol, disallow_negatives, disallow_CRnegatives, cfl_max, use_smalld, use_smallei, smalld, smallei, smallc, smallp, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, &
         &                     repeat_step, limiter, limiter_b, relax_time, integration_order, cfr_smooth, skip_sweep, geometry25D, sweeps_mgu, print_divB, &
-        &                     use_fargo, divB_0, glm_alpha, use_eglm, cfl_glm, ch_grid, interpol_str, w_epsilon, psi_bnd_str, ord_mag_prolong, ord_fc_eq_mag, do_external_corners, solver_str, max_mem
+        &                     use_fargo, divB_0, glm_alpha, use_eglm, cfl_glm, ch_grid, interpol_str, w_epsilon, psi_bnd_str, ord_mag_prolong, ord_fc_eq_mag, do_external_corners, solver_str
 
 contains
 
@@ -155,7 +154,6 @@ contains
 !!   <tr><td>ord_mag_prolong  </td><td>2      </td><td>integer                              </td><td>\copydoc global::ord_mag_prolong  </td></tr>
 !!   <tr><td>ord_fc_eq_mag    </td><td>.false.</td><td>logical                              </td><td>\copydoc global::ord_fc_eq_mag    </td></tr>
 !!   <tr><td>do_external_corners </td><td>.false.</td><td>logical                           </td><td>\copydoc global::do_external_corners </td></tr>
-!!   <tr><td>max_mem          </td><td>huge(1)</td><td>integer value                        </td><td>\copydoc global::max_mem          </td></tr>
 !! </table>
 !! \n \n
 !<
@@ -231,7 +229,6 @@ contains
       ord_fc_eq_mag = .false.          !< Conservative choice, perhaps O_LIN will be safer. Higher orders may result in negative density or energy in f/c guardcells
       do_external_corners =.false.
       solver_str = ""
-      max_mem     = huge(1_4)
 
       if (master) then
          if (.not.nh%initialized) call nh%init()
@@ -276,7 +273,6 @@ contains
          ibuff(1) = integration_order
          ibuff(2) = print_divB
          ibuff(3) = ord_mag_prolong
-         ibuff(4) = max_mem
 
          rbuff( 1) = smalld
          rbuff( 2) = smallc
@@ -360,7 +356,6 @@ contains
          integration_order    = ibuff(1)
          print_divB           = ibuff(2)
          ord_mag_prolong      = ibuff(3)
-         max_mem              = ibuff(4)
 
       endif
 
@@ -488,86 +483,5 @@ contains
       implicit none
       grace_period_passed = (t >= relax_time)
    end function grace_period_passed
-
-!>
-!! \brief tell the current estimate of memory used by current thread.
-!!
-!! \todo Add optional intent(in) argument with other interesting labels such as VmPeak or VmSize
-!>
-
-   integer(kind=4) function system_mem_usage()
-
-      use constants,  only: INVALID, fnamelen
-      use dataio_pub, only: warn
-
-      implicit none
-
-      integer, parameter :: pidlen = 8
-      character(len=fnamelen) :: filename, line
-      character(len=pidlen)   :: pid_char
-      integer :: stat_lun, io
-      logical :: io_exists
-
-      system_mem_usage = INVALID
-
-      write(pid_char, '(i8)') getpid()
-      filename = '/proc/' // trim(adjustl(pid_char)) // '/status'
-
-      inquire (file=filename, exist=io_exists)
-      if (.not. io_exists) then
-         call warn("[global:system_mem_usage] Cannot find '" // filename // "'")
-         return
-      endif
-
-      open(newunit=stat_lun, file=filename, status='old')
-      do
-         read (stat_lun,'(a)', iostat=io) line
-         if (io /= 0) exit
-         if (line(1:6) == 'VmRSS:') then
-            read (line(7:), *) system_mem_usage
-            exit
-         endif
-      enddo
-
-      close(stat_lun)
-
-   end function system_mem_usage
-
-!>
-!! \brief Check if current memory usage doex not exceed the limit.
-!!
-!! \detailed This routine should be called after each potentially large allocaltion.
-!! This may be used to crash Piernik before running into swapped memory.
-!!
-!! Cannot make a clean exit and call a restart dump from here because
-!! it is not guaranteed that each process visits this routine.
-!<
-
-   subroutine check_mem_usage
-
-      use dataio_pub, only: warn, die, msg
-      use mpisetup,   only: proc
-
-      implicit none
-
-      integer :: rss
-      real, parameter :: warnlevel = 0.95
-      integer, save :: nextwarn = 1, warncnt = 0
-
-      rss = system_mem_usage()
-
-      if (rss > max_mem) then
-         write(msg, '(a,2(i11,a),i5)')"[global:check_mem_usage] RSS exceeded max mem (", rss, " kiB > ", max_mem, " kiB) on process ", proc
-         call die(msg)
-      else if (rss > warnlevel*max_mem) then
-         warncnt = warncnt + 1
-         if (warncnt >= nextwarn) then
-            write(msg, '(a,2(i11,a),i5)')"[global:check_mem_usage] RSS is approaching max mem (", rss, " kiB <= ", max_mem, " kiB) on process ", proc
-            call warn(msg)
-            nextwarn = 2 * nextwarn
-         endif
-      endif
-
-   end subroutine check_mem_usage
 
 end module global

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -63,8 +63,8 @@ contains
       use initproblem,           only: problem_initial_conditions, read_problem_par, problem_pointers
       use interpolations,        only: set_interpolations
       use memory_usage,          only: init_memory
-      use mpisetup,              only: init_mpi, master
-      use ppp,                   only: init_profiling
+      use mpisetup,              only: init_mpi, master, bigbang
+      use ppp,                   only: init_profiling, tst_cnt
       use refinement,            only: init_refinement, level_max
       use refinement_update,     only: update_refinement
       use sources,               only: init_sources
@@ -110,6 +110,7 @@ contains
       real    :: ts                  !< Timestep wallclock
       logical :: finished
       integer, parameter :: nit_over = 3 ! maximum number of auxiliary iterations after reaching level_max
+      character(len=*), parameter :: ip_label = "init_piernik"
 
       call set_colors(.false.)               ! Make sure that we won't emit colorful messages before we are allowed to do so
 
@@ -139,6 +140,7 @@ contains
       call init_dataio_parameters            ! Required very early to call colormessage without side-effects
       call init_memory
       call init_profiling                    ! May require init_dataio_parameters and memory_usage set up
+      call tst_cnt%put(ip_label, bigbang)  ! can't call tst_cnt%start("init_piernik") before init_mpi
 
       call init_units
 
@@ -294,6 +296,8 @@ contains
       call write_data(output=INCEPTIVE)
 
       call sanitize_smallx_checks            ! depends on problem_initial_conditions || init_dataio/read_restart_hdf5
+
+      call tst_cnt%stop(ip_label)
 
    end subroutine init_piernik
 !-----------------------------------------------------------------------------

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -46,7 +46,7 @@ contains
       use all_boundaries,        only: all_bnd, all_bnd_vital_q
       use cg_level_finest,       only: finest
       use cg_list_global,        only: all_cg
-      use constants,             only: PIERNIK_INIT_MPI, PIERNIK_INIT_GLOBAL, PIERNIK_INIT_FLUIDS, PIERNIK_INIT_DOMAIN, PIERNIK_INIT_GRID, PIERNIK_INIT_IO_IC, PIERNIK_POST_IC, INCEPTIVE, tmr_fu, cbuff_len
+      use constants,             only: PIERNIK_INIT_MPI, PIERNIK_INIT_GLOBAL, PIERNIK_INIT_FLUIDS, PIERNIK_INIT_DOMAIN, PIERNIK_INIT_GRID, PIERNIK_INIT_IO_IC, PIERNIK_POST_IC, INCEPTIVE, tmr_fu, cbuff_len, PPP_PROB
       use dataio,                only: init_dataio, init_dataio_parameters, write_data
       use dataio_pub,            only: nrestart, restarted_sim, wd_rd, par_file, tmp_log_file, msg, printio, printinfo, warn, require_problem_IC, problem_name, run_id, code_progress, log_wr, set_colors
       use decomposition,         only: init_decomposition
@@ -251,9 +251,9 @@ contains
 
          nit = 0
          finished = .false.
-         call ppp_main%start(iter_label // "0")
+         call ppp_main%start(iter_label // "0", PPP_PROB)
          call problem_initial_conditions ! may depend on anything
-         call ppp_main%stop(iter_label // "0")
+         call ppp_main%stop(iter_label // "0", PPP_PROB)
          call init_psi ! initialize the auxiliary field for divergence cleaning when needed
 
          write(msg, '(a,f10.2)')"[initpiernik] IC on base level, time elapsed: ",set_timer(tmr_fu)
@@ -270,9 +270,9 @@ contains
             call update_refinement(act_count=ac)
             finished = (ac == 0) .or. (nit > level_max + nit_over) ! level_max iterations for creating refinement levels + level_max iterations for derefining excess of blocks
 
-            call ppp_main%start(iter_label // adjustl(label))
+            call ppp_main%start(iter_label // adjustl(label), PPP_PROB)
             call problem_initial_conditions ! reset initial conditions after possible changes of refinement structure
-            call ppp_main%stop(iter_label // adjustl(label))
+            call ppp_main%stop(iter_label // adjustl(label), PPP_PROB)
 
             nit = nit + 1
             write(msg, '(2(a,i3),a,f10.2)')"[initpiernik] IC iteration: ",nit,", finest level:",finest%level%l%id,", time elapsed: ",set_timer(tmr_fu)

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -64,7 +64,7 @@ contains
       use interpolations,        only: set_interpolations
       use memory_usage,          only: init_memory
       use mpisetup,              only: init_mpi, master, bigbang
-      use ppp,                   only: init_profiling, tst_cnt
+      use ppp,                   only: init_profiling, ppp_main
       use refinement,            only: init_refinement, level_max
       use refinement_update,     only: update_refinement
       use sources,               only: init_sources
@@ -140,7 +140,7 @@ contains
       call init_dataio_parameters            ! Required very early to call colormessage without side-effects
       call init_memory
       call init_profiling                    ! May require init_dataio_parameters and memory_usage set up
-      call tst_cnt%put(ip_label, bigbang)  ! can't call tst_cnt%start("init_piernik") before init_mpi
+      call ppp_main%put(ip_label, bigbang)   ! can't call tst_cnt%start("init_piernik") before init_mpi
 
       call init_units
 
@@ -297,7 +297,7 @@ contains
 
       call sanitize_smallx_checks            ! depends on problem_initial_conditions || init_dataio/read_restart_hdf5
 
-      call tst_cnt%stop(ip_label)
+      call ppp_main%stop(ip_label)
 
    end subroutine init_piernik
 !-----------------------------------------------------------------------------

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -62,6 +62,7 @@ contains
       use initfluids,            only: init_fluids, sanitize_smallx_checks
       use initproblem,           only: problem_initial_conditions, read_problem_par, problem_pointers
       use interpolations,        only: set_interpolations
+      use memory_usage,          only: init_memory
       use mpisetup,              only: init_mpi, master
       use ppp,                   only: init_profiling
       use refinement,            only: init_refinement, level_max
@@ -136,7 +137,8 @@ contains
       call cg_extptrs%epa_init
 
       call init_dataio_parameters            ! Required very early to call colormessage without side-effects
-      call init_profiling                    ! May require init_dataio_parameters set up
+      call init_memory
+      call init_profiling                    ! May require init_dataio_parameters and memory_usage set up
 
       call init_units
 

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -63,6 +63,7 @@ contains
       use initproblem,           only: problem_initial_conditions, read_problem_par, problem_pointers
       use interpolations,        only: set_interpolations
       use mpisetup,              only: init_mpi, master
+      use ppp,                   only: init_profiling
       use refinement,            only: init_refinement, level_max
       use refinement_update,     only: update_refinement
       use sources,               only: init_sources
@@ -135,6 +136,7 @@ contains
       call cg_extptrs%epa_init
 
       call init_dataio_parameters            ! Required very early to call colormessage without side-effects
+      call init_profiling                    ! May require init_dataio_parameters set up
 
       call init_units
 

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -110,8 +110,7 @@ contains
       real    :: ts                  !< Timestep wallclock
       logical :: finished
       integer, parameter :: nit_over = 3 ! maximum number of auxiliary iterations after reaching level_max
-      character(len=*), parameter :: ip_label = "init_piernik", ic_label = "IC_piernik", iter_label = "IC_iteration ", &
-           &                         grav_label = "IC_grav "
+      character(len=*), parameter :: ip_label = "init_piernik", ic_label = "IC_piernik", iter_label = "IC_iteration "
       character(len=cbuff_len) :: label
 
       call set_colors(.false.)               ! Make sure that we won't emit colorful messages before we are allowed to do so
@@ -265,9 +264,7 @@ contains
 
             call all_bnd !> \warning Never assume that problem_initial_conditions set guardcells correctly
 #ifdef GRAV
-            call ppp_main%start(grav_label // adjustl(label))
             call source_terms_grav
-            call ppp_main%stop(grav_label // adjustl(label))
 #endif /* GRAV */
 
             call update_refinement(act_count=ac)
@@ -288,9 +285,7 @@ contains
          if (ac /= 0) then
             if (master) call warn("[initpiernik:init_piernik] The refinement structure does not seem to converge. Your refinement criteria may lead to oscillations of refinement structure. Bailing out.")
 #ifdef GRAV
-            call ppp_main%start(grav_label // adjustl(label))
             call source_terms_grav  ! fix up gravitational potential when refiements did not converge
-            call ppp_main%stop(grav_label // adjustl(label))
 #endif /* GRAV */
          endif
          if (associated(problem_post_IC)) call problem_post_IC

--- a/src/base/memory_usage.F90
+++ b/src/base/memory_usage.F90
@@ -1,0 +1,181 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+#include "piernik.h"
+!>
+!! \brief This module provides tools to check memory usage and abort the simulation before it runs into heavy swap usage
+!!
+!! In this module following namelists of parameters are specified:
+!! \copydetails memory_usage::init_memory
+!<
+module memory_usage
+
+   implicit none
+
+   private
+   public :: init_memory, system_mem_usage, check_mem_usage
+
+   integer(kind=4) :: max_mem  !< Maximum allowed RSS memory per thread (in kiB)
+
+   namelist /MEMORY/ max_mem
+
+contains
+
+!-----------------------------------------------------------------------------
+!>
+!! \brief Routine to set up allowed memory usage for the simulation
+!!
+!! \n \n
+!! @b MEMORY
+!! \n \n
+!! <table border="+1">
+!!   <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
+!!   <tr><td>max_mem          </td><td>huge(1)</td><td>integer value                        </td><td>\copydoc global::max_mem          </td></tr>
+!! </table>
+!! \n \n
+!<
+   subroutine init_memory
+
+      use dataio_pub, only: nh  ! QA_WARN required for diff_nml
+      use mpisetup,   only: ibuff, master, slave, piernik_MPI_Bcast
+
+      implicit none
+
+      max_mem     = huge(1_4)
+
+      if (master) then
+         if (.not.nh%initialized) call nh%init()
+         open(newunit=nh%lun, file=nh%tmp1, status="unknown")
+         write(nh%lun,nml=MEMORY)
+         close(nh%lun)
+         open(newunit=nh%lun, file=nh%par_file)
+         nh%errstr=""
+         read(unit=nh%lun, nml=MEMORY, iostat=nh%ierrh, iomsg=nh%errstr)
+         close(nh%lun)
+         call nh%namelist_errh(nh%ierrh, "MEMORY")
+         read(nh%cmdl_nml,nml=MEMORY, iostat=nh%ierrh)
+         call nh%namelist_errh(nh%ierrh, "MEMORY", .true.)
+         open(newunit=nh%lun, file=nh%tmp2, status="unknown")
+         write(nh%lun,nml=MEMORY)
+         close(nh%lun)
+         call nh%compare_namelist()
+
+         ibuff(1) = max_mem
+
+      endif
+
+      call piernik_MPI_Bcast(ibuff)
+
+      if (slave) then
+
+         max_mem = ibuff(1)
+
+      endif
+
+   end subroutine init_memory
+
+!>
+!! \brief tell the current estimate of memory used by current thread.
+!!
+!! \todo Add optional intent(in) argument with other interesting labels such as VmPeak or VmSize
+!>
+
+   integer(kind=4) function system_mem_usage()
+
+      use constants,  only: INVALID, fnamelen
+      use dataio_pub, only: warn
+
+      implicit none
+
+      integer, parameter :: pidlen = 8
+      character(len=fnamelen) :: filename, line
+      character(len=pidlen)   :: pid_char
+      integer :: stat_lun, io
+      logical :: io_exists
+
+      system_mem_usage = INVALID
+
+      write(pid_char, '(i8)') getpid()
+      filename = '/proc/' // trim(adjustl(pid_char)) // '/status'
+
+      inquire (file=filename, exist=io_exists)
+      if (.not. io_exists) then
+         call warn("[memory_usage:system_mem_usage] Cannot find '" // filename // "'")
+         return
+      endif
+
+      open(newunit=stat_lun, file=filename, status='old')
+      do
+         read (stat_lun,'(a)', iostat=io) line
+         if (io /= 0) exit
+         if (line(1:6) == 'VmRSS:') then
+            read (line(7:), *) system_mem_usage
+            exit
+         endif
+      enddo
+
+      close(stat_lun)
+
+   end function system_mem_usage
+
+!>
+!! \brief Check if current memory usage doex not exceed the limit.
+!!
+!! \detailed This routine should be called after each potentially large allocaltion.
+!! This may be used to crash Piernik before running into swapped memory.
+!!
+!! Cannot make a clean exit and call a restart dump from here because
+!! it is not guaranteed that each process visits this routine.
+!<
+
+   subroutine check_mem_usage
+
+      use dataio_pub, only: warn, die, msg
+      use mpisetup,   only: proc
+
+      implicit none
+
+      integer :: rss
+      real, parameter :: warnlevel = 0.95
+      integer, save :: nextwarn = 1, warncnt = 0
+
+      rss = system_mem_usage()
+
+      if (rss > max_mem) then
+         write(msg, '(a,2(i11,a),i5)')"[memory_usage:check_mem_usage] RSS exceeded max mem (", rss, " kiB > ", max_mem, " kiB) on process ", proc
+         call die(msg)
+      else if (rss > warnlevel * max_mem) then
+         warncnt = warncnt + 1
+         if (warncnt >= nextwarn) then
+            write(msg, '(a,2(i11,a),i5)')"[memory_usage:check_mem_usage] RSS is approaching max mem (", rss, " kiB <= ", max_mem, " kiB) on process ", proc
+            call warn(msg)
+            nextwarn = 2 * nextwarn
+         endif
+      endif
+
+   end subroutine check_mem_usage
+
+end module memory_usage

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -38,7 +38,7 @@ module mpisetup
    implicit none
 
    private
-   public :: cleanup_mpi, init_mpi, inflate_req, &
+   public :: cleanup_mpi, init_mpi, inflate_req, bigbang, &
         &    buffer_dim, cbuff, ibuff, lbuff, rbuff, req, status, mpi_err, procmask, &
         &    master, slave, nproc, proc, FIRST, LAST, comm, have_mpi, is_spawned, &
         &    piernik_MPI_Allreduce, piernik_MPI_Barrier, piernik_MPI_Bcast, report_to_master, &
@@ -51,6 +51,7 @@ module mpisetup
    integer(kind=4), protected :: intercomm      !< intercommunicator
    integer(kind=4) :: mpi_err                   !< error status
    integer(kind=INT4), parameter :: FIRST = 0   !< the rank of the master process
+   real(kind=8), protected    :: bigbang
 
    logical, protected :: master      !< .True. if proc == FIRST
    logical, protected :: slave       !< .True. if proc != FIRST
@@ -125,7 +126,7 @@ contains
    subroutine init_mpi
 
       use constants,     only: cwdlen, I_ONE
-      use mpi,           only: MPI_COMM_WORLD, MPI_CHARACTER, MPI_INTEGER, MPI_COMM_NULL
+      use mpi,           only: MPI_COMM_WORLD, MPI_CHARACTER, MPI_INTEGER, MPI_COMM_NULL, MPI_Wtime
       use dataio_pub,    only: die, printinfo, msg, ansi_white, ansi_black, tmp_log_file
       use dataio_pub,    only: par_file, lun
       use signalhandler, only: SIGINT, register_sighandler
@@ -147,6 +148,7 @@ contains
       integer :: iproc
 
       call MPI_Init( mpi_err )
+      bigbang = MPI_Wtime()
       comm = MPI_COMM_WORLD
 
 #if defined(__INTEL_COMPILER) || defined(__GFORTRAN__)

--- a/src/base/named_array.F90
+++ b/src/base/named_array.F90
@@ -101,9 +101,9 @@ contains
 !<
    subroutine named_array_init(this, n1, n2)
 
-      use constants,  only: dirtyH1, ndims, xdim, ydim, zdim, I_ONE
-      use dataio_pub, only: die
-      use global,     only: check_mem_usage
+      use constants,    only: dirtyH1, ndims, xdim, ydim, zdim, I_ONE
+      use dataio_pub,   only: die
+      use memory_usage, only: check_mem_usage
 
       implicit none
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -47,7 +47,7 @@ program piernik
    use list_of_cg_lists,  only: all_lists
    use mpisetup,          only: master, piernik_MPI_Barrier, piernik_MPI_Bcast, cleanup_mpi
    use named_array_list,  only: qna, wna
-   use ppp,               only: cleanup_profiling, ppp_main
+   use ppp,               only: cleanup_profiling, update_profiling, ppp_main
    use refinement,        only: emergency_fix
    use refinement_update, only: update_refinement
    use timer,             only: walltime_end
@@ -184,6 +184,7 @@ program piernik
       first_step = .false.
 
       call ppp_main%stop(label)
+      call update_profiling
 
    enddo ! main loop
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -116,7 +116,7 @@ program piernik
    call print_progress(nstep)
    if (print_divB > 0) call print_divB_norm
 
-   nstep_started = nstep - 1
+   nstep_started = nstep - I_ONE
    call tst_cnt%start("steps")
    do while (t < tend .and. nstep < nend .and. .not.(end_sim) .or. (cfl_violated .and. repeat_step)) ! main loop
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -47,7 +47,7 @@ program piernik
    use list_of_cg_lists,  only: all_lists
    use mpisetup,          only: master, piernik_MPI_Barrier, piernik_MPI_Bcast, cleanup_mpi
    use named_array_list,  only: qna, wna
-   use ppp,               only: cleanup_profiling, tst_cnt
+   use ppp,               only: cleanup_profiling, ppp_main
    use refinement,        only: emergency_fix
    use refinement_update, only: update_refinement
    use timer,             only: walltime_end
@@ -115,7 +115,7 @@ program piernik
    if (print_divB > 0) call print_divB_norm
 
    nstep_started = nstep - I_ONE
-   call tst_cnt%start(st_label)
+   call ppp_main%start(st_label)
    do while (t < tend .and. nstep < nend .and. .not.(end_sim) .or. (cfl_violated .and. repeat_step)) ! main loop
 
       dump(:) = .false.
@@ -142,13 +142,13 @@ program piernik
       endif
       if (nstep > nstep_started) then
          write(label, '(i8)') nstep
-         call tst_cnt%start(fu_label // adjustl(label))
+         call ppp_main%start(fu_label // adjustl(label))
          nstep_started = nstep
       endif
       call fluid_update
       if (nstep >= nstep_started) then
          write(label, '(i8)') nstep
-         call tst_cnt%stop(fu_label // adjustl(label))
+         call ppp_main%stop(fu_label // adjustl(label))
       endif
       nstep = nstep + I_ONE
       call print_progress(nstep)
@@ -190,11 +190,11 @@ program piernik
    if (print_divB > 0) then
       if (mod(nstep, print_divB) /= 0) call print_divB_norm ! print the norm at the end, if it wasn't printed inside the loop above
    endif
-   call tst_cnt%stop(st_label)
+   call ppp_main%stop(st_label)
 
    code_progress = PIERNIK_FINISHED
 
-   call tst_cnt%start(f_label)
+   call ppp_main%start(f_label)
    if (master) then
       write(tstr, '(g14.6)') t
       write(nstr, '(i7)') nstep
@@ -245,8 +245,8 @@ program piernik
 
    call cleanup_piernik
 
-   call tst_cnt%stop(f_label)
-   call tst_cnt%publish  ! we can use HDF5 here because we don't rely on anything that is affected by cleanup_hdf5
+   call ppp_main%stop(f_label)
+   call ppp_main%publish  ! we can use HDF5 here because we don't rely on anything that is affected by cleanup_hdf5
    call cleanup_profiling
    call cleanup_mpi
    if (master) write(stdout,'(a)')"#"

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -75,13 +75,13 @@ program piernik
    character(len=cbuff_len) :: label
    integer(kind=4) :: nstep_started
 
-   call tst_cnt%init("main")
    try_rebalance = .false.
    tlast = 0.0
 
    code_progress = PIERNIK_START
 
    call init_piernik
+   call tst_cnt%init("main")
    call tst_cnt%put("init_piernik", bigbang)  ! can't call tst_cnt%start("init_piernik") before init_mpi
    call tst_cnt%stop("init_piernik")
 
@@ -244,13 +244,14 @@ program piernik
 
    code_progress = PIERNIK_CLEANUP
 
-   if (master) write(stdout, '(a)', advance='no') "Finishing "
+   if (master) write(stdout, '(a)', advance='no') "Finishing #"
 
    call cleanup_piernik
 
    call tst_cnt%stop("finalize")
    call tst_cnt%publish  ! we can use HDF5 here because we don't rely on anything that is affected by cleanup_hdf5
    call cleanup_mpi
+   if (master) write(stdout,'(a)')"#"
 
 contains
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -117,6 +117,7 @@ program piernik
    call print_progress(nstep)
    if (print_divB > 0) call print_divB_norm
 
+   nstep_started = nstep - 1
    call tst_cnt%start("steps")
    do while (t < tend .and. nstep < nend .and. .not.(end_sim) .or. (cfl_violated .and. repeat_step)) ! main loop
 
@@ -142,9 +143,11 @@ program piernik
 
          tlast = t
       endif
-      write(label, '(i8)') nstep
-      nstep_started = nstep
-      call tst_cnt%start("fluid_update " // adjustl(label))
+      if (nstep > nstep_started) then
+         write(label, '(i8)') nstep
+         call tst_cnt%start("fluid_update " // adjustl(label))
+         nstep_started = nstep
+      endif
       call fluid_update
       if (nstep >= nstep_started) then
          write(label, '(i8)') nstep

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -47,6 +47,7 @@ program piernik
    use list_of_cg_lists,  only: all_lists
    use mpisetup,          only: master, piernik_MPI_Barrier, piernik_MPI_Bcast, bigbang, cleanup_mpi
    use named_array_list,  only: qna, wna
+   use ppp,               only: eventlist, cleanup_profiling
    use refinement,        only: emergency_fix
    use refinement_update, only: update_refinement
    use timer,             only: walltime_end
@@ -59,8 +60,6 @@ program piernik
 #if defined DEBUG && defined GRAV
    use particle_pub,      only: pset
 #endif /* DEBUG && GRAV */
-
-   use ppp, only: eventlist
 
    implicit none
 
@@ -250,6 +249,7 @@ program piernik
 
    call tst_cnt%stop("finalize")
    call tst_cnt%publish  ! we can use HDF5 here because we don't rely on anything that is affected by cleanup_hdf5
+   call cleanup_profiling
    call cleanup_mpi
    if (master) write(stdout,'(a)')"#"
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -42,7 +42,7 @@ program piernik
    use fluidindex,        only: flind
    use fluidupdate,       only: fluid_update
    use func,              only: operator(.equals.)
-   use global,            only: t, nstep, dt, dtm, cfl_violated, print_divB, repeat_step
+   use global,            only: t, nstep, dt, dtm, cfl_violated, print_divB, repeat_step, tstep_attempt
    use initpiernik,       only: init_piernik
    use list_of_cg_lists,  only: all_lists
    use mpisetup,          only: master, piernik_MPI_Barrier, piernik_MPI_Bcast, cleanup_mpi
@@ -71,9 +71,8 @@ program piernik
    logical              :: try_rebalance
 
    ! ppp-related
-   character(len=cbuff_len)    :: label
-   integer(kind=4)             :: nstep_started
-   character(len=*), parameter :: st_label = "steps", fu_label = "fluid_update ", f_label = "finalize"
+   character(len=cbuff_len)    :: label, buf
+   character(len=*), parameter :: f_label = "finalize"
 
    try_rebalance = .false.
    tlast = 0.0
@@ -114,9 +113,15 @@ program piernik
    call print_progress(nstep)
    if (print_divB > 0) call print_divB_norm
 
-   nstep_started = nstep - I_ONE
-   call ppp_main%start(st_label)
    do while (t < tend .and. nstep < nend .and. .not.(end_sim) .or. (cfl_violated .and. repeat_step)) ! main loop
+
+      write(buf, '(i10)') nstep
+      label = "step " // adjustl(trim(buf))
+      if (tstep_attempt /= 0) then
+         write(buf, '(i3)') tstep_attempt
+         label = "repeated_" // trim(label) // "." // adjustl(trim(buf))
+      endif
+      call ppp_main%start(label)
 
       dump(:) = .false.
       if (associated(problem_domain_update)) then
@@ -140,16 +145,8 @@ program piernik
 
          tlast = t
       endif
-      if (nstep > nstep_started) then
-         write(label, '(i8)') nstep
-         call ppp_main%start(fu_label // adjustl(label))
-         nstep_started = nstep
-      endif
+
       call fluid_update
-      if (nstep >= nstep_started) then
-         write(label, '(i8)') nstep
-         call ppp_main%stop(fu_label // adjustl(label))
-      endif
       nstep = nstep + I_ONE
       call print_progress(nstep)
       call check_cfl_violation(dt, flind)
@@ -185,12 +182,14 @@ program piernik
       if (.not.tleft) end_sim = .true.
 
       first_step = .false.
+
+      call ppp_main%stop(label)
+
    enddo ! main loop
 
    if (print_divB > 0) then
       if (mod(nstep, print_divB) /= 0) call print_divB_norm ! print the norm at the end, if it wasn't printed inside the loop above
    endif
-   call ppp_main%stop(st_label)
 
    code_progress = PIERNIK_FINISHED
 

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -512,7 +512,7 @@ contains
       character(len=cbuff_len), dimension(:), intent(in) :: ev_label  !< array of event labels
       real(kind=8), dimension(:),             intent(in) :: ev_time   !< array of event times
 
-      integer :: i
+      integer :: i, d
 
       if (slave) then
          call warn("[ppprofiling:publish_array] only master is supposed to write")
@@ -523,9 +523,12 @@ contains
 
       if (size(ev_label) /= size(ev_time)) call die("[ppprofiling:publish_array] arrays size mismatch")
 
+      d = 1
       do i = lbound(ev_label, dim=1), ubound(ev_label, dim=1)
          if (ev_time(i) .equals. 0.) exit
-         write(profile_lun, '(i4,2a,f20.7)') process, " ", ev_label(i), ev_time(i)
+         if (ev_time(i) < 0.) d = d - 1
+         write(profile_lun, '(i5,a,f20.7,2a)') process, " ", ev_time(i), repeat("  ", d) , trim(ev_label(i))
+         if (ev_time(i) > 0.) d = d + 1
       enddo
 
    end subroutine publish_buffers

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -427,7 +427,8 @@ contains
 
       class(eventlist), intent(inout) :: this   !< an object invoking the type-bound procedure
 
-      integer(kind=4) :: t, ia, p, ne
+      integer(kind=4) :: t, ne, p
+      integer :: ia
       character(len=cbuff_len), dimension(:), allocatable  :: buflabel
       real(kind=8), dimension(:), allocatable :: buftime
       integer(kind=4), dimension(:,:), pointer :: mpistatus
@@ -455,12 +456,12 @@ contains
          enddo
       else
          ! send
-         call inflate_req(TAG_ARR_T)
+         call inflate_req(int(TAG_ARR_T))
          t = TAG_CNT
          ne = I_ZERO
          do ia = lbound(this%arrays, dim=1), ubound(this%arrays, dim=1)
             if (allocated(this%arrays(ia)%ev_arr)) then
-               ne = ne + size(this%arrays(ia)%ev_arr)
+               ne = ne + size(this%arrays(ia)%ev_arr, kind=4)
             else
                exit
             endif
@@ -474,7 +475,7 @@ contains
                if (allocated(this%arrays(ia)%ev_arr)) then
                   buflabel(p:p+size(this%arrays(ia)%ev_arr)-I_ONE) = this%arrays(ia)%ev_arr(:)%label
                   buftime (p:p+size(this%arrays(ia)%ev_arr)-I_ONE) = this%arrays(ia)%ev_arr(:)%wtime
-                  p = p + size(this%arrays(ia)%ev_arr)
+                  p = p + size(this%arrays(ia)%ev_arr, kind=4)
                endif
             enddo
             call MPI_Isend(buflabel, size(buflabel)*len(buflabel(1)), MPI_CHARACTER,        FIRST, TAG_ARR_L, comm, req(TAG_ARR_L), mpi_err)
@@ -502,7 +503,7 @@ contains
 
       implicit none
 
-      integer,                   intent(in) :: process  !< origin of the event
+      integer(kind=4),           intent(in) :: process  !< origin of the event
       type(event), dimension(:), intent(in) :: ev_arr   !< array of events
 
       integer :: i
@@ -531,7 +532,7 @@ contains
 
       implicit none
 
-      integer,                                intent(in) :: process   !< origin of the event
+      integer(kind=4),                        intent(in) :: process   !< origin of the event
       character(len=cbuff_len), dimension(:), intent(in) :: ev_label  !< array of event labels
       real(kind=8), dimension(:),             intent(in) :: ev_time   !< array of event times
 

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -99,7 +99,7 @@ module ppp
    integer :: profile_lun                      !< logical unit number for profile file
    integer, save :: umsg_request = 0           !< turn on profiling for next umsg_request steps (read from msg file)
    logical, save :: profile_file_cr = .false.  !< .true after we open the profile file for writing
-   integer :: disable_mask                     !< logical mask for disabled events
+   integer(kind=4) :: disable_mask             !< logical mask for disabled events
    enum, bind(C)
       enumerator :: TAG_CNT = 1, TAG_ARR_L, TAG_ARR_T
    end enum
@@ -427,7 +427,7 @@ contains
 
       class(eventlist),  intent(inout) :: this   !< an object invoking the type-bound procedure
       character(len=*),  intent(in)    :: label  !< event label
-      integer, optional, intent(in)    :: mask   !< event category, if provided
+      integer(kind=4), optional, intent(in) :: mask   !< event category, if provided
 
       character(len=cbuff_len) :: l
 
@@ -455,7 +455,7 @@ contains
 
       class(eventlist),  intent(inout) :: this   !< an object invoking the type-bound procedure
       character(len=*),  intent(in)    :: label  !< event label
-      integer, optional, intent(in)    :: mask   !< event category, if provided, should match the category provided in this%start call
+      integer(kind=4), optional, intent(in) :: mask   !< event category, if provided, should match the category provided in this%start call
 
       character(len=cbuff_len) :: l
 

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -52,7 +52,7 @@ module ppp
    implicit none
 
    private
-   public :: eventlist, init_profiling, cleanup_profiling
+   public :: eventlist, init_profiling, cleanup_profiling, tst_cnt
 
    ! namelist parametrs
    logical               :: use_profiling  !< control whether to do any PPProfiling or not
@@ -97,6 +97,8 @@ module ppp
       procedure, private :: expand  !< create next array for events
       procedure :: publish  !< write the collected data to a log file
    end type eventlist
+
+   type(eventlist) :: tst_cnt  ! main eventlist
 
 contains
 
@@ -184,6 +186,8 @@ contains
             open(newunit=profile_lun, file=profile_file)
          endif
       endif
+
+      call tst_cnt%init("main")
 
    end subroutine init_profiling
 

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -52,7 +52,7 @@ module ppp
    implicit none
 
    private
-   public :: eventlist, init_profiling, cleanup_profiling, tst_cnt
+   public :: eventlist, init_profiling, cleanup_profiling, ppp_main
 
    ! namelist parametrs
    logical               :: use_profiling  !< control whether to do any PPProfiling or not
@@ -98,7 +98,7 @@ module ppp
       procedure :: publish  !< write the collected data to a log file
    end type eventlist
 
-   type(eventlist) :: tst_cnt  ! main eventlist
+   type(eventlist) :: ppp_main  ! main eventlist
 
 contains
 
@@ -187,7 +187,7 @@ contains
          endif
       endif
 
-      call tst_cnt%init("main")
+      call ppp_main%init("main")
 
    end subroutine init_profiling
 

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -210,9 +210,9 @@ contains
 
    subroutine arr_init(this, asize)
 
-      use constants,  only: PIERNIK_INIT_MPI
-      use dataio_pub, only: die, code_progress
-      use global,     only: check_mem_usage
+      use constants,    only: PIERNIK_INIT_MPI
+      use dataio_pub,   only: die, code_progress
+      use memory_usage, only: check_mem_usage
 
       implicit none
 
@@ -418,10 +418,10 @@ contains
 
    subroutine publish(this)
 
-      use constants, only: I_ZERO, I_ONE
-      use global,    only: check_mem_usage
-      use mpi,       only: MPI_STATUS_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION
-      use mpisetup,  only: proc, master, comm, mpi_err, FIRST, LAST, req, status, inflate_req
+      use constants,    only: I_ZERO, I_ONE
+      use memory_usage, only: check_mem_usage
+      use mpi,          only: MPI_STATUS_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION
+      use mpisetup,     only: proc, master, comm, mpi_err, FIRST, LAST, req, status, inflate_req
 
       implicit none
 

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -111,6 +111,7 @@ contains
       use global,             only: t, dt_old, dt_max_grow, dt_initial, dt_min, dt_max, nstep, cfl_violated
       use grid_cont,          only: grid_container
       use mpisetup,           only: master, piernik_MPI_Allreduce
+      use ppp,                only: ppp_main
       use sources,            only: timestep_sources
       use timestep_pub,       only: c_all, c_all_old
 #ifdef COSM_RAYS
@@ -132,6 +133,9 @@ contains
       type(grid_container),  pointer   :: cg
       real                             :: c_, dt_
       integer                          :: ifl
+      character(len=*), parameter :: ts_label = "timestep"
+
+      call ppp_main%start(ts_label)
 
 ! Timestep computation
 
@@ -198,6 +202,8 @@ contains
       endif
 #endif /* DEBUG */
       call compare_array1D([dt])  ! just in case
+
+      call ppp_main%stop(ts_label)
 
    end subroutine time_step
 

--- a/src/fluids/cosmicrays/crdiffusion.F90
+++ b/src/fluids/cosmicrays/crdiffusion.F90
@@ -74,7 +74,7 @@ contains
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
       use cg_list_global,   only: all_cg
-      use constants,        only: ndims, xdim, ydim, zdim, LO, HI, BND_PER, BND_MPI, BND_FC, BND_MPI_FC, I_TWO, I_THREE, wcr_n
+      use constants,        only: ndims, xdim, ydim, zdim, LO, HI, BND_PER, BND_MPI, BND_FC, BND_MPI_FC, I_TWO, I_THREE, wcr_n, PPP_CR
       use dataio_pub,       only: die
       use domain,           only: dom
       use grid_cont,        only: grid_container
@@ -92,7 +92,7 @@ contains
 
       if (.not. has_cr) return
 
-      call ppp_main%start(awb_label)
+      call ppp_main%start(awb_label, PPP_CR)
 
       call all_cg%internal_boundaries_4d(wna%ind(wcr_n)) ! should be more selective (modified leaves?)
 
@@ -126,7 +126,7 @@ contains
          cgl => cgl%nxt
       enddo
 
-      call ppp_main%stop(awb_label)
+      call ppp_main%stop(awb_label, PPP_CR)
 
    end subroutine all_wcr_boundaries
 
@@ -141,7 +141,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: xdim, ydim, zdim, ndims, LO, HI, oneeig, eight, wcr_n, GEO_XYZ
+      use constants,        only: xdim, ydim, zdim, ndims, LO, HI, oneeig, eight, wcr_n, GEO_XYZ, PPP_CR
       use dataio_pub,       only: die
       use domain,           only: dom
       use fluidindex,       only: flind
@@ -175,7 +175,7 @@ contains
       if (.not. has_cr) return
       if (.not.dom%has_dir(crdim)) return
 
-      call ppp_main%start(crd_label(crdim))
+      call ppp_main%start(crd_label(crdim), PPP_CR)
 
       if (dom%geometry_type /= GEO_XYZ) call die("[crdiffusion:cr_diff] Unsupported geometry")
 
@@ -260,7 +260,7 @@ contains
          cgl => cgl%nxt
       enddo
 
-      call ppp_main%stop(crd_label(crdim))
+      call ppp_main%stop(crd_label(crdim), PPP_CR)
 
    end subroutine cr_diff
 

--- a/src/fluids/cosmicrays/crdiffusion.F90
+++ b/src/fluids/cosmicrays/crdiffusion.F90
@@ -79,6 +79,7 @@ contains
       use domain,           only: dom
       use grid_cont,        only: grid_container
       use named_array_list, only: wna
+      use ppp,              only: ppp_main
 
       implicit none
 
@@ -87,8 +88,11 @@ contains
       real, dimension(:,:,:,:), pointer       :: wcr
       type(cg_list_element),    pointer       :: cgl
       type(grid_container),     pointer       :: cg
+      character(len=*), parameter :: awb_label = "all_wcr_boundaries"
 
       if (.not. has_cr) return
+
+      call ppp_main%start(awb_label)
 
       call all_cg%internal_boundaries_4d(wna%ind(wcr_n)) ! should be more selective (modified leaves?)
 
@@ -122,6 +126,8 @@ contains
          cgl => cgl%nxt
       enddo
 
+      call ppp_main%stop(awb_label)
+
    end subroutine all_wcr_boundaries
 
 !>
@@ -144,6 +150,7 @@ contains
       use initcosmicrays,   only: iarr_crs, K_crs_paral, K_crs_perp
       use named_array,      only: p4
       use named_array_list, only: wna
+      use ppp,              only: ppp_main
 #ifdef MAGNETIC
       use constants,        only: four
 #endif /* MAGNETIC */
@@ -163,9 +170,12 @@ contains
       logical, dimension(ndims)            :: present_not_crdim
       real, dimension(:,:,:,:), pointer    :: wcr
       integer                              :: wcri
+      character(len=*), dimension(ndims), parameter :: crd_label = [ "cr_diff_X", "cr_diff_Y", "cr_diff_Z" ]
 
       if (.not. has_cr) return
       if (.not.dom%has_dir(crdim)) return
+
+      call ppp_main%start(crd_label(crdim))
 
       if (dom%geometry_type /= GEO_XYZ) call die("[crdiffusion:cr_diff] Unsupported geometry")
 
@@ -249,6 +259,8 @@ contains
 
          cgl => cgl%nxt
       enddo
+
+      call ppp_main%stop(crd_label(crdim))
 
    end subroutine cr_diff
 

--- a/src/fluids/cosmicrays/multigrid_diffusion.F90
+++ b/src/fluids/cosmicrays/multigrid_diffusion.F90
@@ -370,7 +370,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_list_dataop,     only: ind_val, dirty_label
       use cg_list_global,     only: all_cg
-      use constants,          only: base_level_id, zero, dirtyH1
+      use constants,          only: base_level_id, zero, dirtyH1, PPP_MG, PPP_CR
       use dataio_pub,         only: die
       use func,               only: operator(.notequals.)
       use initcosmicrays,     only: iarr_crs
@@ -383,7 +383,7 @@ contains
       integer, intent(in) :: cr_id !< CR component index
       character(len=*), parameter :: cris_label = "CR:init_source"
 
-      call ppp_main%start(cris_label)
+      call ppp_main%start(cris_label, PPP_MG + PPP_CR)
 
       if (finest%level%l%id /= base_level_id) call die("[multigrid_diffusion:init_source] refinements not implemented yet")
 
@@ -404,7 +404,7 @@ contains
 
       vstat%norm_rhs = leaves%norm_sq(source)
 
-      call ppp_main%stop(cris_label)
+      call ppp_main%stop(cris_label, PPP_MG + PPP_CR)
 
    end subroutine init_source
 
@@ -509,7 +509,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_list_dataop,     only: ind_val, dirty_label
       use cg_list_global,     only: all_cg
-      use constants,          only: base_level_id, zero, tmr_mgd, dirtyH1, cbuff_len
+      use constants,          only: base_level_id, zero, tmr_mgd, dirtyH1, cbuff_len, PPP_MG, PPP_CR
       use dataio_pub,         only: msg, warn, die
       use global,             only: do_ascii_dump
       use func,               only: operator(.notequals.)
@@ -533,7 +533,7 @@ contains
       character(len=*), parameter :: crmgv_label = "CR:MG_V-cycles", crmgc_label = "CR:V-cycle "
       character(len=cbuff_len)    :: label
 
-      call ppp_main%start(crmgv_label)
+      call ppp_main%start(crmgv_label, PPP_MG + PPP_CR)
 
       write(vstat%cprefix,'("C",i1,"-")') cr_id !> \deprecated BEWARE: this is another place with 0 <= cr_id <= 9 limit
       write(dirty_label, '("md_",i1,"_dump")')  cr_id
@@ -574,7 +574,7 @@ contains
          if (dump_every_step) call all_cg%numbered_ascii_dump([ source, solution, defect, correction ], dirty_label, v)
 
          if (norm_lhs/norm_rhs <= norm_tol) exit
-         call ppp_main%start(crmgc_label // adjustl(label))
+         call ppp_main%start(crmgc_label // adjustl(label), PPP_MG + PPP_CR)
 
          if (v>convergence_history) then
             if (product(vstat%factor(v-convergence_history:v)) < barely_greater_than_1) then
@@ -601,7 +601,7 @@ contains
          call finest%level%check_dirty(correction, "c_residual")
          call finest%level%check_dirty(defect, "d_residual")
          call leaves%q_lin_comb( [ ind_val(solution, 1.), ind_val(correction, -1.) ], solution) ! solution := solution - correction
-         call ppp_main%stop(crmgc_label // adjustl(label))
+         call ppp_main%stop(crmgc_label // adjustl(label), PPP_MG + PPP_CR)
       enddo
 
       if (dump_every_step) call all_cg%numbered_ascii_dump([ source, solution, defect, correction ], dirty_label)
@@ -627,7 +627,7 @@ contains
 
       call leaves%qw_copy(solution, wna%fi, iarr_crs(cr_id))
 
-      call ppp_main%stop(crmgv_label)
+      call ppp_main%stop(crmgv_label, PPP_MG + PPP_CR)
 
    end subroutine vcycle_hg
 
@@ -715,7 +715,7 @@ contains
    subroutine residual(curl, src, soln, def, cr_id)
 
       use cg_level_connected, only: cg_level_connected_t
-      use constants,          only: xdim, ydim, zdim, ndims, LO, HI, GEO_XYZ
+      use constants,          only: xdim, ydim, zdim, ndims, LO, HI, GEO_XYZ, PPP_MG, PPP_CR
       use dataio_pub,         only: die
       use domain,             only: dom
       use cg_list,            only: cg_list_element
@@ -741,7 +741,7 @@ contains
       type(grid_container), pointer  :: cg
       character(len=*), parameter :: crr_label = "CR:residual"
 
-      call ppp_main%start(crr_label)
+      call ppp_main%start(crr_label, PPP_MG + PPP_CR)
 
       if (dom%geometry_type /= GEO_XYZ) call die("[multigrid_diffusion:diff_flux] Unsupported geometry")
 
@@ -773,7 +773,7 @@ contains
 
 !      call curl%check_dirty(def, "res def")
 
-     call ppp_main%stop(crr_label)
+     call ppp_main%stop(crr_label, PPP_MG + PPP_CR)
 
    end subroutine residual
 
@@ -790,7 +790,7 @@ contains
 
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t
-      use constants,          only: xdim, ydim, zdim, one, half, ndims, LO, GEO_XYZ
+      use constants,          only: xdim, ydim, zdim, one, half, ndims, LO, GEO_XYZ, PPP_MG, PPP_CR
       use dataio_pub,         only: die
       use domain,             only: dom
       use cg_list,            only: cg_list_element
@@ -817,7 +817,7 @@ contains
       type(cg_list_element), pointer  :: cgl
       character(len=*), parameter :: crs_label = "CR:approximate_solution"
 
-      call ppp_main%start(crs_label)
+      call ppp_main%start(crs_label, PPP_MG + PPP_CR)
 
       if (dom%geometry_type /= GEO_XYZ) call die("[multigrid_diffusion:diff_flux] Unsupported geometry")
 
@@ -882,7 +882,7 @@ contains
          enddo
       enddo
 
-      call ppp_main%stop(crs_label)
+      call ppp_main%stop(crs_label, PPP_MG + PPP_CR)
 
    end subroutine approximate_solution
 

--- a/src/gravity/gravity.F90
+++ b/src/gravity/gravity.F90
@@ -422,6 +422,7 @@ contains
 
    subroutine source_terms_grav
 
+      use ppp,               only: ppp_main
 #ifdef SELF_GRAV
       use cg_leaves,         only: leaves
       use cg_list_dataop,    only: expanded_domain
@@ -435,10 +436,15 @@ contains
 
       implicit none
 
+      character(len=*), parameter :: grav_label = "source_terms_grav"
 #ifdef SELF_GRAV
       logical, save :: frun = .true.
       logical :: initialized
+#endif /* SELF_GRAV */
 
+      call ppp_main%start(grav_label)
+
+#ifdef SELF_GRAV
       initialized = .true.
       if (frun) then
          ! try to recover sgpm from old soln
@@ -469,6 +475,7 @@ contains
       if (variable_gp) call grav_pot_3d
 
       call sum_potential
+      call ppp_main%stop(grav_label)
 
    end subroutine source_terms_grav
 

--- a/src/gravity/gravity.F90
+++ b/src/gravity/gravity.F90
@@ -422,6 +422,7 @@ contains
 
    subroutine source_terms_grav
 
+      use constants,         only: PPP_GRAV
       use ppp,               only: ppp_main
 #ifdef SELF_GRAV
       use cg_leaves,         only: leaves
@@ -442,7 +443,7 @@ contains
       logical :: initialized
 #endif /* SELF_GRAV */
 
-      call ppp_main%start(grav_label)
+      call ppp_main%start(grav_label, PPP_GRAV)
 
 #ifdef SELF_GRAV
       initialized = .true.
@@ -475,7 +476,7 @@ contains
       if (variable_gp) call grav_pot_3d
 
       call sum_potential
-      call ppp_main%stop(grav_label)
+      call ppp_main%stop(grav_label, PPP_GRAV)
 
    end subroutine source_terms_grav
 

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -667,7 +667,7 @@ contains
    subroutine init_source(i_sg_dens)
 
       use cg_list_global, only: all_cg
-      use constants,      only: GEO_RPZ, LO, HI, xdim, ydim, zdim, O_I4, zero, dirtyH1
+      use constants,      only: GEO_RPZ, LO, HI, xdim, ydim, zdim, O_I4, zero, dirtyH1, PPP_GRAV, PPP_MG
       use dataio_pub,     only: die
       use domain,         only: dom
       use cg_list,        only: cg_list_element
@@ -694,7 +694,7 @@ contains
       logical                        :: apply_src_Mcorrection
       character(len=*), parameter :: mgi_label = "grav_MG_init_source"
 
-      call ppp_main%start(mgi_label)
+      call ppp_main%start(mgi_label, PPP_GRAV + PPP_MG)
 
       call all_cg%set_dirty(source, 0.979*dirtyH1)
 
@@ -776,7 +776,7 @@ contains
 
       call leaves%check_dirty(source, "init_src")
 
-      call ppp_main%stop(mgi_label)
+      call ppp_main%stop(mgi_label, PPP_GRAV + PPP_MG)
 
    end subroutine init_source
 
@@ -953,7 +953,7 @@ contains
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t
       use cg_level_finest,    only: finest
-      use constants,          only: cbuff_len, tmr_mg, dirtyH1
+      use constants,          only: cbuff_len, tmr_mg, dirtyH1, PPP_GRAV, PPP_MG
       use dataio_pub,         only: msg, die, warn, printinfo
       use global,             only: do_ascii_dump
       use mpisetup,           only: master
@@ -979,7 +979,7 @@ contains
       character(len=*), parameter :: mgv_label = "grav_MG_V-cycles", mgc_label = "V-cycle "
       character(len=cbuff_len)    :: label
 
-      call ppp_main%start(mgv_label)
+      call ppp_main%start(mgv_label, PPP_GRAV + PPP_MG)
 
 #ifdef DEBUG
       inquire(file = "_dump_every_step_", EXIST=dump_every_step) ! use for debug only
@@ -1006,7 +1006,7 @@ contains
          call leaves%set_q_value(solution, 0.)
          if (master .and. .not. norm_was_zero) call warn("[multigrid_gravity:vcycle_hg] No gravitational potential for an empty space.")
          norm_was_zero = .true.
-         call ppp_main%stop(mgv_label)
+         call ppp_main%stop(mgv_label, PPP_GRAV + PPP_MG)
          return
       endif
 
@@ -1044,7 +1044,7 @@ contains
          if (dump_result .and. norm_lhs/norm_rhs <= norm_tol) call all_cg%numbered_ascii_dump(mg_fields, dname)
 
          if (norm_lhs/norm_rhs <= norm_tol) exit
-         call ppp_main%start(mgc_label // adjustl(label))
+         call ppp_main%start(mgc_label // adjustl(label), PPP_GRAV + PPP_MG)
 
          if (v<1) then ! forgive poor convergence in some first V-cycles
             norm_lowest = norm_lhs
@@ -1086,7 +1086,7 @@ contains
          call finest%level%restrict_to_base_q_1var(solution)
 
          if (dump_every_step) call all_cg%numbered_ascii_dump(mg_fields, dname, v)
-         call ppp_main%stop(mgc_label // adjustl(label))
+         call ppp_main%stop(mgc_label // adjustl(label), PPP_GRAV + PPP_MG)
 
       enddo
 
@@ -1101,7 +1101,7 @@ contains
       vstat%norm_final = norm_lhs/norm_rhs
       if (.not. verbose_vcycle) call vstat%brief_v_log
 
-      call ppp_main%stop(mgv_label)
+      call ppp_main%stop(mgv_label, PPP_GRAV + PPP_MG)
 
       call leaves%check_dirty(solution, "final_solution")
 

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -519,8 +519,8 @@ contains
       use cg_level_connected, only: cg_level_connected_t, find_level
       use constants,          only: fft_none
       use dataio_pub,         only: die
-      use grid_cont,          only: grid_container
       use func,               only: operator(.notequals.)
+      use grid_cont,          only: grid_container
       use multigridvars,      only: overrelax
 #ifndef NO_FFT
       use constants,          only: fft_rcr, fft_dst, pi, dpi, zero, half, one
@@ -666,19 +666,19 @@ contains
 
    subroutine init_source(i_sg_dens)
 
-      use cg_list_global, only: all_cg
-      use constants,      only: GEO_RPZ, LO, HI, xdim, ydim, zdim, O_I4, zero, dirtyH1, PPP_GRAV, PPP_MG
-      use dataio_pub,     only: die
-      use domain,         only: dom
-      use cg_list,        only: cg_list_element
-      use cg_leaves,      only: leaves
-      use grid_cont,      only: grid_container
-      use func,           only: operator(.notequals.), operator(.equals.)
-      use multigridvars,  only: source, bnd_periodic, bnd_dirichlet, bnd_givenval, grav_bnd
+      use cg_leaves,         only: leaves
+      use cg_list,           only: cg_list_element
+      use cg_list_global,    only: all_cg
+      use constants,         only: GEO_RPZ, LO, HI, xdim, ydim, zdim, O_I4, zero, dirtyH1, PPP_GRAV, PPP_MG
+      use dataio_pub,        only: die
+      use domain,            only: dom
+      use func,              only: operator(.notequals.), operator(.equals.)
+      use grid_cont,         only: grid_container
+      use multigridvars,     only: source, bnd_periodic, bnd_dirichlet, bnd_givenval, grav_bnd
       use multigrid_Laplace, only: ord_laplacian_outer
-      use ppp,            only: ppp_main
-      use units,          only: fpiG
-      use particle_pub,   only: pset
+      use particle_pub,      only: pset
+      use ppp,               only: ppp_main
+      use units,             only: fpiG
 #ifdef JEANS_PROBLEM
       use problem_pub,    only: jeans_d0, jeans_mode ! hack for tests
 #endif /* JEANS_PROBLEM */
@@ -894,15 +894,15 @@ contains
 
    subroutine poisson_solver(history)
 
-      use cg_level_finest,    only: finest
-      use cg_list_global,     only: all_cg
-      use constants,          only: fft_none, dirtyH1
-      use dataio_pub,         only: printinfo
-      use mpisetup,           only: nproc
+      use cg_level_finest,          only: finest
+      use cg_list_global,           only: all_cg
+      use constants,                only: fft_none, dirtyH1
+      use dataio_pub,               only: printinfo
+      use mpisetup,                 only: nproc
       use multigrid_gravity_helper, only: fft_solve_level
-      use multigrid_old_soln, only: soln_history
-      use multigridvars,      only: grav_bnd, bnd_givenval, stdout, source, solution
-      use pcg,                only: mgpcg, use_CG, use_CG_outer
+      use multigrid_old_soln,       only: soln_history
+      use multigridvars,            only: grav_bnd, bnd_givenval, stdout, source, solution
+      use pcg,                      only: mgpcg, use_CG, use_CG_outer
 
       implicit none
 
@@ -948,20 +948,20 @@ contains
 
    subroutine vcycle_hg
 
-      use cg_leaves,          only: leaves
-      use cg_list_global,     only: all_cg
-      use cg_level_coarsest,  only: coarsest
-      use cg_level_connected, only: cg_level_connected_t
-      use cg_level_finest,    only: finest
-      use constants,          only: cbuff_len, tmr_mg, dirtyH1, PPP_GRAV, PPP_MG
-      use dataio_pub,         only: msg, die, warn, printinfo
-      use global,             only: do_ascii_dump
-      use mpisetup,           only: master
-      use multigridvars,      only: source, solution, correction, defect, verbose_vcycle, stdout, tot_ts, ts, grav_bnd, bnd_periodic
+      use cg_leaves,                only: leaves
+      use cg_level_coarsest,        only: coarsest
+      use cg_level_connected,       only: cg_level_connected_t
+      use cg_level_finest,          only: finest
+      use cg_list_global,           only: all_cg
+      use constants,                only: cbuff_len, tmr_mg, dirtyH1, PPP_GRAV, PPP_MG
+      use dataio_pub,               only: msg, die, warn, printinfo
+      use global,                   only: do_ascii_dump
+      use mpisetup,                 only: master
+      use multigridvars,            only: source, solution, correction, defect, verbose_vcycle, stdout, tot_ts, ts, grav_bnd, bnd_periodic
       use multigrid_gravity_helper, only: approximate_solution
-      use multigrid_Laplace,  only: residual
-      use ppp,                only: ppp_main
-      use timer,              only: set_timer
+      use multigrid_Laplace,        only: residual
+      use ppp,                      only: ppp_main
+      use timer,                    only: set_timer
 
       implicit none
 

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -676,6 +676,7 @@ contains
       use func,           only: operator(.notequals.), operator(.equals.)
       use multigridvars,  only: source, bnd_periodic, bnd_dirichlet, bnd_givenval, grav_bnd
       use multigrid_Laplace, only: ord_laplacian_outer
+      use ppp,            only: ppp_main
       use units,          only: fpiG
       use particle_pub,   only: pset
 #ifdef JEANS_PROBLEM
@@ -691,6 +692,9 @@ contains
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg
       logical                        :: apply_src_Mcorrection
+      character(len=*), parameter :: mgi_label = "grav_MG_init_source"
+
+      call ppp_main%start(mgi_label)
 
       call all_cg%set_dirty(source, 0.979*dirtyH1)
 
@@ -771,6 +775,8 @@ contains
       end select
 
       call leaves%check_dirty(source, "init_src")
+
+      call ppp_main%stop(mgi_label)
 
    end subroutine init_source
 
@@ -954,6 +960,7 @@ contains
       use multigridvars,      only: source, solution, correction, defect, verbose_vcycle, stdout, tot_ts, ts, grav_bnd, bnd_periodic
       use multigrid_gravity_helper, only: approximate_solution
       use multigrid_Laplace,  only: residual
+      use ppp,                only: ppp_main
       use timer,              only: set_timer
 
       implicit none
@@ -969,6 +976,10 @@ contains
       integer(kind=4), dimension(4)    :: mg_fields
       type(cg_level_connected_t), pointer :: curl
       integer, parameter :: some_warm_up_cycles = 1
+      character(len=*), parameter :: mgv_label = "grav_MG_V-cycles", mgc_label = "V-cycle "
+      character(len=cbuff_len)    :: label
+
+      call ppp_main%start(mgv_label)
 
 #ifdef DEBUG
       inquire(file = "_dump_every_step_", EXIST=dump_every_step) ! use for debug only
@@ -995,11 +1006,13 @@ contains
          call leaves%set_q_value(solution, 0.)
          if (master .and. .not. norm_was_zero) call warn("[multigrid_gravity:vcycle_hg] No gravitational potential for an empty space.")
          norm_was_zero = .true.
+         call ppp_main%stop(mgv_label)
          return
       endif
 
       ! iterations
       do v = 0, max_cycles
+         write(label, '(i8)') v
 
          call all_cg%set_dirty(defect, 0.977*dirtyH1)
          call residual(leaves, source, solution, defect)
@@ -1031,6 +1044,7 @@ contains
          if (dump_result .and. norm_lhs/norm_rhs <= norm_tol) call all_cg%numbered_ascii_dump(mg_fields, dname)
 
          if (norm_lhs/norm_rhs <= norm_tol) exit
+         call ppp_main%start(mgc_label // adjustl(label))
 
          if (v<1) then ! forgive poor convergence in some first V-cycles
             norm_lowest = norm_lhs
@@ -1072,6 +1086,7 @@ contains
          call finest%level%restrict_to_base_q_1var(solution)
 
          if (dump_every_step) call all_cg%numbered_ascii_dump(mg_fields, dname, v)
+         call ppp_main%stop(mgc_label // adjustl(label))
 
       enddo
 
@@ -1085,6 +1100,8 @@ contains
 
       vstat%norm_final = norm_lhs/norm_rhs
       if (.not. verbose_vcycle) call vstat%brief_v_log
+
+      call ppp_main%stop(mgv_label)
 
       call leaves%check_dirty(solution, "final_solution")
 

--- a/src/gravity/multigrid_gravity_helper.F90
+++ b/src/gravity/multigrid_gravity_helper.F90
@@ -58,7 +58,7 @@ contains
 
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t
-      use constants,          only: BND_NEGREF, fft_none
+      use constants,          only: BND_NEGREF, fft_none, PPP_MG
       use multigridvars,      only: nsmool
       use multigrid_Laplace,  only: approximate_solution_relax
       use ppp,                only: ppp_main
@@ -75,9 +75,9 @@ contains
       call curl%check_dirty(src, "approx_soln src-")
 
       if (associated(curl, coarsest%level) .and. curl%fft_type /= fft_none) then
-         call ppp_main%start(as_label // "FFT")
+         call ppp_main%start(as_label // "FFT", PPP_MG)
          call fft_solve_level(curl, src, soln)
-         call ppp_main%stop(as_label // "FFT")
+         call ppp_main%stop(as_label // "FFT", PPP_MG)
       else
          if (associated(curl, coarsest%level)) then
             !> \todo Implement alternative bottom-solvers
@@ -89,9 +89,9 @@ contains
             !> \warning when this is incompatible with V-cycle or other scheme, use direct call to approximate_solution_relax
          endif
 
-         call ppp_main%start(as_label // "relax")
+         call ppp_main%start(as_label // "relax", PPP_MG)
          call approximate_solution_relax(curl, src, soln, nsmoo)
-         call ppp_main%stop(as_label // "relax")
+         call ppp_main%stop(as_label // "relax", PPP_MG)
 
       endif
 

--- a/src/gravity/multigridmultipole.F90
+++ b/src/gravity/multigridmultipole.F90
@@ -216,9 +216,14 @@ contains
       use dataio_pub, only: die
       use global,     only: dirty_debug
       use monopole,   only: isolated_monopole, find_img_CoM
+      use ppp,        only: ppp_main
       use user_hooks, only: ext_bnd_potential
 
       implicit none
+
+      character(len=*), parameter :: mpole_label = "multipole_solver"
+
+      call ppp_main%start(mpole_label)
 
       if (associated(ext_bnd_potential)) then
          call ext_bnd_potential
@@ -259,6 +264,8 @@ contains
             call die("[multigridmultipole:multipole_solver] unimplemented solver")
       end select
 
+      call ppp_main%stop(mpole_label)
+
    end subroutine multipole_solver
 
 !>
@@ -283,6 +290,7 @@ contains
       use domain,        only: dom
       use grid_cont,     only: grid_container
       use multigridvars, only: solution
+      use ppp,           only: ppp_main
 
       implicit none
 
@@ -293,7 +301,9 @@ contains
       ! a1 = -2. is the simplest, 1st order choice, gives best agreement of total mass and CoM location when compared to 3-D integration
       ! a1 = -1., a2 = -1./3. seems to do the best job,
       ! a1 = -3./2., a2 = -1./6. seems to be 2nd order estimator
+      character(len=*), parameter :: p2m_label = "multipole_pot2img"
 
+      call ppp_main%start(p2m_label)
       cgl => leaves%first
       do while (associated(cgl))
          cg => cgl%cg
@@ -350,6 +360,7 @@ contains
          cgl => cgl%nxt
          end associate
       enddo
+      call ppp_main%stop(p2m_label)
 
    end subroutine potential2img_mass
 
@@ -361,13 +372,14 @@ contains
 
    subroutine img_mass2moments
 
-      use cg_leaves,    only: leaves
-      use cg_list,      only: cg_list_element
-      use constants,    only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero
-      use dataio_pub,   only: die
-      use domain,       only: dom
-      use grid_cont,    only: grid_container
-      use func,         only: operator(.notequals.)
+      use cg_leaves,  only: leaves
+      use cg_list,    only: cg_list_element
+      use constants,  only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero
+      use dataio_pub, only: die
+      use domain,     only: dom
+      use grid_cont,  only: grid_container
+      use func,       only: operator(.notequals.)
+      use ppp,        only: ppp_main
 
       implicit none
 
@@ -375,7 +387,9 @@ contains
       real, dimension(LO:HI) :: geofac
       type(cg_list_element), pointer :: cgl
       type(grid_container), pointer :: cg
+      character(len=*), parameter :: m2m_label = "multipole_img2mom"
 
+      call ppp_main%start(m2m_label)
       if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
 
       geofac(:) = 1.
@@ -421,6 +435,7 @@ contains
          endif
          cgl => cgl%nxt
       enddo
+      call ppp_main%stop(m2m_label)
 
    end subroutine img_mass2moments
 
@@ -444,6 +459,7 @@ contains
       use grid_cont,          only: grid_container
       use func,               only: operator(.notequals.)
       use multigridvars,      only: source
+      use ppp,                only: ppp_main
 
       implicit none
 
@@ -451,6 +467,9 @@ contains
       type(cg_level_connected_t), pointer :: level
       type(cg_list_element), pointer :: cgl
       type(grid_container), pointer :: cg
+      character(len=*), parameter :: d2m_label = "multipole_dom2mom"
+
+      call ppp_main%start(d2m_label)
 
       if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:domain2moments] Q%center /= 0. not implemented for non-cartesian geometry")
       if (dom%geometry_type /= GEO_XYZ) call die("[multigridmultipole:domain2moments] Noncartesian geometry haven't been tested. Verify it before use.")
@@ -487,6 +506,7 @@ contains
          enddo
          cgl => cgl%nxt
       enddo
+      call ppp_main%stop(d2m_label)
 
    end subroutine domain2moments
 
@@ -496,16 +516,22 @@ contains
 
       use constants,    only: xdim, ydim, zdim
       use particle_pub, only: pset
+      use ppp,          only: ppp_main
       use units,        only: fpiG
 
       implicit none
 
       integer :: i
+      character(len=*), parameter :: p2m_label = "multipole_part2mom"
+
+      if (size(pset%p) > 0) call ppp_main%start(p2m_label)
 
       ! Add only those particles, which are placed outside the domain. Particles inside the domain were already mapped on the grid.
       do i = lbound(pset%p, dim=1), ubound(pset%p, dim=1)
          if (pset%p(i)%outside) call Q%point2moments(fpiG*pset%p(i)%mass, pset%p(i)%pos(xdim), pset%p(i)%pos(ydim), pset%p(i)%pos(zdim))
       enddo
+
+      if (size(pset%p) > 0) call ppp_main%stop(p2m_label)
 
    end subroutine particles2moments
 
@@ -524,12 +550,16 @@ contains
       use domain,     only: dom
       use grid_cont,  only: grid_container
       use func,       only: operator(.notequals.)
+      use ppp,        only: ppp_main
 
       implicit none
 
       integer :: i, j, k
       type(cg_list_element), pointer :: cgl
       type(grid_container), pointer :: cg
+      character(len=*), parameter :: m2p_label = "multipole_mom2pot"
+
+      call ppp_main%start(m2p_label)
 
       if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
 
@@ -565,6 +595,7 @@ contains
          endif
          cgl => cgl%nxt
       enddo
+      call ppp_main%stop(m2p_label)
 
    end subroutine moments2bnd_potential
 

--- a/src/gravity/multigridmultipole.F90
+++ b/src/gravity/multigridmultipole.F90
@@ -212,7 +212,7 @@ contains
    subroutine multipole_solver
 
       use cg_leaves,   only: leaves
-      use constants,   only: dirtyH1
+      use constants,   only: dirtyH1, PPP_GRAV
       use dataio_pub,  only: die
       use global,      only: dirty_debug
       use mg_monopole, only: isolated_monopole, find_img_CoM
@@ -223,7 +223,7 @@ contains
 
       character(len=*), parameter :: mpole_label = "multipole_solver"
 
-      call ppp_main%start(mpole_label)
+      call ppp_main%start(mpole_label, PPP_GRAV)
 
       if (associated(ext_bnd_potential)) then
          call ext_bnd_potential
@@ -264,7 +264,7 @@ contains
             call die("[multigridmultipole:multipole_solver] unimplemented solver")
       end select
 
-      call ppp_main%stop(mpole_label)
+      call ppp_main%stop(mpole_label, PPP_GRAV)
 
    end subroutine multipole_solver
 
@@ -286,7 +286,7 @@ contains
 
       use cg_leaves,     only: leaves
       use cg_list,       only: cg_list_element
-      use constants,     only: GEO_RPZ, LO, HI, xdim, ydim, zdim
+      use constants,     only: GEO_RPZ, LO, HI, xdim, ydim, zdim, PPP_GRAV
       use domain,        only: dom
       use grid_cont,     only: grid_container
       use multigridvars, only: solution
@@ -303,7 +303,7 @@ contains
       ! a1 = -3./2., a2 = -1./6. seems to be 2nd order estimator
       character(len=*), parameter :: p2m_label = "multipole_pot2img"
 
-      call ppp_main%start(p2m_label)
+      call ppp_main%start(p2m_label, PPP_GRAV)
       cgl => leaves%first
       do while (associated(cgl))
          cg => cgl%cg
@@ -360,7 +360,7 @@ contains
          cgl => cgl%nxt
          end associate
       enddo
-      call ppp_main%stop(p2m_label)
+      call ppp_main%stop(p2m_label, PPP_GRAV)
 
    end subroutine potential2img_mass
 
@@ -374,7 +374,7 @@ contains
 
       use cg_leaves,  only: leaves
       use cg_list,    only: cg_list_element
-      use constants,  only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero
+      use constants,  only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero, PPP_GRAV
       use dataio_pub, only: die
       use domain,     only: dom
       use grid_cont,  only: grid_container
@@ -389,7 +389,7 @@ contains
       type(grid_container), pointer :: cg
       character(len=*), parameter :: m2m_label = "multipole_img2mom"
 
-      call ppp_main%start(m2m_label)
+      call ppp_main%start(m2m_label, PPP_GRAV)
       if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
 
       geofac(:) = 1.
@@ -435,7 +435,7 @@ contains
          endif
          cgl => cgl%nxt
       enddo
-      call ppp_main%stop(m2m_label)
+      call ppp_main%stop(m2m_label, PPP_GRAV)
 
    end subroutine img_mass2moments
 
@@ -453,7 +453,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t, base_level
       use cg_list,            only: cg_list_element
-      use constants,          only: xdim, zdim, GEO_XYZ, zero, base_level_id
+      use constants,          only: xdim, zdim, GEO_XYZ, zero, base_level_id, PPP_GRAV
       use dataio_pub,         only: die, msg, warn
       use domain,             only: dom
       use grid_cont,          only: grid_container
@@ -469,7 +469,7 @@ contains
       type(grid_container), pointer :: cg
       character(len=*), parameter :: d2m_label = "multipole_dom2mom"
 
-      call ppp_main%start(d2m_label)
+      call ppp_main%start(d2m_label, PPP_GRAV)
 
       if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:domain2moments] Q%center /= 0. not implemented for non-cartesian geometry")
       if (dom%geometry_type /= GEO_XYZ) call die("[multigridmultipole:domain2moments] Noncartesian geometry haven't been tested. Verify it before use.")
@@ -506,7 +506,7 @@ contains
          enddo
          cgl => cgl%nxt
       enddo
-      call ppp_main%stop(d2m_label)
+      call ppp_main%stop(d2m_label, PPP_GRAV)
 
    end subroutine domain2moments
 
@@ -514,7 +514,7 @@ contains
 
    subroutine particles2moments
 
-      use constants,    only: xdim, ydim, zdim
+      use constants,    only: xdim, ydim, zdim, PPP_GRAV, PPP_PART
       use particle_pub, only: pset
       use ppp,          only: ppp_main
       use units,        only: fpiG
@@ -524,14 +524,14 @@ contains
       integer :: i
       character(len=*), parameter :: p2m_label = "multipole_part2mom"
 
-      if (size(pset%p) > 0) call ppp_main%start(p2m_label)
+      if (size(pset%p) > 0) call ppp_main%start(p2m_label, PPP_GRAV + PPP_PART)
 
       ! Add only those particles, which are placed outside the domain. Particles inside the domain were already mapped on the grid.
       do i = lbound(pset%p, dim=1), ubound(pset%p, dim=1)
          if (pset%p(i)%outside) call Q%point2moments(fpiG*pset%p(i)%mass, pset%p(i)%pos(xdim), pset%p(i)%pos(ydim), pset%p(i)%pos(zdim))
       enddo
 
-      if (size(pset%p) > 0) call ppp_main%stop(p2m_label)
+      if (size(pset%p) > 0) call ppp_main%stop(p2m_label, PPP_GRAV + PPP_PART)
 
    end subroutine particles2moments
 
@@ -545,7 +545,7 @@ contains
 
       use cg_leaves,  only: leaves
       use cg_list,    only: cg_list_element
-      use constants,  only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero
+      use constants,  only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero, PPP_GRAV
       use dataio_pub, only: die
       use domain,     only: dom
       use grid_cont,  only: grid_container
@@ -559,7 +559,7 @@ contains
       type(grid_container), pointer :: cg
       character(len=*), parameter :: m2p_label = "multipole_mom2pot"
 
-      call ppp_main%start(m2p_label)
+      call ppp_main%start(m2p_label, PPP_GRAV)
 
       if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
 
@@ -595,7 +595,7 @@ contains
          endif
          cgl => cgl%nxt
       enddo
-      call ppp_main%stop(m2p_label)
+      call ppp_main%stop(m2p_label, PPP_GRAV)
 
    end subroutine moments2bnd_potential
 

--- a/src/gravity/multipole_array.F90
+++ b/src/gravity/multipole_array.F90
@@ -136,7 +136,7 @@ contains
       use constants,       only: xdim, zdim, GEO_XYZ, GEO_RPZ, HI, pMIN
       use dataio_pub,      only: die, warn, msg, printinfo
       use domain,          only: dom
-      use global,          only: check_mem_usage
+      use memory_usage,    only: check_mem_usage
       use mpisetup,        only: piernik_MPI_Allreduce, master
 
       implicit none

--- a/src/gravity/multipole_array.F90
+++ b/src/gravity/multipole_array.F90
@@ -281,7 +281,8 @@ contains
 
    subroutine reset(this)
 
-      use ppp, only: ppp_main
+      use constants, only: PPP_GRAV
+      use ppp,       only: ppp_main
 
       implicit none
 
@@ -289,9 +290,9 @@ contains
 
       character(len=*), parameter :: mpoleQr_label = "multipole_Q=0."
 
-      call ppp_main%start(mpoleQr_label)
+      call ppp_main%start(mpoleQr_label, PPP_GRAV)
       this%Q = 0.
-      call ppp_main%stop(mpoleQr_label)
+      call ppp_main%stop(mpoleQr_label, PPP_GRAV)
 
    end subroutine reset
 
@@ -299,7 +300,7 @@ contains
 
    subroutine red_int_norm(this)
 
-      use constants, only: pSUM
+      use constants, only: pSUM, PPP_GRAV, PPP_MPI
       use mpisetup,  only: piernik_MPI_Allreduce
       use ppp,       only: ppp_main
 
@@ -311,7 +312,7 @@ contains
       character(len=*), parameter :: mpoleQr_label = "multipole_Qinout", mpoleQallred_label = "multipole_Q_allreduce"
 
       ! integrate radially and apply normalization factor (the (4 \pi)/(2 l  + 1) terms cancel out)
-      call ppp_main%start(mpoleQr_label)
+      call ppp_main%start(mpoleQr_label, PPP_GRAV)
       rr = 0
       this%Q(:, INSIDE, rr-1) = this%Q(:, INSIDE, rr-1) * this%ofact(:)
       do r = rr, ubound(this%Q, dim=3)
@@ -322,11 +323,11 @@ contains
       do r = ubound(this%Q, dim=3)-1, rr-1, -1
          this%Q(:, OUTSIDE, r) = this%Q(:, OUTSIDE, r) * this%ofact(:) + this%Q(:, OUTSIDE, r+1)
       enddo
-      call ppp_main%stop(mpoleQr_label)
+      call ppp_main%stop(mpoleQr_label, PPP_GRAV)
 
-      call ppp_main%start(mpoleQallred_label)
+      call ppp_main%start(mpoleQallred_label, PPP_GRAV + PPP_MPI)
       call piernik_MPI_Allreduce(this%Q, pSUM)
-      call ppp_main%stop(mpoleQallred_label)
+      call ppp_main%stop(mpoleQallred_label, PPP_GRAV + PPP_MPI)
 
    end subroutine red_int_norm
 

--- a/src/gravity/multipole_array.F90
+++ b/src/gravity/multipole_array.F90
@@ -281,11 +281,17 @@ contains
 
    subroutine reset(this)
 
+      use ppp, only: ppp_main
+
       implicit none
 
       class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
 
+      character(len=*), parameter :: mpoleQr_label = "multipole_Q=0."
+
+      call ppp_main%start(mpoleQr_label)
       this%Q = 0.
+      call ppp_main%stop(mpoleQr_label)
 
    end subroutine reset
 
@@ -295,14 +301,17 @@ contains
 
       use constants, only: pSUM
       use mpisetup,  only: piernik_MPI_Allreduce
+      use ppp,       only: ppp_main
 
       implicit none
 
       class(mpole_container), intent(inout) :: this  !< object invoking type-bound procedure
 
       integer :: r, rr
+      character(len=*), parameter :: mpoleQr_label = "multipole_Qinout", mpoleQallred_label = "multipole_Q_allreduce"
 
       ! integrate radially and apply normalization factor (the (4 \pi)/(2 l  + 1) terms cancel out)
+      call ppp_main%start(mpoleQr_label)
       rr = 0
       this%Q(:, INSIDE, rr-1) = this%Q(:, INSIDE, rr-1) * this%ofact(:)
       do r = rr, ubound(this%Q, dim=3)
@@ -313,8 +322,11 @@ contains
       do r = ubound(this%Q, dim=3)-1, rr-1, -1
          this%Q(:, OUTSIDE, r) = this%Q(:, OUTSIDE, r) * this%ofact(:) + this%Q(:, OUTSIDE, r+1)
       enddo
+      call ppp_main%stop(mpoleQr_label)
 
+      call ppp_main%start(mpoleQallred_label)
       call piernik_MPI_Allreduce(this%Q, pSUM)
+      call ppp_main%stop(mpoleQallred_label)
 
    end subroutine red_int_norm
 

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -92,6 +92,7 @@ contains
       use domain,             only: dom
       use list_of_cg_lists,   only: all_lists
       use mpisetup,           only: master, piernik_MPI_Allreduce, nproc
+      use ppp,                only: ppp_main
       use timer,              only: set_timer
 
       implicit none
@@ -106,6 +107,9 @@ contains
       integer, save :: prev_is = 0
       character(len=len(msg)), save :: prev_msg
       real :: lf
+      character(len=*), parameter :: leaves_label = "leaves_update"
+
+      call ppp_main%start(leaves_label)
 
       call leaves%delete
       call all_lists%register(this, "leaves")
@@ -156,6 +160,8 @@ contains
       prev_msg = msg
       prev_is = is
 
+      call ppp_main%stop(leaves_label)
+
    end subroutine update
 
 !> \brief Rebalance if required and update.
@@ -164,6 +170,7 @@ contains
 
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t
+      use ppp,                only: ppp_main
 
       implicit none
 
@@ -171,7 +178,9 @@ contains
       character(len=*), optional, intent(in)    :: str   !< optional string identifier to show the progress of updating refinement
 
       type(cg_level_connected_t), pointer :: curl
+      character(len=*), parameter :: bu_label = "leaves_balance_and_update"
 
+      call ppp_main%start(bu_label)
       curl => finest%level
       do while (associated(curl)) ! perhaps it is worth to limit to the base level
          call curl%balance_old
@@ -180,6 +189,7 @@ contains
       enddo
 
       call this%update(str)
+      call ppp_main%stop(bu_label)
 
    end subroutine balance_and_update
 

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -87,7 +87,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
-      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, base_level_id, INVALID, tmr_amr
+      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, base_level_id, INVALID, tmr_amr, PPP_AMR
       use dataio_pub,         only: msg, printinfo
       use domain,             only: dom
       use list_of_cg_lists,   only: all_lists
@@ -109,7 +109,7 @@ contains
       real :: lf
       character(len=*), parameter :: leaves_label = "leaves_update"
 
-      call ppp_main%start(leaves_label)
+      call ppp_main%start(leaves_label, PPP_AMR)
 
       call leaves%delete
       call all_lists%register(this, "leaves")
@@ -160,7 +160,7 @@ contains
       prev_msg = msg
       prev_is = is
 
-      call ppp_main%stop(leaves_label)
+      call ppp_main%stop(leaves_label, PPP_AMR)
 
    end subroutine update
 
@@ -170,6 +170,7 @@ contains
 
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t
+      use constants,          only: PPP_AMR
       use ppp,                only: ppp_main
 
       implicit none
@@ -180,7 +181,7 @@ contains
       type(cg_level_connected_t), pointer :: curl
       character(len=*), parameter :: bu_label = "leaves_balance_and_update"
 
-      call ppp_main%start(bu_label)
+      call ppp_main%start(bu_label, PPP_AMR)
       curl => finest%level
       do while (associated(curl)) ! perhaps it is worth to limit to the base level
          call curl%balance_old
@@ -189,7 +190,7 @@ contains
       enddo
 
       call this%update(str)
-      call ppp_main%stop(bu_label)
+      call ppp_main%stop(bu_label, PPP_AMR)
 
    end subroutine balance_and_update
 

--- a/src/grid/cg_level.F90
+++ b/src/grid/cg_level.F90
@@ -229,9 +229,15 @@ contains
 
    subroutine update_everything(this)
 
+      use ppp, only: ppp_main
+
       implicit none
 
       class(cg_level_t), intent(inout) :: this   !< object invoking type bound procedure
+
+      character(len=*), parameter :: lue_label = "level_update_everything"
+
+      call ppp_main%start(lue_label)
 
       call this%update_decomposition_properties
       call this%dot%update_global(this%first, this%cnt, this%l%off) ! communicate everything that was added before
@@ -240,6 +246,8 @@ contains
       call this%update_req     ! Perhaps this%find_neighbors added some new entries
       call this%dot%update_tot_se
       call this%print_segments
+
+      call ppp_main%stop(lue_label)
 
    end subroutine update_everything
 

--- a/src/grid/cg_level.F90
+++ b/src/grid/cg_level.F90
@@ -229,7 +229,8 @@ contains
 
    subroutine update_everything(this)
 
-      use ppp, only: ppp_main
+      use constants, only: PPP_AMR
+      use ppp,       only: ppp_main
 
       implicit none
 
@@ -237,7 +238,7 @@ contains
 
       character(len=*), parameter :: lue_label = "level_update_everything"
 
-      call ppp_main%start(lue_label)
+      call ppp_main%start(lue_label, PPP_AMR)
 
       call this%update_decomposition_properties
       call this%dot%update_global(this%first, this%cnt, this%l%off) ! communicate everything that was added before
@@ -247,7 +248,7 @@ contains
       call this%dot%update_tot_se
       call this%print_segments
 
-      call ppp_main%stop(lue_label)
+      call ppp_main%stop(lue_label, PPP_AMR)
 
    end subroutine update_everything
 

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -109,14 +109,14 @@ contains
 
       use cg_list,        only: cg_list_element
       use cg_list_global, only: all_cg
-      use constants,      only: xdim, ydim, zdim, LO, HI
+      use constants,      only: xdim, ydim, zdim, LO, HI, PPP_AMR
       use dataio_pub,     only: die
       use domain,         only: dom
       use grid_cont,      only: grid_container
       use grid_helpers,   only: f2c, c2f
       use mpisetup,       only: FIRST, LAST
       use overlap,        only: is_overlap
-!      use ppp,            only: ppp_main
+      use ppp,            only: ppp_main
 
       implicit none
 
@@ -134,12 +134,12 @@ contains
          integer :: n_se
       end type int_pair
       type(int_pair), dimension(:), allocatable    :: ps
-!      character(len=*), parameter :: vp_label = "vertical_prep"
+      character(len=*), parameter :: vp_label = "vertical_prep"
 
       call this%dot%update_tot_se
 
       if (all_cg%ord_prolong_nb == this%ord_prolong_set) return ! no need to update vertical communication on this level
-!      call ppp_main%start(vp_label)
+      call ppp_main%start(vp_label, PPP_AMR)
 
       ! enlarge the fine blocks to allow for high orders of interpolation
       enlargement(:, LO) = -dom%D_(:) * all_cg%ord_prolong_nb
@@ -302,7 +302,7 @@ contains
       this%ord_prolong_set = all_cg%ord_prolong_nb
 
       call all_cg%update_req
-!      call ppp_main%stop(vp_label)
+      call ppp_main%stop(vp_label, PPP_AMR)
 
    end subroutine vertical_prep
 
@@ -316,7 +316,7 @@ contains
 !<
    subroutine prolong(this, bnd_type)
 
-      use constants,        only: base_level_id, GEO_RPZ
+      use constants,        only: base_level_id, GEO_RPZ, PPP_AMR
       use dataio_pub,       only: warn
       use domain,           only: dom
       use fluidindex,       only: iarr_all_my
@@ -331,15 +331,15 @@ contains
       integer(kind=4) :: i, iw
       character(len=*), parameter :: proq_label = "prolong_qna", prow_label = "prolong_wna"
 
-      call ppp_main%start(proq_label)
+      call ppp_main%start(proq_label, PPP_AMR)
       do i = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
          if (qna%lst(i)%vital .and. (qna%lst(i)%multigrid .or. this%l%id >= base_level_id)) call this%prolong_q_1var(i, bnd_type = bnd_type)
          ! Although we aren't worried too much by nonconservation of psi or multigrid fields here
          ! but it will be worth checking if cnservative high-order prolongation can help.
       enddo
-      call ppp_main%stop(proq_label)
+      call ppp_main%stop(proq_label, PPP_AMR)
 
-      call ppp_main%start(prow_label)
+      call ppp_main%start(prow_label, PPP_AMR)
       do i = lbound(wna%lst(:), dim=1, kind=4), ubound(wna%lst(:), dim=1, kind=4)
          if (wna%lst(i)%vital .and. (wna%lst(i)%multigrid .or. this%l%id >= base_level_id)) then
             qna%lst(qna%wai)%ord_prolong = 0 !> \todo implement high order conservative prolongation and use wna%lst(i)%ord_prolong here
@@ -357,7 +357,7 @@ contains
             enddo
          endif
       enddo
-      call ppp_main%stop(prow_label)
+      call ppp_main%stop(prow_label, PPP_AMR)
 
    end subroutine prolong
 
@@ -370,7 +370,7 @@ contains
 !<
    subroutine restrict(this)
 
-      use constants,        only: base_level_id, GEO_RPZ
+      use constants,        only: base_level_id, GEO_RPZ, PPP_AMR
       use dataio_pub,       only: warn
       use domain,           only: dom
       use fluidindex,       only: iarr_all_my
@@ -384,13 +384,13 @@ contains
       integer(kind=4) :: i, iw
       character(len=*), parameter :: resq_label = "restrict_qna", resw_label = "restrict_wna"
 
-      call ppp_main%start(resq_label)
+      call ppp_main%start(resq_label, PPP_AMR)
       do i = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
          if (qna%lst(i)%vital .and. (qna%lst(i)%multigrid .or. this%l%id > base_level_id)) call this%restrict_q_1var(i)
       enddo
-      call ppp_main%stop(resq_label)
+      call ppp_main%stop(resq_label, PPP_AMR)
 
-      call ppp_main%start(resw_label)
+      call ppp_main%start(resw_label, PPP_AMR)
       do i = lbound(wna%lst(:), dim=1, kind=4), ubound(wna%lst(:), dim=1, kind=4)
          if (wna%lst(i)%vital .and. (wna%lst(i)%multigrid .or. this%l%id > base_level_id)) then
             if (wna%lst(i)%multigrid) call warn("[cg_level_connected:restrict] mg set for cg%w ???")
@@ -408,7 +408,7 @@ contains
          endif
       enddo
 
-      call ppp_main%stop(resw_label)
+      call ppp_main%stop(resw_label, PPP_AMR)
 
    end subroutine restrict
 
@@ -653,14 +653,14 @@ contains
    subroutine prolong_q_1var(this, iv, pos, bnd_type)
 
       use cg_list,          only: cg_list_element
-      use constants,        only: xdim, ydim, zdim, LO, HI, I_ONE, I_ZERO, VAR_CENTER, ndims  !, dirtyH1
+      use constants,        only: xdim, ydim, zdim, LO, HI, I_ONE, I_ZERO, VAR_CENTER, ndims, PPP_AMR  !, dirtyH1
       use dataio_pub,       only: msg, warn
       use grid_cont,        only: grid_container
       use grid_helpers,     only: f2c
       use mpisetup,         only: comm, mpi_err, req, status, inflate_req, master
       use mpi,              only: MPI_DOUBLE_PRECISION
       use named_array_list, only: qna
-!      use ppp,              only: ppp_main
+      use ppp,              only: ppp_main
 
       implicit none
 
@@ -680,9 +680,9 @@ contains
       logical, save                                      :: warned = .false.
       integer                                            :: position
       integer(kind=8), dimension(ndims, LO:HI)           :: box_8            !< temporary storage
-!      character(len=*), parameter :: pq1_label = "prolong_q1v"
+      character(len=*), parameter :: pq1_label = "prolong_q1v"
 
-!      call ppp_main%start(pq1_label)
+      call ppp_main%start(pq1_label, PPP_AMR)
 
       position = qna%lst(iv)%position(I_ONE)
       if (present(pos)) position = pos
@@ -773,7 +773,7 @@ contains
          endif
          cgl => cgl%nxt
       enddo
-!      call ppp_main%stop(pq1_label)
+      call ppp_main%stop(pq1_label, PPP_AMR)
 
       call fine%check_dirty(iv, "prolong+")
 
@@ -783,9 +783,10 @@ contains
 
    subroutine arr3d_boundaries(this, ind, area_type, bnd_type, dir, nocorners)
 
+      use constants,        only: PPP_AMR
       use global,           only: ord_fc_eq_mag, ord_mag_prolong
       use named_array_list, only: qna
-!      use ppp,              only: ppp_main
+      use ppp,              only: ppp_main
 
       implicit none
 
@@ -798,9 +799,9 @@ contains
       logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       integer(kind=4) :: ord_saved
-!      character(len=*), parameter :: a3b_label = "level:arr3d_boundaries"
+      character(len=*), parameter :: a3b_label = "level:arr3d_boundaries"
 
-!      call ppp_main%start(a3b_label)
+      call ppp_main%start(a3b_label, PPP_AMR)
 
       ord_saved = qna%lst(ind)%ord_prolong
       if (ord_fc_eq_mag) qna%lst(ind)%ord_prolong = ord_mag_prolong
@@ -812,7 +813,7 @@ contains
 
       qna%lst(ind)%ord_prolong = ord_saved
 
-!      call ppp_main%stop(a3b_label)
+      call ppp_main%stop(a3b_label, PPP_AMR)
 
    end subroutine arr3d_boundaries
 
@@ -820,10 +821,10 @@ contains
 
    subroutine arr4d_boundaries(this, ind, area_type, dir, nocorners)
 
-      use constants,        only: base_level_id
+      use constants,        only: base_level_id, PPP_AMR
       use global,           only: ord_mag_prolong, ord_fc_eq_mag
       use named_array_list, only: qna, wna
-!      use ppp,              only: ppp_main
+      use ppp,              only: ppp_main
 
       implicit none
 
@@ -834,9 +835,9 @@ contains
       logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       integer(kind=4) :: iw
-!      character(len=*), parameter :: a4b_label = "level:arr4d_boundaries"
+      character(len=*), parameter :: a4b_label = "level:arr4d_boundaries"
 
-!      call ppp_main%start(a4b_label)
+      call ppp_main%start(a4b_label, PPP_AMR)
 
 !      call this%dirty_boundaries(ind)
 !      call this%clear_boundaries(ind, value=10.)
@@ -856,7 +857,7 @@ contains
       endif
       call this%level_4d_boundaries(ind, area_type=area_type, dir=dir, nocorners=nocorners)
 
-!      call ppp_main%stop(a4b_label)
+      call ppp_main%stop(a4b_label, PPP_AMR)
 
    end subroutine arr4d_boundaries
 

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -211,7 +211,7 @@ contains
       logical,         optional, intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       logical, dimension(xdim:cor_dim) :: dmask
-      character(len=*), parameter :: ib_label = "internal_boundaries_MPI"
+      character(len=*), parameter :: ibl_label = "internal_boundaries_MPI_local", ibm_label = "internal_boundaries_MPI_merged", ib1_label = "internal_boundaries_MPI_1by1"
 
       dmask(xdim:zdim) = dom%has_dir
       if (present(dir)) then
@@ -222,15 +222,19 @@ contains
       dmask(cor_dim) = .true.
       if (present(nocorners)) dmask(cor_dim) = .not. nocorners
 
+      call ppp_main%start(ibl_label, PPP_AMR)
       call internal_boundaries_local(this, ind, tgt3d, dmask)
+      call ppp_main%stop(ibl_label, PPP_AMR)
 
-      call ppp_main%start(ib_label, PPP_AMR)
       if (this%ms%valid) then
+         call ppp_main%start(ibm_label, PPP_AMR)
          call internal_boundaries_MPI_merged(this, ind, tgt3d, dmask)
+         call ppp_main%stop(ibm_label, PPP_AMR)
       else
+         call ppp_main%start(ib1_label, PPP_AMR)
          call internal_boundaries_MPI_1by1(this, ind, tgt3d, dmask)
+         call ppp_main%stop(ib1_label, PPP_AMR)
       endif
-      call ppp_main%stop(ib_label, PPP_AMR)
 
    end subroutine internal_boundaries
 

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -198,9 +198,9 @@ contains
 
    subroutine internal_boundaries(this, ind, tgt3d, dir, nocorners)
 
-      use constants, only: xdim, zdim, cor_dim
+      use constants, only: xdim, zdim, cor_dim, PPP_AMR
       use domain,    only: dom
-!      use ppp,       only: ppp_main
+      use ppp,       only: ppp_main
 
       implicit none
 
@@ -211,7 +211,7 @@ contains
       logical,         optional, intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       logical, dimension(xdim:cor_dim) :: dmask
-!      character(len=*), parameter :: ib_label = "internal_boundaries_MPI"
+      character(len=*), parameter :: ib_label = "internal_boundaries_MPI"
 
       dmask(xdim:zdim) = dom%has_dir
       if (present(dir)) then
@@ -224,13 +224,13 @@ contains
 
       call internal_boundaries_local(this, ind, tgt3d, dmask)
 
-!      call ppp_main%start(ib_label)
+      call ppp_main%start(ib_label, PPP_AMR)
       if (this%ms%valid) then
          call internal_boundaries_MPI_merged(this, ind, tgt3d, dmask)
       else
          call internal_boundaries_MPI_1by1(this, ind, tgt3d, dmask)
       endif
-!      call ppp_main%stop(ib_label)
+      call ppp_main%stop(ib_label, PPP_AMR)
 
    end subroutine internal_boundaries
 

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -200,6 +200,7 @@ contains
 
       use constants, only: xdim, zdim, cor_dim
       use domain,    only: dom
+!      use ppp,       only: ppp_main
 
       implicit none
 
@@ -210,6 +211,7 @@ contains
       logical,         optional, intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       logical, dimension(xdim:cor_dim) :: dmask
+!      character(len=*), parameter :: ib_label = "internal_boundaries_MPI"
 
       dmask(xdim:zdim) = dom%has_dir
       if (present(dir)) then
@@ -221,11 +223,14 @@ contains
       if (present(nocorners)) dmask(cor_dim) = .not. nocorners
 
       call internal_boundaries_local(this, ind, tgt3d, dmask)
+
+!      call ppp_main%start(ib_label)
       if (this%ms%valid) then
          call internal_boundaries_MPI_merged(this, ind, tgt3d, dmask)
       else
          call internal_boundaries_MPI_1by1(this, ind, tgt3d, dmask)
       endif
+!      call ppp_main%stop(ib_label)
 
    end subroutine internal_boundaries
 

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -256,7 +256,9 @@ contains
 
    subroutine qw_copy(this, q_from, w_to, w_ind)
 
-      use cg_list, only: cg_list_element
+      use cg_list,   only: cg_list_element
+      use constants, only: PPP_AMR
+      use ppp,       only: ppp_main
 
       implicit none
 
@@ -266,12 +268,15 @@ contains
       integer(kind=4),         intent(in) :: w_ind   !< First index of destination in cg%w(w_to)%arr(:,:,:,:)
 
       type(cg_list_element), pointer      :: cgl
+      character(len=*), parameter :: qwc_label = "qw_copy"
 
+      call ppp_main%start(qwc_label, PPP_AMR)
       cgl => this%first
       do while (associated(cgl))
          cgl%cg%w(w_to)%arr(w_ind, :, :, :) = cgl%cg%q(q_from)%arr(:, :, :)
          cgl => cgl%nxt
       enddo
+      call ppp_main%stop(qwc_label, PPP_AMR)
 
    end subroutine qw_copy
 
@@ -279,7 +284,9 @@ contains
 
    subroutine wq_copy(this, w_from, w_ind, q_to)
 
-      use cg_list, only: cg_list_element
+      use cg_list,   only: cg_list_element
+      use constants, only: PPP_AMR
+      use ppp,       only: ppp_main
 
       implicit none
 
@@ -289,12 +296,15 @@ contains
       integer(kind=4),         intent(in) :: q_to    !< Index of destination in cg%q(:)
 
       type(cg_list_element), pointer      :: cgl
+      character(len=*), parameter :: wqc_label = "wq_copy"
 
+      call ppp_main%start(wqc_label, PPP_AMR)
       cgl => this%first
       do while (associated(cgl))
          cgl%cg%q(q_to)%arr(:, :, :) = cgl%cg%w(w_from)%arr(w_ind, :, :, :)
          cgl => cgl%nxt
       enddo
+      call ppp_main%stop(wqc_label, PPP_AMR)
 
    end subroutine wq_copy
 

--- a/src/grid/cg_list_neighbors.F90
+++ b/src/grid/cg_list_neighbors.F90
@@ -123,6 +123,7 @@ contains
 
    subroutine find_neighbors(this)
 
+      use constants,  only: PPP_AMR
       use dataio_pub, only: warn, msg
       use global,     only: do_external_corners
       use refinement, only: prefer_n_bruteforce
@@ -136,7 +137,7 @@ contains
       logical, save :: firstcall = .true.
       character(len=*), parameter :: fn_label = "find_neighbors"
 
-      call ppp_main%start(fn_label)
+      call ppp_main%start(fn_label, PPP_AMR)
 
       if (do_external_corners) then
          write(msg, '(3a)') "[cg_list_neighbors:find_neighbors] do_external_corners implemented experimentally (", trim(merge("SFC       ", "bruteforce", this%dot%is_blocky .and. .not. prefer_n_bruteforce)), ")"
@@ -156,7 +157,7 @@ contains
          ! covers the domain in at least one direction.
       endif
 
-      call ppp_main%stop(fn_label)
+      call ppp_main%stop(fn_label, PPP_AMR)
 
 #ifdef DEBUG
       call this%print_bnd_list

--- a/src/grid/cg_list_neighbors.F90
+++ b/src/grid/cg_list_neighbors.F90
@@ -127,12 +127,16 @@ contains
       use global,     only: do_external_corners
       use refinement, only: prefer_n_bruteforce
       use mpisetup,   only: master
+      use ppp,        only: ppp_main
 
       implicit none
 
       class(cg_list_neighbors_t), intent(inout) :: this !< object invoking type bound procedure
 
       logical, save :: firstcall = .true.
+      character(len=*), parameter :: fn_label = "find_neighbors"
+
+      call ppp_main%start(fn_label)
 
       if (do_external_corners) then
          write(msg, '(3a)') "[cg_list_neighbors:find_neighbors] do_external_corners implemented experimentally (", trim(merge("SFC       ", "bruteforce", this%dot%is_blocky .and. .not. prefer_n_bruteforce)), ")"
@@ -151,6 +155,8 @@ contains
          ! calling this%ms%merge(this) here makes sense only for such setups, so in periodic boundaries 2 blocks
          ! covers the domain in at least one direction.
       endif
+
+      call ppp_main%stop(fn_label)
 
 #ifdef DEBUG
       call this%print_bnd_list

--- a/src/grid/cg_list_rebalance.F90
+++ b/src/grid/cg_list_rebalance.F90
@@ -56,7 +56,7 @@ contains
       use cg_list,         only: cg_list_element
       use cg_list_balance, only: I_N_B, I_OFF
       use cg_list_dataop,  only: expanded_domain
-      use constants,       only: LO, HI, I_ONE, pSUM, ndims
+      use constants,       only: LO, HI, I_ONE, pSUM, ndims, PPP_AMR
       use dataio_pub,      only: warn, msg, printinfo
       use mpisetup,        only: master, FIRST, LAST, nproc, piernik_MPI_Bcast, piernik_MPI_Allreduce
       use ppp,             only: ppp_main
@@ -87,7 +87,7 @@ contains
 #endif /* DEBUG */
       character(len=*), parameter :: ro_label = "rebalance_old"
 
-      call ppp_main%start(ro_label)
+      call ppp_main%start(ro_label, PPP_AMR)
 
       this%recently_changed = .false.
       allocate(gptemp(I_OFF:I_GID, this%cnt))
@@ -180,7 +180,7 @@ contains
 
       if (master) call gp%cleanup
 
-      call ppp_main%stop(ro_label)
+      call ppp_main%stop(ro_label, PPP_AMR)
 
    end subroutine rebalance_old
 
@@ -191,7 +191,7 @@ contains
       use grid_container_ext, only: cg_extptrs
       use cg_list,            only: cg_list_element
       use cg_list_global,     only: all_cg
-      use constants,          only: ndims, LO, HI, I_ONE, xdim, ydim, zdim, pMAX
+      use constants,          only: ndims, LO, HI, I_ONE, xdim, ydim, zdim, pMAX, PPP_AMR, PPP_MPI
       use dataio_pub,         only: die
       use grid_cont,          only: grid_container
       use list_of_cg_lists,   only: all_lists
@@ -262,7 +262,7 @@ contains
       call piernik_MPI_Bcast(gptemp)
 
       ! Irecv & Isend
-      call ppp_main%start(ISR_label)
+      call ppp_main%start(ISR_label, PPP_AMR)
       nr = 0
       allocate(cglepa(size(gptemp)))
       do i = lbound(gptemp, dim=2, kind=4), ubound(gptemp, dim=2, kind=4)
@@ -320,14 +320,14 @@ contains
             call MPI_Irecv(cglepa(i)%tbuf, size(cglepa(i)%tbuf), MPI_DOUBLE_PRECISION, gptemp(I_C_P, i), i, comm, req(nr), mpi_err)
          endif
       enddo
-      call ppp_main%stop(ISR_label)
+      call ppp_main%stop(ISR_label, PPP_AMR)
 
-      call ppp_main%start(Wall_label)
+      call ppp_main%start(Wall_label, PPP_AMR + PPP_MPI)
       if (nr > 0) then
          mpistatus => status(:, :nr)
          call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
       endif
-      call ppp_main%stop(Wall_label)
+      call ppp_main%stop(Wall_label, PPP_AMR + PPP_MPI)
 
       do i = lbound(gptemp, dim=2, kind=4), ubound(gptemp, dim=2, kind=4)
          cgl => cglepa(i)%p

--- a/src/grid/refinement/unified_ref_crit_list.F90
+++ b/src/grid/refinement/unified_ref_crit_list.F90
@@ -400,7 +400,7 @@ contains
 
    subroutine all_mark(this, first)
 
-      use cg_list,   only: cg_list_element
+      use cg_list, only: cg_list_element
 
       implicit none
 

--- a/src/grid/refinement/unified_ref_crit_var.F90
+++ b/src/grid/refinement/unified_ref_crit_var.F90
@@ -284,6 +284,9 @@ contains
 !! (note that some indices in the left part of denominator seem to be slightly messed up)
 !!
 !! this%aux is the noise filter (epsilon in Loechner's paper)
+!!
+!! OPT: this routine seems to take way too much CPU! Implement 3D variant without functions?
+!!
 !<
 
    subroutine refine_on_second_derivative(this, cg, p3d)
@@ -292,6 +295,7 @@ contains
       use dataio_pub, only: die
       use domain,     only: dom
       use grid_cont,  only: grid_container
+      use ppp,        only: ppp_main
 
       implicit none
 
@@ -302,7 +306,9 @@ contains
       integer(kind=4) :: i, j, k
       real :: sn, sd, r
       integer(kind=4), parameter :: how_far = 2
+      character(len=*), parameter :: L_label = "Loechner_mark"
 
+      call ppp_main%start(L_label)
       if (dom%geometry_type /= GEO_XYZ) call die("[unified_ref_crit_var:refine_on_second_derivative] noncartesian geometry not supported yet")
       if (dom%nb < how_far+I_ONE) call die("[unified_ref_crit_var:refine_on_second_derivative] at east 2 guardcells are required")
 
@@ -371,6 +377,7 @@ contains
             enddo
          enddo
       enddo
+      call ppp_main%stop(L_label)
 
    contains
 

--- a/src/grid/refinement/unified_ref_crit_var.F90
+++ b/src/grid/refinement/unified_ref_crit_var.F90
@@ -291,7 +291,7 @@ contains
 
    subroutine refine_on_second_derivative(this, cg, p3d)
 
-      use constants,  only: xdim, ydim, zdim, GEO_XYZ, INVALID, I_ONE
+      use constants,  only: xdim, ydim, zdim, GEO_XYZ, INVALID, I_ONE, PPP_AMR, PPP_CG
       use dataio_pub, only: die
       use domain,     only: dom
       use grid_cont,  only: grid_container
@@ -308,7 +308,7 @@ contains
       integer(kind=4), parameter :: how_far = 2
       character(len=*), parameter :: L_label = "Loechner_mark"
 
-      call ppp_main%start(L_label)
+      call ppp_main%start(L_label, PPP_AMR + PPP_CG)
       if (dom%geometry_type /= GEO_XYZ) call die("[unified_ref_crit_var:refine_on_second_derivative] noncartesian geometry not supported yet")
       if (dom%nb < how_far+I_ONE) call die("[unified_ref_crit_var:refine_on_second_derivative] at east 2 guardcells are required")
 
@@ -377,7 +377,7 @@ contains
             enddo
          enddo
       enddo
-      call ppp_main%stop(L_label)
+      call ppp_main%stop(L_label, PPP_AMR + PPP_CG)
 
    contains
 

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -361,11 +361,30 @@ contains
 
    end subroutine parents_prevent_derefinement_lev
 
+!> \brief PPPP-aware wrapper for update the refinement topology
+
+   subroutine update_refinement(act_count, refinement_fixup_only)
+
+      use ppp, only: ppp_main
+
+      implicit none
+
+      integer, optional, intent(out) :: act_count             !< counts number of blocks refined or deleted
+      logical, optional, intent(in)  :: refinement_fixup_only !< When present and .true. then do not check refinement criteria, do only correction, if necessary.
+
+      character(len=*), parameter :: ref_label = "refinement"
+
+      call ppp_main%start(ref_label)
+      call update_refinement_wrapped(act_count, refinement_fixup_only)
+      call ppp_main%stop(ref_label)
+
+   end subroutine update_refinement
+
 !> \brief Update the refinement topology
 
 !#define DEBUG_DUMPS
 
-   subroutine update_refinement(act_count, refinement_fixup_only)
+   subroutine update_refinement_wrapped(act_count, refinement_fixup_only)
 
       use all_boundaries,        only: all_bnd, all_bnd_vital_q
       use cg_leaves,             only: leaves
@@ -612,7 +631,7 @@ contains
 
       end subroutine print_time
 
-   end subroutine update_refinement
+   end subroutine update_refinement_wrapped
 
 !> \brief Refine a single grid piece. Pay attention whether it is already refined
 

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -47,6 +47,7 @@ contains
       use constants,             only: I_ONE, pSUM
       use dataio_pub,            only: msg, printinfo
       use mpisetup,              only: master, piernik_MPI_Allreduce
+      use ppp,                   only: ppp_main
       use unified_ref_crit_list, only: urc_list
       use user_hooks,            only: problem_refine_derefine
 
@@ -59,7 +60,9 @@ contains
          enumerator :: URC
       end enum
       integer, dimension(PROBLEM:URC) :: cnt
+      character(len=*), parameter :: scan_ref_label = "scan_for_refinement", u_ref_label = "user_scan_for_refinement", urc_label = "URC_scan_for_refinement"
 
+      call ppp_main%start(scan_ref_label)
       cnt = 0
       call prepare_ref
 
@@ -68,7 +71,11 @@ contains
       call all_bnd_vital_q
 
       ! Call user routine first, so it cannot alter flags set by automatic routines
-      if (associated(problem_refine_derefine)) call problem_refine_derefine
+      if (associated(problem_refine_derefine)) then
+         call ppp_main%start(u_ref_label)
+         call problem_refine_derefine
+         call ppp_main%stop(u_ref_label)
+      endif
 
       if (verbose) then
          cnt(PROBLEM) = count_ref_flags()
@@ -76,7 +83,9 @@ contains
       endif
 
       ! Apply all Unified Refinement Criteria (everythinng that works locally, cg-wise)
+      call ppp_main%start(urc_label)
       call urc_list%all_mark(leaves%first)
+      call ppp_main%stop(urc_label)
 
       if (verbose) then
          cnt(URC) = count_ref_flags()
@@ -102,6 +111,7 @@ contains
          call cgl%cg%refinemap2SFC_list
          cgl => cgl%nxt
       enddo
+      call ppp_main%stop(scan_ref_label)
 
    contains
 
@@ -202,14 +212,20 @@ contains
 
       use cg_level_base,      only: base
       use cg_level_connected, only: cg_level_connected_t
+      use ppp,                only: ppp_main
 
       implicit none
 
       type(cg_level_connected_t), pointer :: curl
+      character(len=*), parameter :: ppd_label = "refinement_parent_protection"
 
       curl => base%level
       do while (associated(curl))
-         if (associated(curl%finer)) call parents_prevent_derefinement_lev(curl)
+         if (associated(curl%finer)) then
+            call ppp_main%start(ppd_label)
+            call parents_prevent_derefinement_lev(curl)
+            call ppp_main%stop(ppd_label)
+         endif
          curl => curl%finer
       enddo
 
@@ -399,6 +415,7 @@ contains
       use grid_cont,             only: grid_container
       use list_of_cg_lists,      only: all_lists
       use mpisetup,              only: piernik_MPI_Allreduce
+      use ppp,                   only: ppp_main
       use refinement,            only: n_updAMR, emergency_fix
       use timer,                 only: set_timer
       use unified_ref_crit_list, only: urc_list
@@ -422,6 +439,7 @@ contains
       type(grid_container),  pointer :: cg
       logical :: correct, full_update
       real :: ts  !< time for runtime profiling
+      character(len=*), parameter :: newref_label = "refine", deref_label = "derefinement", plot_label = "URC_map"
 
       ts =  set_timer(tmr_amr, .true.)
 
@@ -500,8 +518,10 @@ contains
             curl => curl%coarser
          enddo
 
+         call ppp_main%start(newref_label)
          curl => finest%level%coarser
          do while (associated(curl) .and. curl%l%id >= base%level%l%id)
+
             some_refined = .false.
             cgl => curl%first
             do while (associated(cgl))
@@ -530,6 +550,7 @@ contains
 
             curl => curl%coarser
          enddo
+         call ppp_main%stop(newref_label)
 
          ! sync structure before trying to fix it
          call leaves%update(" (correcting) ")
@@ -549,6 +570,7 @@ contains
       ! Any excess of refinement will be handled in next call to this routine anyway.
       if (full_update) then
 
+         call ppp_main%start(deref_label)
          curl => finest%level
          do while (associated(curl) .and. .not. associated(curl, base%level))
             cgl => curl%first
@@ -574,6 +596,8 @@ contains
             call curl%sync_ru
             curl => curl%coarser
          enddo
+         call ppp_main%stop(deref_label)
+
          ! sync structure
          call leaves%balance_and_update(" ( derefine ) ")
 
@@ -584,7 +608,9 @@ contains
 
       call all_bnd
 
+      call ppp_main%start(plot_label)
       call urc_list%plot_mark(leaves%first)
+      call ppp_main%stop(plot_label)
 
       !> \todo call the update of cs_i2 and other vital variables if and only if something has changed
       !> \todo add another flag to named_array_list::na_var so the user can also specify fields that need boundary updates on fine/coarse boundaries
@@ -691,6 +717,7 @@ contains
       use constants,        only: xdim, ydim, zdim, I_ONE!, I_TWO
       use dataio_pub,       only: die
       use domain,           only: dom
+      use ppp,              only: ppp_main
       use named_array_list, only: qna
 !      use cg_level_base, only: base
 
@@ -704,7 +731,9 @@ contains
          enumerator :: OUTSIDE  =  0
          enumerator :: BOUNDARY =  1
       end enum
+      character(len=*), parameter :: fix_ref_label = "fix_refinement", frp_label = "fix_refinement_wa"
 
+      call ppp_main%start(fix_ref_label)
       correct = .true.
 
       !> \todo check for excess of refinement levels
@@ -715,6 +744,8 @@ contains
          cgl%cg%wa = cgl%cg%l%id
          cgl => cgl%nxt
       enddo
+
+      call ppp_main%start(frp_label)
       call finest%level%restrict_to_base_q_1var(qna%wai)
 
 !!$      curl => base%level
@@ -726,6 +757,7 @@ contains
 !!$         curl => curl%finer
 !!$      enddo
       call leaves%leaf_arr3d_boundaries(qna%wai)
+      call ppp_main%stop(frp_label)
 
       range = 1
       ! range = min((dom%nb+I_ONE)/I_TWO + all_cg%ord_prolong_nb, dom%nb)
@@ -817,6 +849,7 @@ contains
 
          cgl => cgl%nxt
       enddo
+      call ppp_main%stop(fix_ref_label)
 
    end function fix_refinement
 

--- a/src/multigrid/multigrid_Laplace.F90
+++ b/src/multigrid/multigrid_Laplace.F90
@@ -81,6 +81,7 @@ contains
       use multigrid_Laplace2,  only: residual2
       use multigrid_Laplace4,  only: residual4
       use multigrid_Laplace4M, only: residual_Mehrstellen
+      use ppp,                 only: ppp_main
 
       implicit none
 
@@ -89,6 +90,9 @@ contains
       integer(kind=4),      intent(in) :: soln    !< index of solution in cg%q(:)
       integer(kind=4),      intent(in) :: def     !< index of defect in cg%q(:)
 
+      character(len=*), parameter :: res_label = "grav_MG_residual"
+
+      call ppp_main%start(res_label)
       if (any(def == [ src, soln ])) call die("[multigrid_Laplace:residual] Cannot put the result into one of the input fields.") ! Use %q_copy method in such case
       select case (ordL())
          case (O_I2)
@@ -100,6 +104,7 @@ contains
          case default
             call die("[multigrid_Laplace:residual] The order of Laplacian must be equal to 2, 4 or -4")
       end select
+      call ppp_main%stop(res_label)
 
    end subroutine residual
 

--- a/src/multigrid/multigrid_Laplace.F90
+++ b/src/multigrid/multigrid_Laplace.F90
@@ -76,7 +76,7 @@ contains
    subroutine residual(cg_llst, src, soln, def)
 
       use cg_list_bnd,         only: cg_list_bnd_t
-      use constants,           only: O_I2, O_I4
+      use constants,           only: O_I2, O_I4, PPP_MG
       use dataio_pub,          only: die
       use multigrid_Laplace2,  only: residual2
       use multigrid_Laplace4,  only: residual4
@@ -92,7 +92,7 @@ contains
 
       character(len=*), parameter :: res_label = "grav_MG_residual"
 
-      call ppp_main%start(res_label)
+      call ppp_main%start(res_label, PPP_MG)
       if (any(def == [ src, soln ])) call die("[multigrid_Laplace:residual] Cannot put the result into one of the input fields.") ! Use %q_copy method in such case
       select case (ordL())
          case (O_I2)
@@ -104,7 +104,7 @@ contains
          case default
             call die("[multigrid_Laplace:residual] The order of Laplacian must be equal to 2, 4 or -4")
       end select
-      call ppp_main%stop(res_label)
+      call ppp_main%stop(res_label, PPP_MG)
 
    end subroutine residual
 

--- a/src/scheme/fluidupdate.F90
+++ b/src/scheme/fluidupdate.F90
@@ -118,6 +118,7 @@ contains
       use fargo,               only: make_fargosweep
       use global,              only: skip_sweep, use_fargo
       use hdc,                 only: glmdamping, eglm
+      use ppp,                 only: ppp_main
       use sweeps,              only: sweep
       use user_hooks,          only: problem_customize_solution
 #ifdef GRAV
@@ -139,6 +140,7 @@ contains
       logical, intent(in) :: forward  !< If .true. then do X->Y->Z sweeps, if .false. then reverse that order
 
       integer(kind=4) :: s
+      character(len=*), parameter :: sw3_label = "sweeps"
 
 #ifdef SHEAR
       call shear_3sweeps
@@ -160,6 +162,7 @@ contains
 
       ! The following block of code may be treated as a 3D (M)HD solver.
       ! Don't put anything inside unless you're sure it should belong to the (M)HD solver.
+      call ppp_main%start(sw3_label)
       if (use_fargo) then
          if (.not.skip_sweep(zdim)) call make_sweep(zdim, forward)
          if (.not.skip_sweep(xdim)) call make_sweep(xdim, forward)
@@ -175,6 +178,7 @@ contains
             enddo
          endif
       endif
+      call ppp_main%stop(sw3_label)
 
 #ifdef GRAV
       if (associated(psolver)) call pset%evolve(psolver, t-dt, dt)

--- a/src/scheme/fluidupdate.F90
+++ b/src/scheme/fluidupdate.F90
@@ -63,9 +63,13 @@ contains
       use dataio_pub,       only: die
       use global,           only: which_solver
       use fluidupdate_hllc, only: fluid_update_simple
+      use ppp,              only: ppp_main
 
       implicit none
 
+      character(len=*), parameter :: fu_label = "fluid_update"
+
+      call ppp_main%start(fu_label)
       select case (which_solver)
          case (HLLC_SPLIT)
             call fluid_update_simple
@@ -74,6 +78,7 @@ contains
          case default
             call die("[fluidupdate:fluid_update] unknown solver")
       end select
+      call ppp_main%stop(fu_label)
 
    end subroutine fluid_update
 

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -108,13 +108,13 @@ contains
 
    subroutine recv_cg_finebnd(cdim, cg, all_received)
 
-      use constants,  only: LO, HI, INVALID, ORTHO1, ORTHO2, pdims
+      use constants,  only: LO, HI, INVALID, ORTHO1, ORTHO2, pdims, PPP_MPI
       use dataio_pub, only: die
       use fluidindex, only: flind
       use grid_cont,  only: grid_container
       use mpi,        only: MPI_STATUS_IGNORE
       use mpisetup,   only: mpi_err
-      !use ppp,        only: ppp_main
+      use ppp,        only: ppp_main
 
       implicit none
 
@@ -125,9 +125,9 @@ contains
       integer :: g, lh
       logical :: received
       integer(kind=8), dimension(LO:HI) :: j1, j2, jc
-      !character(len=*), parameter :: recv_label = "cg_recv_fine_bnd"
+      character(len=*), parameter :: recv_label = "cg_recv_fine_bnd"
 
-      !call ppp_main%start(recv_label)
+      call ppp_main%start(recv_label, PPP_MPI)
       all_received = .true.
       if (allocated(cg%rif_tgt%seg)) then
          associate ( seg => cg%rif_tgt%seg )
@@ -161,7 +161,7 @@ contains
          end associate
       endif
 
-      !call ppp_main%stop(recv_label)
+      call ppp_main%stop(recv_label, PPP_MPI)
 
    end subroutine recv_cg_finebnd
 
@@ -171,14 +171,14 @@ contains
 
    subroutine send_cg_coarsebnd(cdim, cg, nr)
 
-      use constants,    only: pdims, LO, HI, ORTHO1, ORTHO2, I_ONE, INVALID
+      use constants,    only: pdims, LO, HI, ORTHO1, ORTHO2, I_ONE, INVALID, PPP_MPI
       use dataio_pub,   only: die
       use domain,       only: dom
       use grid_cont,    only: grid_container
       use grid_helpers, only: f2c_o
       use mpi,          only: MPI_DOUBLE_PRECISION
       use mpisetup,     only: comm, mpi_err, req, inflate_req
-      !use ppp,          only: ppp_main
+      use ppp,          only: ppp_main
 
       implicit none
 
@@ -189,9 +189,9 @@ contains
       integer :: g, lh
       integer(kind=8), dimension(LO:HI) :: j1, j2, jc
       integer(kind=8) :: j, k
-      !character(len=*), parameter :: send_label = "cg_send_coarse_bnd"
+      character(len=*), parameter :: send_label = "cg_send_coarse_bnd"
 
-      !call ppp_main%start(send_label)
+      call ppp_main%start(send_label, PPP_MPI)
 
       if (allocated(cg%rof_tgt%seg)) then
          associate ( seg => cg%rof_tgt%seg )
@@ -230,7 +230,7 @@ contains
          end associate
       endif
 
-      !call ppp_main%stop(send_label)
+      call ppp_main%stop(send_label, PPP_MPI)
 
    end subroutine send_cg_coarsebnd
 
@@ -293,7 +293,7 @@ contains
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
       use constants,        only: ydim, ndims, first_stage, last_stage, uh_n, magh_n, psih_n, psi_n, INVALID, &
-           &                      RTVD_SPLIT, RIEMANN_SPLIT
+           &                      RTVD_SPLIT, RIEMANN_SPLIT, PPP_CG
       use dataio_pub,       only: die
       use global,           only: integration_order, use_fargo, which_solver
       use grid_cont,        only: grid_container
@@ -336,7 +336,7 @@ contains
       integer(kind=4), dimension(:,:), pointer :: mpistatus
       procedure(solve_cg_sub), pointer :: solve_cg => null()
       character(len=*), dimension(ndims), parameter :: sweep_label = [ "sweep_x", "sweep_y", "sweep_z" ]
-      character(len=*), parameter :: solve_cgs_label = "solve_bunch_of_cg" !, cg_label = "solve_cg"
+      character(len=*), parameter :: solve_cgs_label = "solve_bunch_of_cg", cg_label = "solve_cg"
 
       call ppp_main%start(sweep_label(cdim))
 
@@ -398,9 +398,9 @@ contains
                   call recv_cg_finebnd(cdim, cg, all_received)
 
                   if (all_received) then
-                     !call ppp_main%start(cg_label)
+                     call ppp_main%start(cg_label, PPP_CG)
                      call solve_cg(cg, cdim, istep, fargo_vel)
-                     !call ppp_main%stop(cg_label)
+                     call ppp_main%stop(cg_label, PPP_CG)
 
                      call send_cg_coarsebnd(cdim, cg, nr)
                      blocks_done = blocks_done + 1

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -114,6 +114,7 @@ contains
       use grid_cont,  only: grid_container
       use mpi,        only: MPI_STATUS_IGNORE
       use mpisetup,   only: mpi_err
+      !use ppp,        only: ppp_main
 
       implicit none
 
@@ -124,7 +125,9 @@ contains
       integer :: g, lh
       logical :: received
       integer(kind=8), dimension(LO:HI) :: j1, j2, jc
+      !character(len=*), parameter :: recv_label = "cg_recv_fine_bnd"
 
+      !call ppp_main%start(recv_label)
       all_received = .true.
       if (allocated(cg%rif_tgt%seg)) then
          associate ( seg => cg%rif_tgt%seg )
@@ -157,7 +160,9 @@ contains
          enddo
          end associate
       endif
-      return
+
+      !call ppp_main%stop(recv_label)
+
    end subroutine recv_cg_finebnd
 
 !>
@@ -173,6 +178,7 @@ contains
       use grid_helpers, only: f2c_o
       use mpi,          only: MPI_DOUBLE_PRECISION
       use mpisetup,     only: comm, mpi_err, req, inflate_req
+      !use ppp,          only: ppp_main
 
       implicit none
 
@@ -183,7 +189,9 @@ contains
       integer :: g, lh
       integer(kind=8), dimension(LO:HI) :: j1, j2, jc
       integer(kind=8) :: j, k
+      !character(len=*), parameter :: send_label = "cg_send_coarse_bnd"
 
+      !call ppp_main%start(send_label)
 
       if (allocated(cg%rof_tgt%seg)) then
          associate ( seg => cg%rof_tgt%seg )
@@ -221,6 +229,9 @@ contains
          enddo
          end associate
       endif
+
+      !call ppp_main%stop(send_label)
+
    end subroutine send_cg_coarsebnd
 
 !>
@@ -281,13 +292,14 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: ydim, first_stage, last_stage, uh_n, magh_n, psih_n, psi_n, INVALID, &
+      use constants,        only: ydim, ndims, first_stage, last_stage, uh_n, magh_n, psih_n, psi_n, INVALID, &
            &                      RTVD_SPLIT, RIEMANN_SPLIT
       use dataio_pub,       only: die
       use global,           only: integration_order, use_fargo, which_solver
       use grid_cont,        only: grid_container
       use mpisetup,         only: mpi_err, req, status
       use named_array_list, only: qna, wna
+      use ppp,              only: ppp_main
       use solvecg_rtvd,     only: solve_cg_rtvd
       use solvecg_riemann,  only: solve_cg_riemann
       use sources,          only: prepare_sources
@@ -323,6 +335,10 @@ contains
       integer                        :: uhi, bhi, psii, psihi
       integer(kind=4), dimension(:,:), pointer :: mpistatus
       procedure(solve_cg_sub), pointer :: solve_cg => null()
+      character(len=*), dimension(ndims), parameter :: sweep_label = [ "sweep_x", "sweep_y", "sweep_z" ]
+      character(len=*), parameter :: solve_cgs_label = "solve_bunch_of_cg" !, cg_label = "solve_cg"
+
+      call ppp_main%start(sweep_label(cdim))
 
       select case (which_solver)
          case (RTVD_SPLIT)
@@ -373,6 +389,8 @@ contains
             blocks_done = 0
             ! OPT this loop should probably go from finest to coarsest for better compute-communicate overlap.
             cgl => leaves%first
+
+            call ppp_main%start(solve_cgs_label)
             do while (associated(cgl))
                cg => cgl%cg
 
@@ -380,7 +398,10 @@ contains
                   call recv_cg_finebnd(cdim, cg, all_received)
 
                   if (all_received) then
+                     !call ppp_main%start(cg_label)
                      call solve_cg(cg, cdim, istep, fargo_vel)
+                     !call ppp_main%stop(cg_label)
+
                      call send_cg_coarsebnd(cdim, cg, nr)
                      blocks_done = blocks_done + 1
                   else
@@ -389,6 +410,7 @@ contains
                endif
                cgl => cgl%nxt
             enddo
+            call ppp_main%stop(solve_cgs_label)
 
             if (.not. all_processed .and. blocks_done == 0) then
                if (nr_recv > 0) then
@@ -406,6 +428,7 @@ contains
 
          call update_boundaries(cdim, istep)
       enddo
+      call ppp_main%stop(sweep_label(cdim))
 
    end subroutine sweep
 

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -90,7 +90,7 @@ contains
       use mass_defect,      only: downgrade_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
-      use ppp,               only: ppp_main
+      use ppp,              only: ppp_main
       use user_hooks,       only: user_reaction_to_redo_step
 #ifdef RANDOMIZE
       use randomization,    only: randoms_redostep

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -90,6 +90,7 @@ contains
       use mass_defect,      only: downgrade_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
+      use ppp,               only: ppp_main
       use user_hooks,       only: user_reaction_to_redo_step
 #ifdef RANDOMIZE
       use randomization,    only: randoms_redostep
@@ -102,6 +103,7 @@ contains
       integer                        :: i, j
       character(len=dsetnamelen)     :: rname
       integer, parameter             :: max_attempts = 10  !< Something is terribly wrong if a single step requires too many reductions
+      character(len=*), parameter :: rs_label = "repeat_step_"
 
       if (.not.repeat_step) return
 
@@ -130,6 +132,11 @@ contains
       call randoms_redostep(cfl_violated)
 #endif /* RANDOMIZE */
 
+      if (cfl_violated) then
+         call ppp_main%start(rs_label // "reverting")
+      else
+         call ppp_main%start(rs_label // "saving")
+      endif
       no_hist_count = 0
       cgl => leaves%first
       do while (associated(cgl))
@@ -171,6 +178,12 @@ contains
          enddo
          cgl => cgl%nxt
       enddo
+      if (cfl_violated) then
+         call ppp_main%stop(rs_label // "reverting")
+      else
+         call ppp_main%stop(rs_label // "saving")
+      endif
+
       call piernik_MPI_Allreduce(no_hist_count, pSUM)
       if (master .and. no_hist_count/=0) then
          write(msg, '(a,i6,a)')"[timestep_retry:repeat_fluidstep] Error: not reverted: ", no_hist_count, " grid pieces."


### PR DESCRIPTION
Implementing an MPI_Wtime-based event log that will be useful for parallel profiling of the Piernik code.

General purpose profilers don't know what is important in Piernika and tend to provide a lot of detailed information about irrelevant routines. This sometimes adds too much overhear from instrumenting the code which can be misleading. Here, the developer can choose which parts of the code need closer look. 

Collecting the events should be as cheap as possible, thus we don't construct any trees inside Piernik. All the collected data is meant to be used in postprocessing. The developer can set up several logs, each focused on different aspect of the code and not interfering with other logs.