### PR TITLE
BUGFIX for restarts

### DIFF
--- a/src/gravity/multigrid_old_soln.F90
+++ b/src/gravity/multigrid_old_soln.F90
@@ -357,7 +357,7 @@ contains
       character(len=cbuff_len), allocatable, dimension(:) :: namelist
       real, allocatable, dimension(:) :: timelist
 
-      n = min(this%old%cnt(), ord_time_extrap + I_ONE, I_TWO)  ! try to save at least 2 points to recover also sgpm
+      n = max(min(this%old%cnt(), ord_time_extrap + I_ONE), I_TWO)  ! try to save at least 2 points to recover also sgpm
 
       if (n <= 0) return
 


### PR DESCRIPTION
It restores repeatability with selfgravity and `ord_time_extrap` = 2