### PR TITLE
Cylindrical refinement

### DIFF
--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -183,7 +183,7 @@ contains
    subroutine create_units_description(gid)
 
       use common_hdf5,  only: hdf_vars, hdf_vars_avail
-      use constants,    only: units_len, cbuff_len, I_FIVE
+      use constants,    only: units_len, cbuff_len, I_FIVE, I_ONE
       use hdf5,         only: HID_T, h5dopen_f, h5dclose_f
       use helpers_hdf5, only: create_dataset, create_attribute
       use units,        only: lmtvB, s_lmtvB, get_unit
@@ -211,7 +211,7 @@ contains
       ip = lbound(base_dsets, 1) - 1
       do i = lbound(hdf_vars, 1, kind=4), ubound(hdf_vars, 1, kind=4)
          if (.not.hdf_vars_avail(i)) cycle
-         ip = ip + 1
+         ip = ip + I_ONE
          call get_unit(gdf_translate(hdf_vars(i)), val_unit, s_unit)
          call create_dataset(gid, gdf_translate(hdf_vars(i)), val_unit)
          call h5dopen_f(gid, gdf_translate(hdf_vars(i)), dset_id, error)

--- a/src/grid/refinement.F90
+++ b/src/grid/refinement.F90
@@ -36,7 +36,7 @@ module refinement
 
    private
    public :: n_updAMR, oop_thr, ref_point, refine_points, ref_auto_param, refine_vars, level_min, level_max, inactive_name, bsize, &
-        &    ref_box, refine_boxes, init_refinement, emergency_fix, set_n_updAMR, strict_SFC_ordering, prefer_n_bruteforce, jeans_ref, jeans_plot
+        &    ref_box, refine_boxes, refine_zcyls, init_refinement, emergency_fix, set_n_updAMR, strict_SFC_ordering, prefer_n_bruteforce, jeans_ref, jeans_plot
 
    integer(kind=4), protected :: n_updAMR            !< How often to update the refinement structure
    logical,         protected :: strict_SFC_ordering !< Enforce strict SFC ordering to allow for optimized neighbour search
@@ -62,6 +62,7 @@ module refinement
       real, dimension(ndims, LO:HI) :: coords !< coordinates, where to refine
    end type ref_box
    type(ref_box), dimension(nshapes), protected :: refine_boxes !< Areas (boxes) of refinement to be used from problem.par: level, (x-y-z)-coordinates of lower left corner and (x-y-z)-coordinates of upper right corner
+   type(ref_box), dimension(nshapes), protected :: refine_zcyls !< z-axis cylinders that fit the specified boxes
 
    !> \brief Parameters of automagic refinement
    type :: ref_auto_param
@@ -83,7 +84,7 @@ module refinement
    logical :: emergency_fix                                                    !< set to .true. if you want to call update_refinement ASAP
 
    namelist /AMR/ level_min, level_max, bsize, n_updAMR, strict_SFC_ordering, &
-        &         prefer_n_bruteforce, oop_thr, refine_points, refine_boxes, refine_vars, &
+        &         prefer_n_bruteforce, oop_thr, refine_points, refine_boxes, refine_zcyls, refine_vars, &
         &         jeans_ref, jeans_plot
 
 contains
@@ -101,6 +102,7 @@ contains
 !!   <tr><td> oop_thr             </td><td> 0.1     </td><td> real             </td><td> \copydoc refinement::oop_thr             </td></tr>
 !!   <tr><td> refine_points(10)   </td><td> none    </td><td> integer, 3*real  </td><td> \copydoc refinement::refine_points       </td></tr>
 !!   <tr><td> refine_boxes(10)    </td><td> none    </td><td> integer, 6*real  </td><td> \copydoc refinement::refine_boxes        </td></tr>
+!!   <tr><td> refine_zcyls(10)    </td><td> none    </td><td> integer, 6*real  </td><td> \copydoc refinement::refine_zcyls        </td></tr>
 !!   <tr><td> refine_vars(10)     </td><td> none    </td><td> 2*string, 3*real </td><td> \copydoc refinement::refine_vars         </td></tr>
 !!   <tr><td> prefer_n_bruteforce </td><td> .false. </td><td> logical          </td><td> \copydoc refinement::prefer_n_bruteforce </td></tr>
 !!   <tr><td> strict_SFC_ordering </td><td> .false. </td><td> logical          </td><td> \copydoc refinement::strict_SFC_ordering </td></tr>
@@ -131,6 +133,7 @@ contains
       oop_thr = 0.1
       refine_points(:) = ref_point(base_level_id-1, [ 0., 0., 0.] )
       refine_boxes (:) = ref_box  (base_level_id-1, reshape([ 0., 0., 0., 0., 0., 0.], [ndims, HI-LO+I_ONE] ) )
