### PR TITLE
Non-existent plot vars treatment

### DIFF
--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -31,7 +31,6 @@
 !! \brief Module that contains HDF5 I/O routines for writing single-precision data dumps
 !<
 module data_hdf5
-
 ! pulled by HDF5
 
    implicit none
@@ -51,7 +50,7 @@ contains
 
    subroutine init_data
 
-      use dataio_pub,  only: multiple_h5files
+      use dataio_pub, only: multiple_h5files
 
       implicit none
 
@@ -121,8 +120,8 @@ contains
 
    elemental function gdf_translate(var) result(newname)
 
-      use constants,    only: dsetnamelen
-      use dataio_pub,   only: gdf_strict
+      use constants,  only: dsetnamelen
+      use dataio_pub, only: gdf_strict
 
       implicit none
 
@@ -190,6 +189,7 @@ contains
       use units,        only: lmtvB, s_lmtvB, get_unit
 
       implicit none
+
       integer(HID_T), intent(in)             :: gid
       integer(HID_T)                         :: dset_id
       integer(kind=4)                        :: error, i, ip
@@ -199,13 +199,9 @@ contains
       real                                   :: val_unit
 
       character(len=cbuff_len), dimension(I_FIVE), parameter :: base_dsets = &
-         &  ["length_unit  ", "mass_unit    ", "time_unit    ",  &
-         &   "velocity_unit", "magnetic_unit"]
+         &  ["length_unit  ", "mass_unit    ", "time_unit    ",  "velocity_unit", "magnetic_unit"]
 
-      ip = lbound(base_dsets, 1) - 1
       do i = lbound(base_dsets, 1), ubound(base_dsets, 1)
-         if (.not.hdf_vars_avail(i)) cycle
-         ip = ip + 1
          call create_dataset(gid, base_dsets(i), lmtvB(i))
          call h5dopen_f(gid, base_dsets(i), dset_id, error)
          ssbuf => s_lmtvB(i)
@@ -276,9 +272,9 @@ contains
       use grid_cont,   only: grid_container
       use mpisetup,    only: proc
 #ifdef MAGNETIC
+      use constants,   only: xdim, ydim, zdim, half, two, I_TWO, I_FOUR, I_SIX, I_EIGHT
       use div_B,       only: divB_c_IO
       use domain,      only: dom
-      use constants,   only: xdim, ydim, zdim, half, two, I_TWO, I_FOUR, I_SIX, I_EIGHT
       use global,      only: force_cc_mag
 #endif /* MAGNETIC */
 
@@ -480,8 +476,8 @@ contains
 
       implicit none
 
-      character(len=cwdlen) :: fname
-      real                  :: phv
+      character(len=cwdlen)       :: fname
+      real                        :: phv
       character(len=*), parameter :: wrd_label = "IO_write_datafile_v1"
 
       call ppp_main%start(wrd_label, PPP_IO)
@@ -754,8 +750,8 @@ contains
       use dataio_pub,       only: warn, msg, printinfo
       use dataio_user,      only: user_vars_hdf5
       use grid_cont,        only: grid_container
-      use named_array_list, only: qna
       use mpisetup,         only: master
+      use named_array_list, only: qna
 
       implicit none
 
@@ -955,8 +951,7 @@ contains
       use dataio_pub,  only: msg, printio, printinfo, thdf, last_hdf_time, piernik_hdf5_version
       use grid_cont,   only: grid_container
       use h5lt,        only: h5ltmake_dataset_double_f
-      use hdf5,        only: H5F_ACC_TRUNC_F, h5fcreate_f, h5open_f, h5fclose_f, h5close_f, HID_T, h5gcreate_f, &
-           &                 h5gclose_f, HSIZE_T
+      use hdf5,        only: H5F_ACC_TRUNC_F, h5fcreate_f, h5open_f, h5fclose_f, h5close_f, HID_T, h5gcreate_f, h5gclose_f, HSIZE_T
       use mpisetup,    only: master
       use timer,       only: set_timer
 
@@ -991,8 +986,7 @@ contains
          call h5gcreate_f(file_id, gname, grp_id, error)
 
          ! set attributes here