+      refine_zcyls(:)  = refine_boxes (:)
       refine_vars  (:) = ref_auto_param (inactive_name, inactive_name, 0., 0., .false.)
       jeans_ref = 0.       !< inactive by default, 4. is the absolute minimum for reasonable use
       jeans_plot = .false.
@@ -169,8 +172,9 @@ contains
          ibuff(2) = level_max
          ibuff(3) = n_updAMR
          ibuff(4:3+ndims) = bsize
-         ibuff(11        :10+  nshapes) = refine_points(:)%level
-         ibuff(11+nshapes:10+2*nshapes) = refine_boxes (:)%level
+         ibuff(11          :10+  nshapes) = refine_points(:)%level
+         ibuff(11+  nshapes:10+2*nshapes) = refine_boxes (:)%level
+         ibuff(11+2*nshapes:10+3*nshapes) = refine_zcyls (:)%level
 
          lbuff(1) = jeans_plot
          lbuff(2) = strict_SFC_ordering
@@ -182,14 +186,26 @@ contains
          rbuff(3          :2+  nshapes) = refine_points(:)%coords(xdim)
          rbuff(3+  nshapes:2+2*nshapes) = refine_points(:)%coords(ydim)
          rbuff(3+2*nshapes:2+3*nshapes) = refine_points(:)%coords(zdim)
+
          rbuff(3+3*nshapes:2+4*nshapes) = refine_boxes (:)%coords(xdim, LO)
          rbuff(3+4*nshapes:2+5*nshapes) = refine_boxes (:)%coords(xdim, HI)
          rbuff(3+5*nshapes:2+6*nshapes) = refine_boxes (:)%coords(ydim, LO)
          rbuff(3+6*nshapes:2+7*nshapes) = refine_boxes (:)%coords(ydim, HI)
          rbuff(3+7*nshapes:2+8*nshapes) = refine_boxes (:)%coords(zdim, LO)
          rbuff(3+8*nshapes:2+9*nshapes) = refine_boxes (:)%coords(zdim, HI)
-         rbuff(3+9*nshapes                   :2+9*nshapes+  n_ref_auto_param) = refine_vars(:)%ref_thr
-         rbuff(3+9*nshapes+  n_ref_auto_param:2+9*nshapes+2*n_ref_auto_param) = refine_vars(:)%aux
+
+         rbuff(3+ 9*nshapes:2+10*nshapes) = refine_zcyls (:)%coords(xdim, LO)
+         rbuff(3+10*nshapes:2+11*nshapes) = refine_zcyls (:)%coords(xdim, HI)
+         rbuff(3+11*nshapes:2+12*nshapes) = refine_zcyls (:)%coords(ydim, LO)
+         rbuff(3+12*nshapes:2+13*nshapes) = refine_zcyls (:)%coords(ydim, HI)
+         rbuff(3+13*nshapes:2+14*nshapes) = refine_zcyls (:)%coords(zdim, LO)
+         rbuff(3+14*nshapes:2+15*nshapes) = refine_zcyls (:)%coords(zdim, HI)
+
+         rbuff(3+15*nshapes                   :2+15*nshapes+  n_ref_auto_param) = refine_vars(:)%ref_thr
+         rbuff(3+15*nshapes+  n_ref_auto_param:2+15*nshapes+2*n_ref_auto_param) = refine_vars(:)%aux
+
+         if (2+15*nshapes+2*n_ref_auto_param > ubound(rbuff, dim=1)) &
+              call die("[refinement:init_refinement] run out of buffer_dim")
 
       endif
 
@@ -207,8 +223,9 @@ contains
          level_max = ibuff(2)
          n_updAMR  = ibuff(3)
          bsize     = ibuff(4:3+ndims)
-         refine_points(:)%level = ibuff(11        :10+  nshapes)
-         refine_boxes (:)%level = ibuff(11+nshapes:10+2*nshapes)
+         refine_points(:)%level = ibuff(11          :10+  nshapes)
+         refine_boxes (:)%level = ibuff(11+  nshapes:10+2*nshapes)
+         refine_zcyls (:)%level = ibuff(11+2*nshapes:10+3*nshapes)
 
          jeans_plot               = lbuff(1)
          strict_SFC_ordering      = lbuff(2)
@@ -220,14 +237,23 @@ contains
          refine_points(:)%coords(xdim)     = rbuff(3          :2+  nshapes)
          refine_points(:)%coords(ydim)     = rbuff(3+  nshapes:2+2*nshapes)
          refine_points(:)%coords(zdim)     = rbuff(3+2*nshapes:2+3*nshapes)
+
          refine_boxes (:)%coords(xdim, LO) = rbuff(3+3*nshapes:2+4*nshapes)
          refine_boxes (:)%coords(xdim, HI) = rbuff(3+4*nshapes:2+5*nshapes)
          refine_boxes (:)%coords(ydim, LO) = rbuff(3+5*nshapes:2+6*nshapes)
          refine_boxes (:)%coords(ydim, HI) = rbuff(3+6*nshapes:2+7*nshapes)
          refine_boxes (:)%coords(zdim, LO) = rbuff(3+7*nshapes:2+8*nshapes)
          refine_boxes (:)%coords(zdim, HI) = rbuff(3+8*nshapes:2+9*nshapes)
-         refine_vars  (:)%ref_thr          = rbuff(3+9*nshapes                   :2+9*nshapes+  n_ref_auto_param)
-         refine_vars  (:)%aux              = rbuff(3+9*nshapes+  n_ref_auto_param:2+9*nshapes+2*n_ref_auto_param)
+
+         refine_zcyls (:)%coords(xdim, LO) = rbuff(3+ 9*nshapes:2+10*nshapes)
+         refine_zcyls (:)%coords(xdim, HI) = rbuff(3+10*nshapes:2+11*nshapes)
+         refine_zcyls (:)%coords(ydim, LO) = rbuff(3+11*nshapes:2+12*nshapes)
+         refine_zcyls (:)%coords(ydim, HI) = rbuff(3+12*nshapes:2+13*nshapes)
+         refine_zcyls (:)%coords(zdim, LO) = rbuff(3+13*nshapes:2+14*nshapes)
+         refine_zcyls (:)%coords(zdim, HI) = rbuff(3+14*nshapes:2+15*nshapes)
+
+         refine_vars  (:)%ref_thr          = rbuff(3+15*nshapes                   :2+15*nshapes+  n_ref_auto_param)
+         refine_vars  (:)%aux              = rbuff(3+15*nshapes+  n_ref_auto_param:2+15*nshapes+2*n_ref_auto_param)
 
       endif
 

--- a/src/grid/refinement/unified_ref_crit_geometrical.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical.F90
@@ -48,6 +48,21 @@ module unified_ref_crit_geometrical
 
    type, abstract, extends(urc) :: urc_geom
       integer :: level  !< desired level of refinement
+   contains
+      procedure :: enough_level
    end type urc_geom
+
+contains
+
+   pure logical function enough_level(this, lev)
+
+      implicit none
+
+      class(urc_geom), intent(in) :: this
+      integer(kind=4), intent(in) :: lev
+
+      enough_level = (lev >= this%level)
+
+   end function enough_level
 
 end module unified_ref_crit_geometrical

--- a/src/grid/refinement/unified_ref_crit_geometrical.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical.F90
@@ -50,9 +50,12 @@ module unified_ref_crit_geometrical
       integer :: level  !< desired level of refinement
    contains
       procedure :: enough_level
+      procedure, nopass :: coord2ind
    end type urc_geom
 
 contains
+
+   !> \brief one, uniform check for all dependent types
 
    pure logical function enough_level(this, lev)
 
@@ -64,5 +67,32 @@ contains
       enough_level = (lev >= this%level)
 
    end function enough_level
+
+   !> \brief convert cordinates to indices, perhaps it can go to some more general place
+
+   pure function coord2ind(coords, l) result(ijk)
+
+      use constants,        only: ndims, LO
+      use domain,           only: dom
+      use level_essentials, only: level_t
+
+      implicit none
+
+      real, dimension(ndims),  intent(in) :: coords
+      class(level_t), pointer, intent(in) :: l
+
+      integer(kind=8), dimension(ndims) :: ijk
+
+      where (dom%has_dir)
+         ijk(:) = l%off + floor((coords - dom%edge(:, LO))/dom%L_ * l%n_d)
+         ! Excessively large this%coords will result in FPE exception.
+         ! If FPE is not trapped, then huge() value will be assigned from uninit constant
+         ! (checked on gfortran 7.3.1), which is safe.
+         ! A wrapped value coming from integer overflow may be unsafe.
+      elsewhere
+         ijk(:) = l%off
+      endwhere
+
+   end function coord2ind
 
 end module unified_ref_crit_geometrical

--- a/src/grid/refinement/unified_ref_crit_geometrical_box.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_box.F90
@@ -116,7 +116,7 @@ contains
          ijk(:, LO) = min(max(int(this%ijk_lo(cg%l%id, :), kind=4), cg%ijkse(:, LO)), cg%ijkse(:, HI))
          ijk(:, HI) = min(max(int(this%ijk_hi(cg%l%id, :), kind=4), cg%ijkse(:, LO)), cg%ijkse(:, HI))
 