-         call h5ltmake_dataset_double_f(grp_id, "fbnd", int(2,kind=4), shape(cg%fbnd,kind=HSIZE_T), &
-                                      & cg%fbnd, error)
+         call h5ltmake_dataset_double_f(grp_id, "fbnd", int(2,kind=4), shape(cg%fbnd,kind=HSIZE_T), cg%fbnd, error)
 
          if (.not.associated(data)) allocate(data(cg%n_b(xdim),cg%n_b(ydim),cg%n_b(zdim)))
          dims = cg%n_b(:)

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -544,7 +544,8 @@ contains
       use cg_list,     only: cg_list_element
       use common_hdf5, only: get_nth_cg, hdf_vars, cg_output, hdf_vars, hdf_vars_avail, enable_all_hdf_var
       use constants,   only: xdim, ydim, zdim, ndims, FP_REAL, PPP_IO, PPP_CG
-      use dataio_pub,  only: die, nproc_io, can_i_write, h5_64bit
+      use dataio_pub,  only: die, nproc_io, can_i_write, h5_64bit, nstep_start
+      use global,      only: nstep
       use grid_cont,   only: grid_container
       use hdf5,        only: HID_T, HSIZE_T, H5T_NATIVE_REAL, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
       use mpi,         only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
@@ -571,7 +572,7 @@ contains
 
       call ppp_main%start(wrdc_label, PPP_IO)
 
-      call enable_all_hdf_var  ! just in case things have changed meanwhile
+      if (nstep - nstep_start < 1) call enable_all_hdf_var  ! just in case things have changed meanwhile
 
       call cg_desc%init(cgl_g_id, cg_n, nproc_io, gdf_translate(hdf_vars))
 

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -894,6 +894,7 @@ contains
 
             if (.not.associated(data)) allocate(data(cg%nxb, cg%nyb, cg%nzb))
             call get_data_from_cg(hdf_vars(i), cg, data)
+            if (.not.hdf_vars_avail(i)) cycle
 
             chunk_dims = cg%n_b(:) ! Chunks dimensions
             call h5screate_simple_f(rank, chunk_dims, memspace, error)
@@ -949,7 +950,7 @@ contains
 
       use cg_leaves,   only: leaves
       use cg_list,     only: cg_list_element
-      use common_hdf5, only: hdf_vars
+      use common_hdf5, only: hdf_vars, hdf_vars_avail
       use constants,   only: dsetnamelen, fnamelen, xdim, ydim, zdim, I_ONE, tmr_hdf
       use dataio_pub,  only: msg, printio, printinfo, thdf, last_hdf_time, piernik_hdf5_version
       use grid_cont,   only: grid_container
@@ -997,6 +998,7 @@ contains
          dims = cg%n_b(:)
          do i = I_ONE, size(hdf_vars, kind=4)
             call get_data_from_cg(hdf_vars(i), cg, data)
+            if (.not.hdf_vars_avail(i)) cycle
             call h5ltmake_dataset_double_f(grp_id, hdf_vars(i), rank, dims, data(:,:,:), error)
          enddo
          if (associated(data)) deallocate(data)

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -794,7 +794,7 @@ contains
 
    subroutine create_empty_cg_datasets_in_output(cg_g_id, cg_n_b, cg_n_o, Z_avail)
 
-      use common_hdf5, only: create_empty_cg_dataset, hdf_vars, O_OUT
+      use common_hdf5, only: create_empty_cg_dataset, hdf_vars, hdf_vars_avail, O_OUT
       use hdf5,        only: HID_T, HSIZE_T
 
       implicit none
@@ -807,6 +807,7 @@ contains
       integer :: i
 
       do i = lbound(hdf_vars,1), ubound(hdf_vars,1)
+         if (.not.hdf_vars_avail(i)) cycle
          call create_empty_cg_dataset(cg_g_id, gdf_translate(hdf_vars(i)), int(cg_n_b, kind=HSIZE_T), Z_avail, O_OUT)
       enddo
 


### PR DESCRIPTION
* save cancellation of plot vars during the simulation run
* do not process already-cancelled plot var
* do not create h5 description for cancelled plot vars