-         if (cg%l%id < this%level) call cg%flag%set(ijk)
+         call cg%flag%set(ijk)
       endif
 
    end subroutine mark_box

--- a/src/grid/refinement/unified_ref_crit_geometrical_box.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_box.F90
@@ -105,12 +105,12 @@ contains
 
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: ijk
 
-      if (cg%l%id > this%level) return
+      if (cg%l%id >= this%level) return
 
       if (allocated(this%ijk_lo) .neqv. allocated(this%ijk_hi)) call die("[unified_ref_crit_geometrical_box:mark_box] inconsistent alloc")
 
       if (.not. allocated(this%ijk_lo)) call die("[unified_ref_crit_geometrical_box:mark_box] ijk_{lo,hi} not allocated")
-      if (any(this%ijk_lo(cg%l%id, :) == uninit) .or. any(this%ijk_hi(cg%l%id, :) == uninit)) call this%init_lev  ! new levels of refinement have appears in the meantime
+      if (any(this%ijk_lo(cg%l%id, :) == uninit) .or. any(this%ijk_hi(cg%l%id, :) == uninit)) call this%init_lev  ! new levels of refinement have appeared in the meantime
 
       if (all(this%ijk_hi(cg%l%id, :) >= cg%ijkse(:, LO)) .and. all(this%ijk_lo(cg%l%id, :) <= cg%ijkse(:, HI))) then
          ijk(:, LO) = min(max(int(this%ijk_lo(cg%l%id, :), kind=4), cg%ijkse(:, LO)), cg%ijkse(:, HI))
@@ -124,7 +124,7 @@ contains
 !>
 !! \brief Initialize ths%ijk
 !!
-!! \details Initialize uning available levels. If more refinements appear then call this again to reinitialize.
+!! \details Initialize using available levels. If more refinements appear then call this again to reinitialize.
 !>
 
    subroutine init_lev(this)

--- a/src/grid/refinement/unified_ref_crit_geometrical_box.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_box.F90
@@ -105,7 +105,7 @@ contains
 
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: ijk
 
-      if (cg%l%id >= this%level) return
+      if (this%enough_level(cg%l%id)) return
 
       if (allocated(this%ijk_lo) .neqv. allocated(this%ijk_hi)) call die("[unified_ref_crit_geometrical_box:mark_box] inconsistent alloc")
 

--- a/src/grid/refinement/unified_ref_crit_geometrical_point.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_point.F90
@@ -101,7 +101,7 @@ contains
       class(urc_point),              intent(inout) :: this  !< an object invoking the type-bound procedure
       type(grid_container), pointer, intent(inout) :: cg    !< current grid piece
 
-      if (cg%l%id > this%level) return
+      if (cg%l%id >= this%level) return
 
       if (.not. allocated(this%ijk)) call die("[unified_ref_crit_geometrical_point:mark_point] ijk not allocated")
       ! Did some new levels of refinement appeared in the meantime?

--- a/src/grid/refinement/unified_ref_crit_geometrical_point.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_point.F90
@@ -101,7 +101,7 @@ contains
       class(urc_point),              intent(inout) :: this  !< an object invoking the type-bound procedure
       type(grid_container), pointer, intent(inout) :: cg    !< current grid piece
 
-      if (cg%l%id >= this%level) return
+      if (this%enough_level(cg%l%id)) return
 
       if (.not. allocated(this%ijk)) call die("[unified_ref_crit_geometrical_point:mark_point] ijk not allocated")
       ! Did some new levels of refinement appeared in the meantime?

--- a/src/grid/refinement/unified_ref_crit_geometrical_point.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_point.F90
@@ -43,7 +43,7 @@ module unified_ref_crit_geometrical_point
 
    type, extends(urc_geom) :: urc_point
       real, dimension(ndims)                                 :: coords  !< coordinates, where to refine
-      integer(kind=4), allocatable, dimension(:, :), private :: ijk     !< integer coordinates at allowed levels; shape: [ base_level_id:this%level-1, ndims ]
+      integer(kind=8), allocatable, dimension(:, :), private :: ijk     !< integer coordinates at allowed levels; shape: [ base_level_id:this%level-1, ndims ]
    contains
       procedure          :: mark => mark_point
       procedure, private :: init_lev
@@ -92,7 +92,7 @@ contains
 
    subroutine mark_point(this, cg)
 
-      use constants,  only: xdim, ydim, zdim, LO, HI
+      use constants,  only: LO, HI
       use dataio_pub, only: die
       use grid_cont,  only: grid_container
 
@@ -107,9 +107,8 @@ contains
       ! Did some new levels of refinement appeared in the meantime?
       if (any(this%ijk(cg%l%id, :) == uninit)) call this%init_lev
 
-      if (all(this%ijk(cg%l%id, :) >= cg%ijkse(:, LO)) .and. all(this%ijk(cg%l%id, :) <= cg%ijkse(:, HI))) then
-         if (cg%l%id < this%level) call cg%flag%set(this%ijk(cg%l%id, xdim), this%ijk(cg%l%id, ydim), this%ijk(cg%l%id, zdim))
-      endif
+      if (all(this%ijk(cg%l%id, :) >= cg%ijkse(:, LO)) .and. all(this%ijk(cg%l%id, :) <= cg%ijkse(:, HI))) &
+           call cg%flag%set(this%ijk(cg%l%id, :))
 
    end subroutine mark_point
 

--- a/src/grid/refinement/unified_ref_crit_geometrical_point.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_point.F90
@@ -104,8 +104,8 @@ contains
       if (this%enough_level(cg%l%id)) return
 
       if (.not. allocated(this%ijk)) call die("[unified_ref_crit_geometrical_point:mark_point] ijk not allocated")
-      ! Did some new levels of refinement appeared in the meantime?
-      if (any(this%ijk(cg%l%id, :) == uninit)) call this%init_lev
+
+      if (any(this%ijk(cg%l%id, :) == uninit)) call this%init_lev  ! new levels of refinement have appeared in the meantime
 
       if (all(this%ijk(cg%l%id, :) >= cg%ijkse(:, LO)) .and. all(this%ijk(cg%l%id, :) <= cg%ijkse(:, HI))) &
            call cg%flag%set(this%ijk(cg%l%id, :))
@@ -122,30 +122,18 @@ contains
 
       use cg_level_base,      only: base
       use cg_level_connected, only: cg_level_connected_t
-      use dataio_pub,         only: printinfo, msg
-      use mpisetup,           only: master
 
       implicit none
 
       class(urc_point), intent(inout)  :: this  !< an object invoking the type-bound procedure
 
       type(cg_level_connected_t), pointer :: l
-      logical, parameter :: verbose = .false.  ! for debugging only
 
       l => base%level
       do while (associated(l))
          if (l%l%id <= ubound(this%ijk, dim=1)) then
-            if (any(this%ijk(l%l%id, :) == uninit)) then
-
-               this%ijk(l%l%id, :) = this%coord2ind(this%coords, l%l)
-
-               if (verbose .and. master) then
-                  write(msg, '(a,i3,a,3i8,a)')"[URC point]   point coordinates at level ", &
-                       l%l%id, " are: [ ", this%ijk(l%l%id, :), " ]"
-                  call printinfo(msg)
-               endif
-
-            endif
+            if (any(this%ijk(l%l%id, :) == uninit)) &
+                 this%ijk(l%l%id, :) = this%coord2ind(this%coords, l%l)
          endif
          l => l%finer
       enddo

--- a/src/grid/refinement/unified_ref_crit_geometrical_point.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_point.F90
@@ -122,9 +122,7 @@ contains
 
       use cg_level_base,      only: base
       use cg_level_connected, only: cg_level_connected_t
-      use constants,          only: LO
       use dataio_pub,         only: printinfo, msg
-      use domain,             only: dom
       use mpisetup,           only: master
 
       implicit none
@@ -138,20 +136,15 @@ contains
       do while (associated(l))
          if (l%l%id <= ubound(this%ijk, dim=1)) then
             if (any(this%ijk(l%l%id, :) == uninit)) then
-               where (dom%has_dir)
-                  this%ijk(l%l%id, :) = int(l%l%off, kind=4) + floor((this%coords - dom%edge(:, LO))/dom%L_*l%l%n_d, kind=4)
-                  ! Excessively large this%coords will result in FPE exception.
-                  ! If FPE is not trapped, then huge() value will be assigned from uninit constant
-                  ! (checked on gfortran 7.3.1), which is safe.
-                  ! A wrapped value coming from integer overflow may be unsafe.
-               elsewhere
-                  this%ijk(l%l%id, :) = int(l%l%off, kind=4)
-               endwhere
+
+               this%ijk(l%l%id, :) = this%coord2ind(this%coords, l%l)
+
                if (verbose .and. master) then
                   write(msg, '(a,i3,a,3i8,a)')"[URC point]   point coordinates at level ", &
                        l%l%id, " are: [ ", this%ijk(l%l%id, :), " ]"
                   call printinfo(msg)
                endif
+
             endif
          endif
          l => l%finer

--- a/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
@@ -117,9 +117,9 @@ contains
       type(grid_container), pointer, intent(inout) :: cg    !< current grid piece
 
       real :: dist2_y, dist2_x
-      integer :: i, j, k
+      integer(kind=4) :: i, j, k
 
-      if (cg%l%id >= this%level) return
+      if (this%enough_level(cg%l%id)) return
 
       if (allocated(this%ijk_lo) .neqv. allocated(this%ijk_hi)) call die("[unified_ref_crit_geometrical_box:mark_zcyl] inconsistent alloc")
 

--- a/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
@@ -168,15 +168,12 @@ contains
       use cg_level_base,      only: base
       use cg_level_connected, only: cg_level_connected_t
       use constants,          only: LO, HI
-      use dataio_pub,         only: printinfo, msg
-      use mpisetup,           only: master
 
       implicit none
 
       class(urc_zcyl), intent(inout)  :: this  !< an object invoking the type-bound procedure
 
       type(cg_level_connected_t), pointer :: l
-      logical, parameter :: verbose = .false.  ! for debugging only
 
       l => base%level
       do while (associated(l))
@@ -188,11 +185,6 @@ contains
                this%ijk_lo(l%l%id, :) = this%coord2ind(this%coords(:, LO), l%l)
                this%ijk_hi(l%l%id, :) = this%coord2ind(this%coords(:, HI), l%l)
                this%ijk_c (l%l%id, :) = this%coord2ind(this%center,        l%l)
-
-               if (verbose .and. master) then
-                  write(msg, '(a,i3,a,3i8,a,3i8,a)')"[URC zcyl]  z-cylinder coordinates at level ", l%l%id, " are: [ ", this%ijk_lo(l%l%id, :), " ]..[ ", this%ijk_hi(l%l%id, :), " ]"
-                  call printinfo(msg)
-               endif
 
             endif
          endif

--- a/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
@@ -1,0 +1,194 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see http://www.gnu.org/licenses/.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+
+#include "piernik.h"
+
+!> \brief Unified refinement criterion for a cylinder with axis in the z-direction that fits to a simple box
+
+module unified_ref_crit_geometrical_zcyl
+
+   use constants,                    only: ndims, LO, HI
+   use unified_ref_crit_geometrical, only: urc_geom
+
+   implicit none
+
+   private
+   public :: urc_zcyl
+
+!> \brief A type for box refinement
+
+   type, extends(urc_geom) :: urc_zcyl
+      real, dimension(ndims, LO:HI)                          :: coords  !< coordinates of the box that contains the cylinder, where to refine
+      real, dimension(ndims), private                        :: center  !< coordinates of the center of the cylinder
+      real, dimension(ndims), private                        :: size    !< x- and y-radius (elliptical cylinders are allowed) and half-height
+      integer(kind=8), allocatable, dimension(:, :), private :: ijk_lo  !< integer coordinates of "bottom left corner" at allowed levels; shape: [ base_level_id:this%level-1, ndims ]
+      integer(kind=8), allocatable, dimension(:, :), private :: ijk_hi  !< integer coordinates of "top right corner" at allowed levels; shape: [ base_level_id:this%level-1, ndims ]
+   contains
+      procedure          :: mark => mark_zcyl
+      procedure, private :: init_lev
+   end type urc_zcyl
+
+   interface urc_zcyl
+      procedure :: init
+   end interface urc_zcyl
+
+   integer(kind=8), parameter :: uninit = huge(1_8)
+
+contains
+
+!> \brief A simple constructor fed by parameters read from problem.par
+
+   function init(rp) result(this)
+
+      use constants,  only: base_level_id, ndims, LO, HI
+      use dataio_pub, only: printinfo, msg
+      use domain,     only: dom
+      use mpisetup,   only: master
+      use refinement, only: ref_box
+
+      implicit none
+
+      type(ref_box), intent(in) :: rp  !< the data read from problem.par
+
+      type(urc_zcyl) :: this  !< an object to be constructed
+
+      this%level  = rp%level
+      this%coords = rp%coords
+
+      where (dom%has_dir)
+         this%center = (this%coords(:, HI) + this%coords(:, LO)) / 2.
+         this%size   = (this%coords(:, HI) - this%coords(:, LO)) / 2.
+      elsewhere
+         this%center = dom%C_
+         this%size   = dom%L_
+      endwhere
+
+      allocate(this%ijk_lo(base_level_id:this%level, ndims), this%ijk_hi(base_level_id:this%level, ndims))
+      this%ijk_lo = uninit
+      this%ijk_hi = uninit
+      if (master) then
+         write(msg, '(a,3g13.5,a,3g13.5,a)')"[URC zcyl]   Initializing cylindrical refinement in a box: [ ", this%coords(:, LO), " ]..[ ", this%coords(:, HI), " ]"
+         call printinfo(msg)
+      endif
+
+   end function init
+
+!>
+!! \brief Mark a z-oriented cylinted inside a specified box in the domain for refinement
+!!
+!! Please note that it uses grid topology, so in GEO_RPZ may result in funny shapes, especially for "cylinders" extended in angular direction.
+!!
+!! \details this%iplot is ignored here as not very interesting
+!<
+
+   subroutine mark_zcyl(this, cg)
+
+      use constants,  only: xdim, ydim, zdim, LO, HI
+      use dataio_pub, only: die
+      use grid_cont,  only: grid_container
+
+      implicit none
+
+      class(urc_zcyl),               intent(inout) :: this  !< an object invoking the type-bound procedure
+      type(grid_container), pointer, intent(inout) :: cg    !< current grid piece
+
+      real :: dist2_y, dist2_x
+      integer :: i, j, k
+
+      if (cg%l%id > this%level) return
+
+      if (allocated(this%ijk_lo) .neqv. allocated(this%ijk_hi)) call die("[unified_ref_crit_geometrical_box:mark_zcyl] inconsistent alloc")
+
+      if (.not. allocated(this%ijk_lo)) call die("[unified_ref_crit_geometrical_box:mark_zcyl] ijk_{lo,hi} not allocated")
+      if (any(this%ijk_lo(cg%l%id, :) == uninit) .or. any(this%ijk_hi(cg%l%id, :) == uninit)) call this%init_lev  ! new levels of refinement have appeared in the meantime
+
+      if (all(this%ijk_hi(cg%l%id, :) >= cg%ijkse(:, LO)) .and. all(this%ijk_lo(cg%l%id, :) <= cg%ijkse(:, HI))) then
+         do k = cg%ks, cg%ke
+            if ((cg%z(k) >= this%coords(zdim, LO)) .and. (cg%z(k) <= this%coords(zdim, HI))) then
+               do j = cg%js, cg%je
+                  dist2_y = ((cg%y(j) - this%center(ydim)) / this%size(ydim))**2
+                  do i = cg%is, cg%ie
+                     dist2_x = ((cg%x(i) - this%center(xdim)) / this%size(xdim))**2
+                     if (dist2_x + dist2_y <= 1.) call cg%flag%set(i, j, k)
+                  enddo
+               enddo
+            endif
+         enddo
+      endif
+
+   end subroutine mark_zcyl
+
+!>
+!! \brief Initialize ths%ijk
+!!
+!! \details Initialize using available levels. If more refinements appear then call this again to reinitialize.
+!!
+!! Spaghetti warning: practically identical to unified_ref_crit_geometrical_box:init_lev
+!>
+
+   subroutine init_lev(this)
+
+      use cg_level_base,      only: base
+      use cg_level_connected, only: cg_level_connected_t
+      use constants,          only: LO, HI
+      use dataio_pub,         only: printinfo, msg
+      use domain,             only: dom
+      use mpisetup,           only: master
+
+      implicit none
+
+      class(urc_zcyl), intent(inout)  :: this  !< an object invoking the type-bound procedure
+
+      type(cg_level_connected_t), pointer :: l
+      logical, parameter :: verbose = .false.  ! for debugging only
+
+      l => base%level
+      do while (associated(l))
+         if (l%l%id <= ubound(this%ijk_lo, dim=1)) then
+            if (any(this%ijk_lo(l%l%id, :) == uninit) .or. any(this%ijk_hi(l%l%id, :) == uninit)) then
+               where (dom%has_dir)
+                  this%ijk_lo(l%l%id, :) = l%l%off + floor((this%coords(:, LO) - dom%edge(:, LO))/dom%L_*l%l%n_d, kind=8)
+                  this%ijk_hi(l%l%id, :) = l%l%off + floor((this%coords(:, HI) - dom%edge(:, LO))/dom%L_*l%l%n_d, kind=8)
+                  ! Excessively large this%coords will result in FPE exception.
+                  ! If not trapped then huge() value will be assigned (checked on gfortran 7.3.1), which is safe.
+                  ! A wrapped value coming from integer overflow may be unsafe.
+               elsewhere
+                  this%ijk_lo(l%l%id, :) = l%l%off
+                  this%ijk_hi(l%l%id, :) = l%l%off
+               endwhere
+               if (verbose .and. master) then
+                  write(msg, '(a,i3,a,3i8,a,3i8,a)')"[URC zcyl]  z-cylinder coordinates at level ", l%l%id, " are: [ ", this%ijk_lo(l%l%id, :), " ]..[ ", this%ijk_hi(l%l%id, :), " ]"
+                  call printinfo(msg)
+               endif
+            endif
+         endif
+         l => l%finer
+      enddo
+
+   end subroutine init_lev
+
+end module unified_ref_crit_geometrical_zcyl

--- a/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
+++ b/src/grid/refinement/unified_ref_crit_geometrical_zcyl.F90
@@ -119,7 +119,7 @@ contains
       real :: dist2_y, dist2_x
       integer :: i, j, k
 
-      if (cg%l%id > this%level) return
+      if (cg%l%id >= this%level) return
 
       if (allocated(this%ijk_lo) .neqv. allocated(this%ijk_hi)) call die("[unified_ref_crit_geometrical_box:mark_zcyl] inconsistent alloc")
 

--- a/src/grid/refinement/unified_ref_crit_list.F90
+++ b/src/grid/refinement/unified_ref_crit_list.F90
@@ -109,9 +109,10 @@ contains
    subroutine init(this)
 
       use constants,                          only: base_level_id
-      use refinement,                         only: refine_points, refine_boxes, refine_vars, inactive_name, jeans_ref, jeans_plot
+      use refinement,                         only: refine_points, refine_boxes, refine_zcyls, refine_vars, inactive_name, jeans_ref, jeans_plot
       use unified_ref_crit_geometrical_box,   only: urc_box
       use unified_ref_crit_geometrical_point, only: urc_point
+      use unified_ref_crit_geometrical_zcyl,  only: urc_zcyl
       use unified_ref_crit_Jeans,             only: urc_jeans
       use unified_ref_crit_var,               only: decode_urcv
 
@@ -121,6 +122,7 @@ contains
 
       type(urc_box),   pointer :: urcb
       type(urc_point), pointer :: urcp
+      type(urc_zcyl),  pointer :: urczc
       type(urc_jeans), pointer :: urcj
       integer :: ip
 
@@ -152,6 +154,14 @@ contains
             allocate(urcb)
             urcb = urc_box(refine_boxes(ip))
             call this%add(urcb)
+         endif
+      enddo
+
+      do ip = lbound(refine_zcyls, dim=1), ubound(refine_zcyls, dim=1)
+         if (refine_zcyls(ip)%level > base_level_id) then
+            allocate(urczc)
+            urczc = urc_zcyl(refine_zcyls(ip))
+            call this%add(urczc)
          endif
       enddo
 

--- a/src/grid/refinement_flag.F90
+++ b/src/grid/refinement_flag.F90
@@ -57,8 +57,9 @@ module refinement_flag
       procedure          :: reset_blocks   !> make SFC_refine_list empty
 
       !> Set the refinement flag in the map. This is the only call supposed to be used in user routines.
-      generic,   public  :: set => set_cell, set_arrng, set_all, set_mask  !, set_range
-      procedure, private :: set_cell       !> Mark a cell for refinement
+      generic,   public  :: set => set_cell, set_arrcell, set_arrng, set_all, set_mask  !, set_range
+      procedure, private :: set_cell       !> Mark a cell for refinement (separate indices)
+      procedure, private :: set_arrcell    !> Mark a cell for refinement (array indices)
 !      procedure, private :: set_range      !> Mark a box of cells for refinement (list of indices)
       procedure, private :: set_arrng      !> Mark a box of cells for refinement (se-type array of indices)
       procedure, private :: set_all        !> Mark all cells for refinement
@@ -228,7 +229,7 @@ contains
 
    end function get_any_arrng
 
-!> \brief Mark a cell for refinement
+!> \brief Mark a cell for refinement (separate indices)
 
    subroutine set_cell(this, i, j, k)
 
@@ -248,6 +249,29 @@ contains
       this%map(i, j, k) = .true.
 
    end subroutine set_cell
+
+!> \brief Mark a cell for refinement (array indices)
+
+   subroutine set_arrcell(this, ijk)
+
+      use constants, only: xdim, ydim, zdim
+
+#ifdef DEBUG
+      use dataio_pub, only: die
+#endif /* DEBUG */
+
+      implicit none
+
+      class(ref_flag_t),                     intent(inout) :: this  !> object invoking this procedure
+      integer(kind=8), dimension(xdim:zdim), intent(in)    :: ijk   !> cell coordinates
+
+#ifdef DEBUG
+      if (any(ijk < lbound(this%map)) .or. any(ijk > ubound(this%map))) call die("[refinement_flag:set_arrcell] out of range")  ! this can be costly check
+#endif /* DEBUG */
+
+      this%map(ijk(xdim), ijk(ydim), ijk(zdim)) = .true.
+
+   end subroutine set_arrcell
 
 !> \brief Mark a box of cells for refinement
 


### PR DESCRIPTION
Implemented a refinement that can mark a cylinder with the axis along Z-direction and independent X- and Y- semiaxes. Similar to refine_boxes but less grid gets refined.