### PR TITLE
use mpi_f08

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ You may use `hdf5-mpich-devel` if you prefer MPICH over OpenMPI.
 
 * OpenMPI refuses to run on all threads of a CPU with SMT/HT. Override with `--use-hwthread-cpus` or `--oversubscribe` (only when necessary).
 
-### older Fedora releases
+### older Fedora releases (24 .. 31)
 
 * Install `python-pycodestyle` instead of `python3-pycodestyle` if necessary for `make qa`.
 * If you are affected by a bug in dependencies in Fedora packages that results in failure of MPI compilation due to missing `/usr/lib/rpm/redhat/redhat-hardened-cc1`, you can fix it by installing the missing package:
@@ -58,6 +58,17 @@ You may use `hdf5-mpich-devel` if you prefer MPICH over OpenMPI.
     Remember that doing so is a sort of hack, which may take revenge on you in a distant future.
 
 If you have installed OpenMPI libraries, remember to replace `mpich` with `openmpi` in the `sed` calls above.
+
+### other systems
+
+On other systems you need to find your own way (and you may choose to describe it here). You will need:
+
+* git
+* decent Fortran 2008 compiler (for such things as polymorphism or modern MPI interface)
+* MPI with Fortran support, preferably version that provides mpi_f08.mod. If it is limited to mpi.mod, it must provide interface to all MPI calls
+* hdf5 1.8.8 or newer with high-level library, Fortran 2003 interface and MPI support (--enable-shared --enable-fortran --enable-fortran2003 --enable-parallel) – it allows you to use a wrapper ‘h5pfc’ as a compiler
+* Python (unfortunately we still have some 2.7-based scripts), including packages such as h5py, numpy
+* There are optional tasks that depend on gnuplot, parallel, graphviz and yt
 
 ## Piernik
 

--- a/compilers/jenkins.in
+++ b/compilers/jenkins.in
@@ -1,0 +1,73 @@
+###############################################################################
+#
+# Make definitions for lothlorien (Fedora 25..32)
+#
+# Do not modify if you aren't me :-)
+# Feel free to make your own copy if you like something here.
+#
+
+PROG     = piernik
+
+F90      = h5pfc
+
+F90 += -I/usr/lib64/gfortran/modules/$(subst _,,$(MPI_SUFFIX))
+
+F90FLAGS  = -fdefault-real-8 -ffree-form -std=gnu -fimplicit-none -ffree-line-length-none
+F90FLAGS += -O3 -funroll-loops -fno-stack-arrays
+F90FLAGS += -Wall -Wextra -W -Wsurprising -Wcharacter-truncation -Wno-unused-function -fmodule-private
+F90FLAGS += -fbacktrace -ggdb
+F90FLAGS += -fcheck=all
+
+# Since gfortran >= 10.0 -frecursive was adviced by the compiler.
+# ToDo: Find out why.
+F90FLAGS += -frecursive
+
+# for gfortran >= 10.0 the use mpi_f08 interface is strongly encouraged
+#change this as soon as Jenkins gets updated to gcc 10
+USE_MPI_F08 := 0
+
+
+ifeq ($(USE_MPI_F08),1)
+  F90FLAGS += -pedantic
+  CPPFLAGS += -DMPIF08
+else
+  # Ugly hack for old MPI interface, only got gfortran >= 10
+  # F90FLAGS += -fallow-argument-mismatch
+  # restore pedantic for gfortran < 10
+  F90FLAGS += -pedantic
+endif
+
+ifdef I64
+  F90FLAGS += -fdefault-integer-8
+endif
+
+ifdef ALLINIT
+  RINIT := 1
+  IINIT := 1
+  CINIT := 1
+  LINIT := 1
+endif
+ifdef RINIT
+  F90FLAGS += -finit-real=snan
+endif
+ifdef IINIT
+  F90FLAGS += -finit-integer=-2098765432
+endif
+ifdef CINIT
+  F90FLAGS += -finit-character=96
+endif
+ifdef LINIT
+  F90FLAGS += -finit-logical=true
+endif
+
+F90FLAGS +=  -ffpe-trap=invalid,zero,overflow
+#denormal,underflow,inexact
+## denormal causes weird problems since gcc 4.7.0
+
+LDFLAGS   = -Wl,--as-needed -Wl,-O1
+MAKEFLAGS += -j4
+F90FLAGS += -I/usr/include
+
+# for the kepler problem
+#F90FLAGS += -I/home/gawrysz/usr/include/gfortran
+#LDFLAGS += -L/home/gawrysz/usr/lib/

--- a/compilers/lothlorien.in
+++ b/compilers/lothlorien.in
@@ -18,12 +18,19 @@ F90FLAGS += -Wall -Wextra -W -Wsurprising -Wcharacter-truncation -Wno-unused-fun
 F90FLAGS += -fbacktrace -ggdb
 F90FLAGS += -fcheck=all
 
-GFORTRAN := $(shell gfortran -dumpversion)
-ifeq ($(GFORTRAN),10)
-  # Ugly hack for old MPI interface
-  F90FLAGS += -fallow-argument-mismatch -frecursive
-else
+# Since gfortran >= 10.0 -frecursive was adviced by the compiler.
+# ToDo: Find out why.
+F90FLAGS += -frecursive
+
+# for gfortran >= 10.0 the use mpi_f08 interface is strongly encouraged
+USE_MPI_F08 := 1
+
+ifeq ($(USE_MPI_F08),1)
   F90FLAGS += -pedantic
+  CPPFLAGS += -DMPIF08
+else
+  # Ugly hack for old MPI interface
+  F90FLAGS += -fallow-argument-mismatch
 endif
 
 ifdef I64

--- a/problems/override_test/piernik.F90
+++ b/problems/override_test/piernik.F90
@@ -32,7 +32,7 @@ program hello_world
 ! pulled by ANY
 ! overrides src/base/piernik.F90
 
-   use mpi, only: MPI_COMM_WORLD
+   use MPIF, only: MPI_COMM_WORLD
 
    implicit none
 

--- a/problems/wt4/initproblem.F90
+++ b/problems/wt4/initproblem.F90
@@ -230,7 +230,7 @@ contains
       use dataio_pub,  only: msg, die
       use func,        only: operator(.notequals.)
       use grid_cont,   only: grid_container
-      use mpi,         only: MPI_DOUBLE_PRECISION
+      use MPIF,        only: MPI_DOUBLE_PRECISION
       use mpisetup,    only: proc, master, FIRST, LAST, comm, status, mpi_err
 
       implicit none

--- a/problems/wt4/initproblem.F90
+++ b/problems/wt4/initproblem.F90
@@ -230,13 +230,14 @@ contains
       use dataio_pub,  only: msg, die
       use func,        only: operator(.notequals.)
       use grid_cont,   only: grid_container
-      use MPIF,        only: MPI_DOUBLE_PRECISION
-      use mpisetup,    only: proc, master, FIRST, LAST, comm, status, mpi_err
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_Send, MPI_Recv
+      use mpisetup,    only: proc, master, FIRST, LAST, comm, mpi_err
 
       implicit none
 
-      integer                             :: i, j, k, v, pe, ostat
-      type(grid_container), pointer       :: cg
+      integer                       :: i, j, k, v, ostat
+      integer(kind=4)               :: pe
+      type(grid_container), pointer :: cg
       enum, bind(C)
          enumerator :: DEN0 = 1, VELX0, VELZ0 = VELX0+ndims-1, ENER0
       end enum
@@ -264,10 +265,10 @@ contains
                enddo
             enddo
             do pe = FIRST+1, LAST
-               call MPI_Send(ic_data, size(ic_data), MPI_DOUBLE_PRECISION, pe, pe, comm, mpi_err)
+               call MPI_Send(ic_data, size(ic_data, kind=4), MPI_DOUBLE_PRECISION, pe, pe, comm, mpi_err)
             enddo
          else
-            call MPI_Recv(ic_data, size(ic_data), MPI_DOUBLE_PRECISION, FIRST, proc, comm, status, mpi_err)
+            call MPI_Recv(ic_data, size(ic_data, kind=4), MPI_DOUBLE_PRECISION, FIRST, proc, comm, MPI_STATUS_IGNORE, mpi_err)
          endif
       enddo
 

--- a/python/piernik_setup.py
+++ b/python/piernik_setup.py
@@ -530,9 +530,9 @@ def setup_piernik(data=None):
             uses.append([])
         module.setdefault(f, f)
 
-    known_external_modules = (
-        "hdf5", "h5lt", "mpi", "iso_c_binding", "iso_fortran_env", "fgsl",
-        "ifposix", "ifport", "ifcore")  # Ugly trick: these modules are detected by -D__INTEL_COMPILER
+    known_external_modules = ["hdf5", "h5lt", "iso_c_binding", "iso_fortran_env", "fgsl",
+                              "ifposix", "ifport", "ifcore"]  # Ugly trick: these modules are detected by -D__INTEL_COMPILER
+    known_external_modules.append("mpi_f08" if "-DMPIF08" in cppflags.split() else "mpi")
 
     files_to_build = remove_suf(stripped_files)
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -1703,7 +1703,7 @@ contains
          use constants,    only: I_ONE, INVALID
          use dataio_pub,   only: msg, printinfo
          use memory_usage, only: system_mem_usage
-         use MPIF,         only: MPI_INTEGER
+         use MPIF,         only: MPI_INTEGER, MPI_Gather
          use mpisetup,     only: master, FIRST, LAST, comm, mpi_err
 
          implicit none

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -70,7 +70,7 @@ module dataio
    logical, dimension(RES:TSL) :: dump = .false.     !< logical values for all dump types to restrict to only one dump of each type a step
 
 !   integer                  :: nchar                 !< number of characters in a user/system message
-   integer, parameter       :: umsg_len = 16
+   integer(kind=4), parameter :: umsg_len = 16
    character(len=umsg_len)  :: umsg                  !< string of characters - content of a user/system message
    real                     :: umsg_param            !< parameter changed by a user/system message
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -1703,7 +1703,7 @@ contains
          use constants,    only: I_ONE, INVALID
          use dataio_pub,   only: msg, printinfo
          use memory_usage, only: system_mem_usage
-         use mpi,          only: MPI_INTEGER
+         use MPIF,         only: MPI_INTEGER
          use mpisetup,     only: master, FIRST, LAST, comm, mpi_err
 
          implicit none

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -242,7 +242,7 @@ contains
    subroutine colormessage(nm, mode)
 
       use constants, only: stdout, stderr, idlen, I_ONE
-      use mpi,       only: MPI_COMM_WORLD
+      use MPIF,      only: MPI_COMM_WORLD
 
       implicit none
 
@@ -397,7 +397,7 @@ contains
    !> \deprecated BEWARE: routine is not finished, it should kill PIERNIK gracefully
    subroutine die(nm, allprocs)
 
-      use mpi,    only: MPI_COMM_WORLD
+      use MPIF,   only: MPI_COMM_WORLD
 #if defined(__INTEL_COMPILER)
       use ifcore, only: tracebackqq
 #endif /* __INTEL_COMPILER */
@@ -474,7 +474,7 @@ contains
    subroutine compare_namelist(this)
 
       use constants, only: PIERNIK_INIT_IO_IC
-      use mpi,       only: MPI_COMM_WORLD
+      use MPIF,      only: MPI_COMM_WORLD
 
       implicit none
       class(namelist_handler_t), intent(inout) :: this
@@ -550,7 +550,7 @@ contains
 
    subroutine close_logs
 
-      use mpi, only: MPI_COMM_WORLD
+      use MPIF, only: MPI_COMM_WORLD
 
       implicit none
 

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -242,7 +242,7 @@ contains
    subroutine colormessage(nm, mode)
 
       use constants, only: stdout, stderr, idlen, I_ONE
-      use MPIF,      only: MPI_COMM_WORLD
+      use MPIF,      only: MPI_COMM_WORLD, MPI_Comm_rank
 
       implicit none
 
@@ -397,7 +397,7 @@ contains
    !> \deprecated BEWARE: routine is not finished, it should kill PIERNIK gracefully
    subroutine die(nm, allprocs)
 
-      use MPIF,   only: MPI_COMM_WORLD
+      use MPIF,   only: MPI_COMM_WORLD, MPI_Barrier, MPI_Finalize
 #if defined(__INTEL_COMPILER)
       use ifcore, only: tracebackqq
 #endif /* __INTEL_COMPILER */
@@ -474,7 +474,7 @@ contains
    subroutine compare_namelist(this)
 
       use constants, only: PIERNIK_INIT_IO_IC
-      use MPIF,      only: MPI_COMM_WORLD
+      use MPIF,      only: MPI_COMM_WORLD, MPI_Comm_rank
 
       implicit none
       class(namelist_handler_t), intent(inout) :: this
@@ -550,7 +550,7 @@ contains
 
    subroutine close_logs
 
-      use MPIF, only: MPI_COMM_WORLD
+      use MPIF, only: MPI_COMM_WORLD, MPI_Comm_rank
 
       implicit none
 

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -735,7 +735,8 @@ contains
          &                    h5open_f, h5close_f, h5fopen_f, h5fclose_f, h5gcreate_f, h5gopen_f, h5gclose_f, h5pclose_f, &
          &                    h5zfilter_avail_f
       use helpers_hdf5, only: create_attribute!, create_corefile
-      use MPIF,         only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_REAL8
+      use MPIF,         only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_REAL8, &
+           &                  MPI_Allgather, MPI_Recv, MPI_Send
       use mpisetup,     only: comm, FIRST, LAST, master, mpi_err, piernik_MPI_Bcast
 
       implicit none
@@ -1056,7 +1057,11 @@ contains
          ! when nproc_io < nproc we'll probably need another communicator for subset of processes that
          ! have can_i_write flag set
          if (h5p == H5P_FILE_ACCESS_F) then
+#ifdef MPIF08
+            call h5pset_fapl_mpio_f(plist_id, comm%mpi_val, MPI_INFO_NULL%mpi_val, error)  ! really?
+#else /* !MPIF08 */
             call h5pset_fapl_mpio_f(plist_id, comm, MPI_INFO_NULL, error)
+#endif /* !MPIF08 */
          else if (h5p == H5P_DATASET_XFER_F) then
             call h5pset_dxpl_mpio_f(plist_id, H5FD_MPIO_COLLECTIVE_F, error)
          endif

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -775,9 +775,9 @@ contains
       integer(HID_T)                                :: cg_g_id          !< cg group identifiers
       integer(HID_T)                                :: doml_g_id        !< domain list identifier
       integer(HID_T)                                :: dom_g_id         !< domain group identifier
-      integer(kind=4)                               :: error, cg_cnt
-      integer                                       :: g, p, i
-      integer, parameter                            :: tag = I_ONE
+      integer(kind=4)                               :: error, cg_cnt, p
+      integer                                       :: g, i
+      integer(kind=4), parameter                    :: tag = I_ONE
       integer(kind=4),  dimension(:),   pointer     :: cg_n             !< offset for cg group numbering
       integer(kind=4),  dimension(:,:), pointer     :: cg_all_n_b       !< sizes of all cg
       integer(kind=4),  dimension(:,:), pointer     :: cg_all_n_o       !< sizes of all cg, expanded by external boundaries
@@ -871,13 +871,13 @@ contains
             if (p == FIRST) then
                call collect_cg_data(cg_rl, cg_n_b, cg_n_o, cg_off, dbuf, otype)
             else
-               call MPI_Recv(cg_rl,  size(cg_rl),  MPI_INTEGER,  p, tag,         comm, MPI_STATUS_IGNORE, mpi_err)
-               call MPI_Recv(cg_n_b, size(cg_n_b), MPI_INTEGER,  p, tag+I_ONE,   comm, MPI_STATUS_IGNORE, mpi_err)
-               call MPI_Recv(cg_off, size(cg_off), MPI_INTEGER8, p, tag+I_TWO,   comm, MPI_STATUS_IGNORE, mpi_err)
+               call MPI_Recv(cg_rl,  size(cg_rl, kind=4),  MPI_INTEGER,  p, tag,         comm, MPI_STATUS_IGNORE, mpi_err)
+               call MPI_Recv(cg_n_b, size(cg_n_b, kind=4), MPI_INTEGER,  p, tag+I_ONE,   comm, MPI_STATUS_IGNORE, mpi_err)
+               call MPI_Recv(cg_off, size(cg_off, kind=4), MPI_INTEGER8, p, tag+I_TWO,   comm, MPI_STATUS_IGNORE, mpi_err)
                if (otype == O_OUT) &
-                  & call MPI_Recv(dbuf,   size(dbuf),   MPI_REAL8,    p, tag+I_THREE, comm, MPI_STATUS_IGNORE, mpi_err)
+                  & call MPI_Recv(dbuf,   size(dbuf, kind=4),   MPI_REAL8,    p, tag+I_THREE, comm, MPI_STATUS_IGNORE, mpi_err)
                if (otype == O_RES) &
-                    & call MPI_Recv(cg_n_o, size(cg_n_o), MPI_INTEGER,  p, tag+I_FOUR,  comm, MPI_STATUS_IGNORE, mpi_err)
+                    & call MPI_Recv(cg_n_o, size(cg_n_o, kind=4), MPI_INTEGER,  p, tag+I_FOUR,  comm, MPI_STATUS_IGNORE, mpi_err)
             endif
 
             do g = 1, cg_n(p)
@@ -962,11 +962,11 @@ contains
          nullify(cg_n_o)
          if (otype == O_RES) allocate(cg_n_o(leaves%cnt, ndims))
          call collect_cg_data(cg_rl, cg_n_b, cg_n_o, cg_off, dbuf, otype)
-         call MPI_Send(cg_rl,  size(cg_rl),  MPI_INTEGER,  FIRST, tag,         comm, mpi_err)
-         call MPI_Send(cg_n_b, size(cg_n_b), MPI_INTEGER,  FIRST, tag+I_ONE,   comm, mpi_err)
-         call MPI_Send(cg_off, size(cg_off), MPI_INTEGER8, FIRST, tag+I_TWO,   comm, mpi_err)
-         if (otype == O_OUT) call MPI_Send(dbuf,   size(dbuf),   MPI_REAL8,    FIRST, tag+I_THREE, comm, mpi_err)
-         if (otype == O_RES) call MPI_Send(cg_n_o, size(cg_n_o), MPI_INTEGER,  FIRST, tag+I_FOUR,  comm, mpi_err)
+         call MPI_Send(cg_rl,  size(cg_rl, kind=4),  MPI_INTEGER,  FIRST, tag,         comm, mpi_err)
+         call MPI_Send(cg_n_b, size(cg_n_b, kind=4), MPI_INTEGER,  FIRST, tag+I_ONE,   comm, mpi_err)
+         call MPI_Send(cg_off, size(cg_off, kind=4), MPI_INTEGER8, FIRST, tag+I_TWO,   comm, mpi_err)
+         if (otype == O_OUT) call MPI_Send(dbuf,   size(dbuf, kind=4),   MPI_REAL8,    FIRST, tag+I_THREE, comm, mpi_err)
+         if (otype == O_RES) call MPI_Send(cg_n_o, size(cg_n_o, kind=4), MPI_INTEGER,  FIRST, tag+I_FOUR,  comm, mpi_err)
          deallocate(cg_rl, cg_n_b, cg_off)
          if (associated(dbuf)) deallocate(dbuf)
          if (associated(cg_n_o)) deallocate(cg_n_o)

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -735,7 +735,7 @@ contains
          &                    h5open_f, h5close_f, h5fopen_f, h5fclose_f, h5gcreate_f, h5gopen_f, h5gclose_f, h5pclose_f, &
          &                    h5zfilter_avail_f
       use helpers_hdf5, only: create_attribute!, create_corefile
-      use mpi,          only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_REAL8
+      use MPIF,         only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_REAL8
       use mpisetup,     only: comm, FIRST, LAST, master, mpi_err, piernik_MPI_Bcast
 
       implicit none
@@ -1042,7 +1042,7 @@ contains
    function set_h5_properties(h5p, nproc_io) result (plist_id)
       use hdf5,     only: HID_T, H5P_FILE_ACCESS_F, h5pcreate_f, h5pset_fapl_mpio_f, &
          &                H5FD_MPIO_COLLECTIVE_F, h5pset_dxpl_mpio_f, H5P_DATASET_XFER_F
-      use mpi,      only: MPI_INFO_NULL
+      use MPIF,     only: MPI_INFO_NULL
       use mpisetup, only: comm
 
       implicit none

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -553,7 +553,7 @@ contains
       use global,      only: nstep
       use grid_cont,   only: grid_container
       use hdf5,        only: HID_T, HSIZE_T, H5T_NATIVE_REAL, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
-      use mpi,         only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
       use mpisetup,    only: master, FIRST, proc, comm, mpi_err
       use ppp,         only: ppp_main
 
@@ -825,7 +825,7 @@ contains
            &                     h5dwrite_f, h5screate_simple_f, h5pcreate_f, h5dcreate_f, h5sclose_f, h5dget_space_f, h5sselect_hyperslab_f, &
            &                     h5pset_dxpl_mpio_f, h5dclose_f, h5open_f, h5close_f, h5fopen_f, h5fclose_f, h5pclose_f, h5pset_fapl_mpio_f !, h5pset_chunk_f
       use mpisetup,        only: comm
-      use mpi,             only: MPI_INFO_NULL
+      use MPIF,            only: MPI_INFO_NULL
 
       implicit none
 

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -548,12 +548,12 @@ contains
       use cg_leaves,   only: leaves
       use cg_list,     only: cg_list_element
       use common_hdf5, only: get_nth_cg, hdf_vars, cg_output, hdf_vars, hdf_vars_avail, enable_all_hdf_var
-      use constants,   only: xdim, ydim, zdim, ndims, FP_REAL, PPP_IO, PPP_CG
+      use constants,   only: xdim, ydim, zdim, ndims, FP_REAL, PPP_IO, PPP_CG, I_ONE
       use dataio_pub,  only: die, nproc_io, can_i_write, h5_64bit, nstep_start
       use global,      only: nstep
       use grid_cont,   only: grid_container
       use hdf5,        only: HID_T, HSIZE_T, H5T_NATIVE_REAL, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
-      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_Recv, MPI_Send
       use mpisetup,    only: master, FIRST, proc, comm, mpi_err
       use ppp,         only: ppp_main
 
@@ -568,7 +568,8 @@ contains
       integer(kind=4)                                      :: error
       integer(kind=4), parameter                           :: rank = 3
       integer(HSIZE_T), dimension(:), allocatable          :: dims
-      integer                                              :: i, ip, ncg, n
+      integer(kind=4)                                      :: i, ncg, n
+      integer                                              :: ip
       type(grid_container),            pointer             :: cg
       type(cg_list_element),           pointer             :: cgl
       real, dimension(:,:,:),          pointer             :: data_dbl ! double precision buffer (internal default, single precision buffer is the plotfile output default, overridable by h5_64bit)
@@ -599,14 +600,14 @@ contains
                if (.not. can_i_write) call die("[data_hdf5:write_cg_to_output] Master can't write")
 
                ip = lbound(hdf_vars,1) - 1
-               do i = lbound(hdf_vars,1), ubound(hdf_vars,1)
+               do i = lbound(hdf_vars,1, kind=4), ubound(hdf_vars,1, kind=4)
                   if (.not.hdf_vars_avail(i)) cycle
                   ip = ip + 1
                   if (cg_desc%cg_src_p(ncg) == proc) then
                      cg => get_nth_cg(cg_desc%cg_src_n(ncg))
                      call get_data_from_cg(hdf_vars(i), cg, data_dbl)
                   else
-                     call MPI_Recv(data_dbl(1,1,1), size(data_dbl), MPI_DOUBLE_PRECISION, cg_desc%cg_src_p(ncg), ncg + cg_desc%tot_cg_n*i, comm, MPI_STATUS_IGNORE, mpi_err)
+                     call MPI_Recv(data_dbl(1,1,1), size(data_dbl, kind=4), MPI_DOUBLE_PRECISION, cg_desc%cg_src_p(ncg), ncg + cg_desc%tot_cg_n*i, comm, MPI_STATUS_IGNORE, mpi_err)
                   endif
                   if (.not.hdf_vars_avail(i)) cycle
                   if (h5_64bit) then
@@ -619,10 +620,10 @@ contains
                if (can_i_write) call die("[data_hdf5:write_cg_to_output] Slave can write")
                if (cg_desc%cg_src_p(ncg) == proc) then
                   cg => get_nth_cg(cg_desc%cg_src_n(ncg))
-                  do i = lbound(hdf_vars,1), ubound(hdf_vars,1)
+                  do i = lbound(hdf_vars,1, kind=4), ubound(hdf_vars,1, kind=4)
                      if (hdf_vars_avail(i)) call get_data_from_cg(hdf_vars(i), cg, data_dbl)
                      if (.not.hdf_vars_avail(i)) cycle
-                     call MPI_Send(data_dbl(1,1,1), size(data_dbl), MPI_DOUBLE_PRECISION, FIRST, ncg + cg_desc%tot_cg_n*i, comm, mpi_err)
+                     call MPI_Send(data_dbl(1,1,1), size(data_dbl, kind=4), MPI_DOUBLE_PRECISION, FIRST, ncg + cg_desc%tot_cg_n*i, comm, mpi_err)
                   enddo
                endif
             endif
@@ -636,14 +637,14 @@ contains
             cgl => leaves%first
             do while (associated(cgl))
                call ppp_main%start(wrdc1p_label, PPP_IO + PPP_CG)
-               n = n + 1
+               n = n + I_ONE
                ncg = cg_desc%offsets(proc) + n
                dims(:) = [ cg_all_n_b(xdim, ncg), cg_all_n_b(ydim, ncg), cg_all_n_b(zdim, ncg) ]
                call recycle_data(dims, cg_all_n_b, ncg, data_dbl)
                cg => cgl%cg
 
                ip = lbound(hdf_vars,1) - 1
-               do i = lbound(hdf_vars,1), ubound(hdf_vars,1)
+               do i = lbound(hdf_vars,1, kind=4), ubound(hdf_vars,1, kind=4)
                   if (.not.hdf_vars_avail(i)) cycle
                   ip = ip + 1
                   call get_data_from_cg(hdf_vars(i), cg, data_dbl)
@@ -676,10 +677,10 @@ contains
             ! empty memoryspace
             call h5sselect_none_f(memspace_id, error)
 
-            call recycle_data(dims, cg_all_n_b, 1, data_dbl)
-            do ncg = 1, maxval(cg_n)-n
+            call recycle_data(dims, cg_all_n_b, I_ONE, data_dbl)
+            do ncg = I_ONE, maxval(cg_n)-n
                ip = lbound(hdf_vars,1) - 1
-               do i = lbound(hdf_vars, 1), ubound(hdf_vars, 1)
+               do i = lbound(hdf_vars, 1, kind=4), ubound(hdf_vars, 1, kind=4)
                   if (.not.hdf_vars_avail(i)) cycle
                   ip = ip + 1
                   ! It is crashing due to FPE when there are more processes than blocks
@@ -719,7 +720,7 @@ contains
 
       call ppp_main%stop(wrdc_label, PPP_IO)
 
-      if (.false.) i = size(cg_all_n_o) ! suppress compiler warning
+      if (.false.) i = size(cg_all_n_o, kind=4) ! suppress compiler warning
 
       contains
          !>
@@ -731,7 +732,7 @@ contains
             implicit none
             integer(HSIZE_T), dimension(:)                          :: dims        !< shape of current cg
             integer(kind=4), dimension(:,:), pointer, intent(in)    :: cg_all_n_b  !< all cg sizes
-            integer,                                  intent(in)    :: i           !< no. of cg
+            integer(kind=4),                          intent(in)    :: i           !< no. of cg
             real, dimension(:,:,:), pointer,          intent(inout) :: data        !< temporary storage array used for I/O
 
             if (associated(data)) then

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -851,7 +851,11 @@ contains
       ! Setup file access property list with parallel I/O access.
       !
       call h5pcreate_f(H5P_FILE_ACCESS_F, plist_idf, error)
+#ifdef MPIF08
+      call h5pset_fapl_mpio_f(plist_idf, comm%mpi_val, MPI_INFO_NULL%mpi_val, error)
+#else /* !MPIF08 */
       call h5pset_fapl_mpio_f(plist_idf, comm, MPI_INFO_NULL, error)
+#endif /* !MPIF08 */
       !
       ! Create the file collectively.
       !

--- a/src/IO/hdf5/helpers_hdf5.F90
+++ b/src/IO/hdf5/helpers_hdf5.F90
@@ -83,7 +83,7 @@ contains
       character(len=*),     intent(in)           :: fname   !< Filename
       integer(HID_T),       intent(inout)        :: f_id    !< File id
       integer(kind=SIZE_T), intent(in), optional :: incr    !< \copydoc helpers_hdf5::default_increment
-      logical,              intent(in), optional :: bstore  !< \copydoc helpers_hdf5::default_backing_store
+      logical(kind=4),      intent(in), optional :: bstore  !< \copydoc helpers_hdf5::default_backing_store
 
       integer(hid_t)                             :: faplist_id
       integer(kind=SIZE_T)                       :: increment

--- a/src/IO/hdf5/restart_hdf5_v1.F90
+++ b/src/IO/hdf5/restart_hdf5_v1.F90
@@ -138,7 +138,7 @@ contains
 
       use constants,        only: cwdlen
       use hdf5,             only: HID_T, H5P_FILE_ACCESS_F, H5F_ACC_RDWR_F, h5open_f, h5close_f, h5fopen_f, h5fclose_f, h5pcreate_f, h5pclose_f, h5pset_fapl_mpio_f
-      use mpi,              only: MPI_INFO_NULL
+      use MPIF,             only: MPI_INFO_NULL
       use mpisetup,         only: comm
       use named_array_list, only: qna, wna
 
@@ -476,7 +476,7 @@ contains
            &                      h5open_f, h5pcreate_f, h5pset_fapl_mpio_f, h5fopen_f, h5pclose_f, h5fclose_f, h5close_f
       use h5lt,             only: h5ltget_attribute_double_f, h5ltget_attribute_int_f, h5ltget_attribute_string_f
       use mass_defect,      only: magic_mass
-      use mpi,              only: MPI_INFO_NULL
+      use MPIF,             only: MPI_INFO_NULL
       use mpisetup,         only: comm, master, piernik_MPI_Bcast, ibuff, rbuff, cbuff, slave
       use named_array_list, only: qna, wna
       use timestep_pub,     only: c_all_old, cfl_c, stepcfl

--- a/src/IO/hdf5/restart_hdf5_v1.F90
+++ b/src/IO/hdf5/restart_hdf5_v1.F90
@@ -153,7 +153,11 @@ contains
       ! Set up a new HDF5 file for parallel write
       call h5open_f(error)
       call h5pcreate_f(H5P_FILE_ACCESS_F, plist_id, error)
+#ifdef MPIF08
+      call h5pset_fapl_mpio_f(plist_id, comm%mpi_val, MPI_INFO_NULL%mpi_val, error)
+#else /* !MPIF08 */
       call h5pset_fapl_mpio_f(plist_id, comm, MPI_INFO_NULL, error)
+#endif /* !MPIF08 */
       call h5fopen_f(filename, H5F_ACC_RDWR_F, file_id, error, access_prp = plist_id)
 
       ! Write scalar fields that were declared to be required on restart
@@ -571,7 +575,11 @@ contains
       endif
 
       call h5pcreate_f(H5P_FILE_ACCESS_F, plist_id, error)
+#ifdef MPIF08
+      call h5pset_fapl_mpio_f(plist_id, comm%mpi_val, MPI_INFO_NULL%mpi_val, error)
+#else /* !MPIF08 */
       call h5pset_fapl_mpio_f(plist_id, comm, MPI_INFO_NULL, error)
+#endif /* !MPIF08 */
 
       call h5fopen_f(trim(filename), H5F_ACC_RDONLY_F, file_id, error, access_prp = plist_id)
       call h5pclose_f(plist_id, error)

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -191,7 +191,7 @@ contains
       use dataio_pub,       only: die, nproc_io, can_i_write
       use grid_cont,        only: grid_container
       use hdf5,             only: HID_T, HSIZE_T, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
-      use mpi,              only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
       use mpisetup,         only: master, FIRST, proc, comm, mpi_err
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -191,7 +191,7 @@ contains
       use dataio_pub,       only: die, nproc_io, can_i_write
       use grid_cont,        only: grid_container
       use hdf5,             only: HID_T, HSIZE_T, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_Recv, MPI_Send
       use mpisetup,         only: master, FIRST, proc, comm, mpi_err
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main
@@ -210,7 +210,8 @@ contains
       integer(HSIZE_T), dimension(:), allocatable           :: dims
       real, pointer,    dimension(:,:,:)                    :: pa3d
       real, pointer,    dimension(:,:,:,:)                  :: pa4d
-      integer                                               :: i, ncg, tot_lst_n, ic, n
+      integer                                               :: tot_lst_n, ic
+      integer(kind=4)                                       :: ncg, n, i
       type(grid_container),  pointer                        :: cg
       type(cg_list_element), pointer                        :: cgl
       integer, allocatable, dimension(:)                    :: qr_lst, wr_lst
@@ -229,13 +230,13 @@ contains
       allocate(dsets(tot_lst_n))
       ic = 1
       if (size(qr_lst) > 0) then
-         do i = lbound(qr_lst, dim=1), ubound(qr_lst, dim=1)
+         do i = lbound(qr_lst, dim=1, kind=4), ubound(qr_lst, dim=1, kind=4)
             dsets(ic) = trim(qna%lst(qr_lst(i))%name)
             ic = ic + 1
          enddo
       endif
       if (size(wr_lst) > 0) then
-         do i = lbound(wr_lst, dim=1), ubound(wr_lst, dim=1)
+         do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
             dsets(ic) = trim(wna%lst(wr_lst(i))%name)
             ic = ic + 1
          enddo
@@ -252,7 +253,7 @@ contains
 
                if (size(qr_lst) > 0) then
                   allocate(dims(rank3))
-                  do i = lbound(qr_lst, dim=1), ubound(qr_lst, dim=1)
+                  do i = lbound(qr_lst, dim=1, kind=4), ubound(qr_lst, dim=1, kind=4)
                      if (cg_desc%cg_src_p(ncg) == proc) then
                         cg => get_nth_cg(cg_desc%cg_src_n(ncg))
                         pa3d => cg%q(qr_lst(i))%span(pick_area(cg, qna%lst(qr_lst(i))%restart_mode))
@@ -260,7 +261,7 @@ contains
                      else
                         n_b = pick_size(ncg, qna%lst(qr_lst(i))%restart_mode)
                         allocate(pa3d(n_b(xdim), n_b(ydim), n_b(zdim)))
-                        call MPI_Recv(pa3d(:,:,:), size(pa3d(:,:,:)), MPI_DOUBLE_PRECISION, cg_desc%cg_src_p(ncg), ncg + cg_desc%tot_cg_n*i, comm, MPI_STATUS_IGNORE, mpi_err)
+                        call MPI_Recv(pa3d(:,:,:), size(pa3d(:,:,:), kind=4), MPI_DOUBLE_PRECISION, cg_desc%cg_src_p(ncg), ncg + cg_desc%tot_cg_n*i, comm, MPI_STATUS_IGNORE, mpi_err)
                         dims(:) = shape(pa3d)
                      endif
                      call h5dwrite_f(cg_desc%dset_id(ncg, i), H5T_NATIVE_DOUBLE, pa3d, dims, error, xfer_prp = cg_desc%xfer_prp)
@@ -271,7 +272,7 @@ contains
 
                if (size(wr_lst) > 0) then
                   allocate(dims(rank4))
-                  do i = lbound(wr_lst, dim=1), ubound(wr_lst, dim=1)
+                  do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
                      if (cg_desc%cg_src_p(ncg) == proc) then
                         cg => get_nth_cg(cg_desc%cg_src_n(ncg))
                         pa4d => cg%w(wr_lst(i))%span(pick_area(cg, wna%lst(wr_lst(i))%restart_mode))
@@ -279,8 +280,8 @@ contains
                      else
                         n_b = pick_size(ncg, wna%lst(wr_lst(i))%restart_mode)
                         allocate(pa4d(wna%lst(wr_lst(i))%dim4, n_b(xdim), n_b(ydim), n_b(zdim)))
-                        call MPI_Recv(pa4d(:,:,:,:), size(pa4d(:,:,:,:)), MPI_DOUBLE_PRECISION, cg_desc%cg_src_p(ncg), &
-                           ncg + cg_desc%tot_cg_n*(size(qr_lst)+i), comm, MPI_STATUS_IGNORE, mpi_err)
+                        call MPI_Recv(pa4d(:,:,:,:), size(pa4d(:,:,:,:), kind=4), MPI_DOUBLE_PRECISION, cg_desc%cg_src_p(ncg), &
+                           ncg + cg_desc%tot_cg_n*(size(qr_lst, kind=4)+i), comm, MPI_STATUS_IGNORE, mpi_err)
                         dims(:) = shape(pa4d)
                      endif
                      call h5dwrite_f(cg_desc%dset_id(ncg, i+size(qr_lst)), H5T_NATIVE_DOUBLE, pa4d, dims, error, xfer_prp = cg_desc%xfer_prp)
@@ -293,15 +294,15 @@ contains
                if (cg_desc%cg_src_p(ncg) == proc) then
                   cg => get_nth_cg(cg_desc%cg_src_n(ncg))
                   if (size(qr_lst) > 0) then
-                     do i = lbound(qr_lst, dim=1), ubound(qr_lst, dim=1)
+                     do i = lbound(qr_lst, dim=1, kind=4), ubound(qr_lst, dim=1, kind=4)
                         pa3d => cg%q(qr_lst(i))%span(pick_area(cg, qna%lst(qr_lst(i))%restart_mode))
-                        call MPI_Send(pa3d(:,:,:), size(pa3d(:,:,:)), MPI_DOUBLE_PRECISION, FIRST, ncg + cg_desc%tot_cg_n*i, comm, mpi_err)
+                        call MPI_Send(pa3d(:,:,:), size(pa3d(:,:,:), kind=4), MPI_DOUBLE_PRECISION, FIRST, ncg + cg_desc%tot_cg_n*i, comm, mpi_err)
                      enddo
                   endif
                   if (size(wr_lst) > 0) then
-                     do i = lbound(wr_lst, dim=1), ubound(wr_lst, dim=1)
+                     do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
                         pa4d => cg%w(wr_lst(i))%span(pick_area(cg, wna%lst(wr_lst(i))%restart_mode))
-                        call MPI_Send(pa4d(:,:,:,:), size(pa4d(:,:,:,:)), MPI_DOUBLE_PRECISION, FIRST, ncg + cg_desc%tot_cg_n*(size(qr_lst)+i), comm, mpi_err)
+                        call MPI_Send(pa4d(:,:,:,:), size(pa4d(:,:,:,:), kind=4), MPI_DOUBLE_PRECISION, FIRST, ncg + cg_desc%tot_cg_n*(size(qr_lst, kind=4)+i), comm, mpi_err)
                      enddo
                   endif
                endif
@@ -316,14 +317,14 @@ contains
             cgl => leaves%first
             do while (associated(cgl))
                call ppp_main%start(wrcg1p_label, PPP_IO + PPP_CG)
-               n = n + 1
+               n = n + I_ONE
                ncg = cg_desc%offsets(proc) + n
                cg => cgl%cg
                ic = 0
                if (size(qr_lst) > 0) then
                   allocate(dims(rank3))
                   dims(:) = cg%n_b
-                  do i = lbound(qr_lst, dim=1), ubound(qr_lst, dim=1)
+                  do i = lbound(qr_lst, dim=1, kind=4), ubound(qr_lst, dim=1, kind=4)
                      ic = ic + 1
                      pa3d => cg%q(qr_lst(i))%span(pick_area(cg, qna%lst(qr_lst(i))%restart_mode))
                      dims(:) = pick_dims(cg, qna%lst(qr_lst(i))%restart_mode)
@@ -333,7 +334,7 @@ contains
                endif
                if (size(wr_lst) > 0) then
                   allocate(dims(rank4))
-                  do i = lbound(wr_lst, dim=1), ubound(wr_lst, dim=1)
+                  do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
                      ic = ic + 1
                      pa4d => cg%w(wr_lst(i))%span(pick_area(cg, wna%lst(wr_lst(i))%restart_mode))
                      dims(:) = [ wna%lst(wr_lst(i))%dim4, pick_dims(cg, wna%lst(wr_lst(i))%restart_mode) ]
@@ -346,7 +347,7 @@ contains
             enddo
 
             ! Parallel HDF calls have to be matched on each process, so we're doing some calls on non-existing data here.
-            do ncg = 1, maxval(cg_n)-n
+            do ncg = I_ONE, maxval(cg_n)-n
                ic = 0
                if (size(qr_lst) > 0) then
                   allocate(dims(rank3))
@@ -356,7 +357,7 @@ contains
                   call h5screate_simple_f(rank3, dims, memspace_id, error)
                   call h5sselect_none_f(memspace_id, error)   ! empty memoryscape
 
-                  do i = lbound(qr_lst, dim=1), ubound(qr_lst, dim=1)
+                  do i = lbound(qr_lst, dim=1, kind=4), ubound(qr_lst, dim=1, kind=4)
                      ic = ic + 1
                      pa3d => null_r3d
                      dims(:) = 0
@@ -369,7 +370,7 @@ contains
                endif
                if (size(wr_lst) > 0) then
                   allocate(dims(rank4))
-                  do i = lbound(wr_lst, dim=1), ubound(wr_lst, dim=1)
+                  do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
                      ic = ic + 1
                      dims(:) = 0
                      ! dims can change so h5s* is here as well, I don't know it
@@ -456,7 +457,7 @@ contains
 
          implicit none
 
-         integer,         intent(in) :: ncg
+         integer(kind=4), intent(in) :: ncg
          integer(kind=4), intent(in) :: mode
 
          integer(kind=4), dimension(ndims) :: n_b
@@ -547,7 +548,8 @@ contains
       integer(HID_T)                                    :: doml_g_id, dom_g_id  !< domain list and domain group identifiers
       integer(HID_T)                                    :: cgl_g_id,  cg_g_id   !< cg list and cg group identifiers
       logical                                           :: file_exist, outside, overlapped
-      integer                                           :: ia, j
+      integer                                           :: j
+      integer(kind=4)                                   :: ia
       integer(kind=8)                                   :: tot_cells
       integer(kind=8), dimension(xdim:zdim, LO:HI)      :: my_box, other_box
       integer(kind=4)                                   :: error, nres_old
@@ -751,7 +753,7 @@ contains
       allocate(cg_res(ibuf(1)))
       deallocate(ibuf)
 
-      do ia = lbound(cg_res, dim=1), ubound(cg_res, dim=1)
+      do ia = lbound(cg_res, dim=1, kind=4), ubound(cg_res, dim=1, kind=4)
          call h5gopen_f(cgl_g_id, n_cg_name(ia), cg_g_id, error) ! open "/data/grid_%08d, ia"
 
          allocate(ibuf(1))
@@ -776,7 +778,7 @@ contains
       tot_cells = 0
       outside = .false.
       overlapped = .false.
-      do ia = lbound(cg_res, dim=1), ubound(cg_res, dim=1)
+      do ia = lbound(cg_res, dim=1, kind=4), ubound(cg_res, dim=1, kind=4)
          if (cg_res(ia)%level == base%level%l%id) then
             tot_cells = tot_cells + product(cg_res(ia)%n_b(:))
             my_box(:,LO) = cg_res(ia)%off(:)
@@ -814,7 +816,7 @@ contains
 
       call ppp_main%start(rdrc_label, PPP_IO)
       ! On each process determine which parts of the restart cg have to be read and where
-      do ia = lbound(cg_res, dim=1), ubound(cg_res, dim=1)
+      do ia = lbound(cg_res, dim=1, kind=4), ubound(cg_res, dim=1, kind=4)
          my_box(:,LO) = cg_res(ia)%off(:)
          my_box(:,HI) = cg_res(ia)%off(:) + cg_res(ia)%n_b(:) - 1
          curl => base%level
@@ -928,7 +930,7 @@ contains
 
       type(grid_container), pointer,     intent(inout) :: cg        !< Own grid container
       integer(HID_T),                    intent(in)    :: cgl_g_id  !< cg group identifier in the restart file
-      integer,                           intent(in)    :: ncg       !< number of cg in the restart file
+      integer(kind=4),                   intent(in)    :: ncg       !< number of cg in the restart file
       type(cg_essentials),               intent(in)    :: cg_r      !< cg attributes that do not need to be reread
 
       integer(HID_T)                               :: cg_g_id !< cg group identifier
@@ -980,7 +982,7 @@ contains
 
       if (size(qr_lst) > 0) then
          allocate(dims(ndims), off(ndims), cnt(ndims))
-         do i = lbound(qr_lst, dim=1), ubound(qr_lst, dim=1)
+         do i = lbound(qr_lst, dim=1, kind=4), ubound(qr_lst, dim=1, kind=4)
             call pick_off_and_size(qna%lst(qr_lst(i))%restart_mode, o_size, restart_off, own_off)
             dims(:) = o_size(:)
             call h5dopen_f(cg_g_id, qna%lst(qr_lst(i))%name, dset_id, error) ! open "/data/grid_%08d/cg%q(qr_lst(i))%name"
@@ -1002,7 +1004,7 @@ contains
 
       if (size(wr_lst) > 0) then
          allocate(dims(ndims+1), off(ndims+1), cnt(ndims+1))
-         do i = lbound(wr_lst, dim=1), ubound(wr_lst, dim=1)
+         do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
             call pick_off_and_size(wna%lst(wr_lst(i))%restart_mode, o_size, restart_off, own_off)
             dims(:) = [ int(wna%lst(wr_lst(i))%dim4, kind=HSIZE_T), int(o_size(:), kind=HSIZE_T) ]
             call h5dopen_f(cg_g_id, wna%lst(wr_lst(i))%name, dset_id, error)

--- a/src/base/cmp_1D_mpi.F90
+++ b/src/base/cmp_1D_mpi.F90
@@ -62,7 +62,7 @@ contains
       use constants,  only: I_ONE
       use dataio_pub, only: die
       use func,       only: operator(.notequals.)
-      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
+      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_Send, MPI_Recv
       use mpisetup,   only: slave, LAST, comm, proc, mpi_err
 
       implicit none
@@ -86,7 +86,7 @@ contains
 
       use constants,  only: I_ONE
       use dataio_pub, only: die
-      use MPIF,       only: MPI_INTEGER, MPI_STATUS_IGNORE
+      use MPIF,       only: MPI_INTEGER, MPI_STATUS_IGNORE, MPI_Send, MPI_Recv
       use mpisetup,   only: slave, LAST, comm, proc, mpi_err
 
       implicit none
@@ -110,7 +110,7 @@ contains
 
       use constants,  only: I_ONE
       use dataio_pub, only: die
-      use MPIF,       only: MPI_CHARACTER, MPI_STATUS_IGNORE
+      use MPIF,       only: MPI_CHARACTER, MPI_STATUS_IGNORE, MPI_Send, MPI_Recv
       use mpisetup,   only: slave, LAST, comm, proc, mpi_err
 
       implicit none

--- a/src/base/cmp_1D_mpi.F90
+++ b/src/base/cmp_1D_mpi.F90
@@ -62,7 +62,7 @@ contains
       use constants,  only: I_ONE
       use dataio_pub, only: die
       use func,       only: operator(.notequals.)
-      use mpi,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
+      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE
       use mpisetup,   only: slave, LAST, comm, proc, mpi_err
 
       implicit none
@@ -86,7 +86,7 @@ contains
 
       use constants,  only: I_ONE
       use dataio_pub, only: die
-      use mpi,        only: MPI_INTEGER, MPI_STATUS_IGNORE
+      use MPIF,       only: MPI_INTEGER, MPI_STATUS_IGNORE
       use mpisetup,   only: slave, LAST, comm, proc, mpi_err
 
       implicit none
@@ -110,7 +110,7 @@ contains
 
       use constants,  only: I_ONE
       use dataio_pub, only: die
-      use mpi,        only: MPI_CHARACTER, MPI_STATUS_IGNORE
+      use MPIF,       only: MPI_CHARACTER, MPI_STATUS_IGNORE
       use mpisetup,   only: slave, LAST, comm, proc, mpi_err
 
       implicit none

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -117,16 +117,16 @@ module constants
    end enum
 
    ! string lengths
-   integer, parameter :: cwdlen = 512                    !< allow for quite long CWD
-   integer, parameter :: fmt_len = 128                   !< length of format string
-   integer, parameter :: fnamelen = 128                  !< length of output filename
-   integer, parameter :: cbuff_len = 32                  !< length for problem parameters
-   integer, parameter :: units_len = 5 * cbuff_len       !< length for unit strings
-   integer, parameter :: fplen = 24                      !< length of buffer for printed FP or integer number
-   integer, parameter :: domlen = 16                     !< should be <= cbuff_len
-   integer, parameter :: dsetnamelen = cbuff_len         !< length of dataset name and state variable names in hdf files
-   integer, parameter :: idlen = 3                       !< COMMENT ME
-   integer, parameter :: singlechar = 1                  !< a single character
+   integer(kind=4), parameter :: cwdlen = 512               !< allow for quite long CWD
+   integer(kind=4), parameter :: fmt_len = 128              !< length of format string
+   integer(kind=4), parameter :: fnamelen = 128             !< length of output filename
+   integer(kind=4), parameter :: cbuff_len = 32             !< length for problem parameters
+   integer(kind=4), parameter :: units_len = 5 * cbuff_len  !< length for unit strings
+   integer(kind=4), parameter :: fplen = 24                 !< length of buffer for printed FP or integer number
+   integer(kind=4), parameter :: domlen = 16                !< should be <= cbuff_len
+   integer(kind=4), parameter :: dsetnamelen = cbuff_len    !< length of dataset name and state variable names in hdf files
+   integer(kind=4), parameter :: idlen = 3                  !< COMMENT ME
+   integer(kind=4), parameter :: singlechar = 1             !< a single character
 
    ! simulation state
    enum, bind(C)

--- a/src/base/mass_defect.F90
+++ b/src/base/mass_defect.F90
@@ -62,7 +62,7 @@ contains
    subroutine update_magic_mass
 
       use fluidindex,  only: flind
-      use mpi,         only: MPI_DOUBLE_PRECISION, MPI_SUM
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_SUM
       use mpisetup,    only: comm, mpi_err, FIRST, master
 
       implicit none

--- a/src/base/mass_defect.F90
+++ b/src/base/mass_defect.F90
@@ -62,7 +62,7 @@ contains
    subroutine update_magic_mass
 
       use fluidindex,  only: flind
-      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_SUM
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_Reduce
       use mpisetup,    only: comm, mpi_err, FIRST, master
 
       implicit none

--- a/src/base/mpi_pub.F90
+++ b/src/base/mpi_pub.F90
@@ -53,7 +53,7 @@ module mpi_pub
 contains
 
    subroutine mpi_container(this)
-      use mpi, only: MPI_COMM_WORLD, MPI_LOGICAL, MPI_CHARACTER
+      use MPIF, only: MPI_COMM_WORLD, MPI_LOGICAL, MPI_CHARACTER
 
       implicit none
 
@@ -73,7 +73,7 @@ contains
       contains
 
          function get_mpi_type(dummy) result (mpi_type)
-            use mpi, only: MPI_REAL, MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_INTEGER8
+            use MPIF, only: MPI_REAL, MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_INTEGER8
 
             implicit none
             class(*), pointer :: dummy

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -147,7 +147,7 @@ contains
 
       implicit none
 
-      integer, parameter :: hnlen = 32             !< hostname length limit
+      integer(kind=4), parameter :: hnlen = 32             !< hostname length limit
       character(len=cwdlen) :: cwd_proc
       character(len=hnlen)  :: host_proc
       integer(kind=4)       :: pid_proc
@@ -258,7 +258,7 @@ contains
 
       implicit none
 
-      integer, intent(in) :: nreq !< expected maximum number of concurrent MPI requests in non-blocking parts of the code
+      integer(kind=4), intent(in) :: nreq !< expected maximum number of concurrent MPI requests in non-blocking parts of the code
 
       integer :: sreq
 
@@ -396,7 +396,7 @@ contains
 
       logical, dimension(:), intent(inout) :: lvar   !< logical scalar that will be broadcasted
 
-      call MPI_Bcast(lvar, size(lvar), MPI_LOGICAL, FIRST, comm, mpi_err)
+      call MPI_Bcast(lvar, size(lvar, kind=4), MPI_LOGICAL, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_vec_logical
 !-----------------------------------------------------------------------------
@@ -412,7 +412,7 @@ contains
       implicit none
 
       character(len=*), intent(inout) :: cvar   !< string that will be broadcasted
-      integer,          intent(in)    :: clen   !< length of the cvar
+      integer(kind=4),  intent(in)    :: clen   !< length of the cvar
 
       call MPI_Bcast(cvar, clen, MPI_CHARACTER, FIRST, comm, mpi_err)
 
@@ -430,9 +430,9 @@ contains
       implicit none
 
       character(len=*), dimension(:), intent(inout) :: cvar   !< vector of strings that will be broadcasted
-      integer,                        intent(in)    :: clen   !< length of the cvar
+      integer(kind=4),                intent(in)    :: clen   !< length of the cvar
 
-      call MPI_Bcast(cvar, clen*size(cvar), MPI_CHARACTER, FIRST, comm, mpi_err)
+      call MPI_Bcast(cvar, clen*size(cvar, kind=4), MPI_CHARACTER, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_vec_string
 !-----------------------------------------------------------------------------
@@ -521,7 +521,7 @@ contains
 
       real(kind=4), dimension(:), intent(inout) :: rvar4   !< real4 vector that will be broadcasted
 
-      call MPI_Bcast(rvar4, size(rvar4), MPI_REAL, FIRST, comm, mpi_err)
+      call MPI_Bcast(rvar4, size(rvar4, kind=4), MPI_REAL, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_vec_real4
 !-----------------------------------------------------------------------------
@@ -538,7 +538,7 @@ contains
 
       real(kind=8), dimension(:), intent(inout) :: rvar8   !< real8 vector that will be broadcasted
 
-      call MPI_Bcast(rvar8, size(rvar8), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
+      call MPI_Bcast(rvar8, size(rvar8, kind=4), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_vec_real8
 !-----------------------------------------------------------------------------
@@ -555,7 +555,7 @@ contains
 
       integer(kind=4), dimension(:), intent(inout) :: ivar4   !< int4 vector that will be broadcasted
 
-      call MPI_Bcast(ivar4, size(ivar4), MPI_INTEGER, FIRST, comm, mpi_err)
+      call MPI_Bcast(ivar4, size(ivar4, kind=4), MPI_INTEGER, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_vec_int4
 !-----------------------------------------------------------------------------
@@ -572,7 +572,7 @@ contains
 
       integer(kind=8), dimension(:), intent(inout) :: ivar8   !< int8 vector that will be broadcasted
 
-      call MPI_Bcast(ivar8, size(ivar8), MPI_INTEGER8, FIRST, comm, mpi_err)
+      call MPI_Bcast(ivar8, size(ivar8, kind=4), MPI_INTEGER8, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_vec_int8
 !-----------------------------------------------------------------------------
@@ -589,7 +589,7 @@ contains
 
       real(kind=4), dimension(:,:), intent(inout) :: rvar4   !< real4 arr2d that will be broadcasted
 
-      call MPI_Bcast(rvar4, size(rvar4), MPI_REAL, FIRST, comm, mpi_err)
+      call MPI_Bcast(rvar4, size(rvar4, kind=4), MPI_REAL, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr2d_real4
 !-----------------------------------------------------------------------------
@@ -606,7 +606,7 @@ contains
 
       real(kind=8), dimension(:,:), intent(inout) :: rvar8   !< real8 arr2d that will be broadcasted
 
-      call MPI_Bcast(rvar8, size(rvar8), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
+      call MPI_Bcast(rvar8, size(rvar8, kind=4), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr2d_real8
 !-----------------------------------------------------------------------------
@@ -623,7 +623,7 @@ contains
 
       integer(kind=4), dimension(:, :), intent(inout) :: ivar4   !< int4 arr2d that will be broadcasted
 
-      call MPI_Bcast(ivar4, size(ivar4), MPI_INTEGER, FIRST, comm, mpi_err)
+      call MPI_Bcast(ivar4, size(ivar4, kind=4), MPI_INTEGER, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr2d_int4
 !-----------------------------------------------------------------------------
@@ -640,7 +640,7 @@ contains
 
       integer(kind=8), dimension(:,:), intent(inout) :: ivar8   !< int8 arr2d that will be broadcasted
 
-      call MPI_Bcast(ivar8, size(ivar8), MPI_INTEGER8, FIRST, comm, mpi_err)
+      call MPI_Bcast(ivar8, size(ivar8, kind=4), MPI_INTEGER8, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr2d_int8
 !-----------------------------------------------------------------------------
@@ -657,7 +657,7 @@ contains
 
       real(kind=4), dimension(:,:,:), intent(inout) :: rvar4   !< real4 arr3d that will be broadcasted
 
-      call MPI_Bcast(rvar4, size(rvar4), MPI_REAL, FIRST, comm, mpi_err)
+      call MPI_Bcast(rvar4, size(rvar4, kind=4), MPI_REAL, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr3d_real4
 !-----------------------------------------------------------------------------
@@ -674,7 +674,7 @@ contains
 
       real(kind=8), dimension(:,:,:), intent(inout) :: rvar8   !< real8 arr3d that will be broadcasted
 
-      call MPI_Bcast(rvar8, size(rvar8), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
+      call MPI_Bcast(rvar8, size(rvar8, kind=4), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr3d_real8
 !-----------------------------------------------------------------------------
@@ -691,7 +691,7 @@ contains
 
       integer(kind=4), dimension(:,:, :), intent(inout) :: ivar4   !< int4 arr3d that will be broadcasted
 
-      call MPI_Bcast(ivar4, size(ivar4), MPI_INTEGER, FIRST, comm, mpi_err)
+      call MPI_Bcast(ivar4, size(ivar4, kind=4), MPI_INTEGER, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr3d_int4
 !-----------------------------------------------------------------------------
@@ -708,7 +708,7 @@ contains
 
       integer(kind=8), dimension(:,:,:), intent(inout) :: ivar8   !< int8 arr3d that will be broadcasted
 
-      call MPI_Bcast(ivar8, size(ivar8), MPI_INTEGER8, FIRST, comm, mpi_err)
+      call MPI_Bcast(ivar8, size(ivar8, kind=4), MPI_INTEGER8, FIRST, comm, mpi_err)
 
    end subroutine MPI_Bcast_arr3d_int8
 !-----------------------------------------------------------------------------
@@ -731,7 +731,7 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pLOR:pLAND), parameter :: mpiop = [MPI_LOR, MPI_LAND]
 #else /* !MPIF08 */
-      integer, dimension(pLOR:pLAND), parameter :: mpiop = [MPI_LOR, MPI_LAND]
+      integer(kind=4), dimension(pLOR:pLAND), parameter :: mpiop = [MPI_LOR, MPI_LAND]
 #endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, lvar, I_ONE, MPI_LOGICAL, mpiop(reduction), comm, mpi_err)
@@ -757,7 +757,7 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, ivar4, I_ONE, MPI_INTEGER, mpiop(reduction), comm, mpi_err)
@@ -783,7 +783,7 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, ivar8, I_ONE, MPI_INTEGER8, mpiop(reduction), comm, mpi_err)
@@ -809,10 +809,10 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter     :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter     :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
-      call MPI_Allreduce(MPI_IN_PLACE, ivar4, size(ivar4), MPI_INTEGER, mpiop(reduction), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, ivar4, size(ivar4, kind=4), MPI_INTEGER, mpiop(reduction), comm, mpi_err)
 
    end subroutine MPI_Allreduce_vec_int4
 !-----------------------------------------------------------------------------
@@ -835,10 +835,10 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter     :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter     :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
-      call MPI_Allreduce(MPI_IN_PLACE, ivar8, size(ivar8), MPI_INTEGER8, mpiop(reduction), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, ivar8, size(ivar8, kind=4), MPI_INTEGER8, mpiop(reduction), comm, mpi_err)
 
    end subroutine MPI_Allreduce_vec_int8
 !-----------------------------------------------------------------------------
@@ -861,7 +861,7 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar4, I_ONE, MPI_REAL, mpiop(reduction), comm, mpi_err)
@@ -887,7 +887,7 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar8, I_ONE, MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
@@ -913,10 +913,10 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter  :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter  :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
-      call MPI_Allreduce(MPI_IN_PLACE, rvar4, size(rvar4), MPI_REAL, mpiop(reduction), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, rvar4, size(rvar4, kind=4), MPI_REAL, mpiop(reduction), comm, mpi_err)
 
    end subroutine MPI_Allreduce_vec_real4
 !-----------------------------------------------------------------------------
@@ -939,10 +939,10 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter  :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter  :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
-      call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8, kind=4), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
 
    end subroutine MPI_Allreduce_vec_real8
 !-----------------------------------------------------------------------------
@@ -965,10 +965,10 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter      :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter      :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
-      call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8, kind=4), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
 
    end subroutine MPI_Allreduce_arr3d_real8
 !-----------------------------------------------------------------------------
@@ -991,10 +991,10 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter    :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter    :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
-      call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8, kind=4), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
 
    end subroutine MPI_Allreduce_arr2d_real8
 !-----------------------------------------------------------------------------
@@ -1017,10 +1017,10 @@ contains
 #ifdef MPIF08
       type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #else /* !MPIF08 */
-      integer, dimension(pSUM:pMAX), parameter    :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+      integer(kind=4), dimension(pSUM:pMAX), parameter    :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
 #endif /* !MPIF08 */
 
-      call MPI_Allreduce(MPI_IN_PLACE, rvar4, size(rvar4), MPI_REAL, mpiop(reduction), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, rvar4, size(rvar4, kind=4), MPI_REAL, mpiop(reduction), comm, mpi_err)
 
    end subroutine MPI_Allreduce_arr2d_real4
 !-----------------------------------------------------------------------------
@@ -1040,7 +1040,7 @@ contains
       !! variable lets the slaves skip sending message
       !<
       logical, optional, intent(in) :: only_master
-      integer                       :: tag  !< master scripts accepts ANY_TAG, so it can carry meaningful value too
+      integer(kind=4)               :: tag  !< master scripts accepts ANY_TAG, so it can carry meaningful value too
 
       if (.not.is_spawned) return
 
@@ -1061,7 +1061,7 @@ contains
       implicit none
       character(len=*),  intent(in) :: str
       logical, optional, intent(in) :: only_master
-      integer                       :: tag  !< master scripts accepts ANY_TAG, so it can carry meaningful value too
+      integer(kind=4)               :: tag  !< master scripts accepts ANY_TAG, so it can carry meaningful value too
       integer(kind=4) :: buf
 
       if (.not.is_spawned) return

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -34,6 +34,9 @@
 module mpisetup
 
    use constants, only: cbuff_len, INT4
+#ifdef MPIF08
+   use MPIF, only: MPI_Status, MPI_Comm, MPI_Request
+#endif /* MPIF08 */
 
    implicit none
 
@@ -47,8 +50,6 @@ module mpisetup
    integer(kind=4), protected :: nproc          !< number of processes
    integer(kind=4), protected :: proc           !< rank of my process
    integer(kind=4), protected :: LAST           !< rank of the last process
-   integer(kind=4), protected :: comm           !< global communicator
-   integer(kind=4), protected :: intercomm      !< intercommunicator
    integer(kind=4) :: mpi_err                   !< error status
    integer(kind=INT4), parameter :: FIRST = 0   !< the rank of the master process
    real(kind=8), protected    :: bigbang        !< First result of MPI_Wtime()
@@ -60,8 +61,18 @@ module mpisetup
    logical, protected :: have_mpi    !< .True. when run on more than one processor
    logical, protected :: is_spawned  !< .True. if Piernik was run via MPI_Spawn
 
-   integer(kind=4), allocatable, dimension(:),   target :: req    !< request array for MPI_Waitall
-   integer(kind=4), allocatable, dimension(:,:), target :: status !< status array for MPI_Waitall
+#ifdef MPIF08
+   type(MPI_Request), allocatable, dimension(:), target :: req        !< request array for MPI_Waitall
+   type(MPI_Status), allocatable, dimension(:), target  :: status     !< status array for MPI_Waitall
+   type(MPI_Comm), protected                            :: comm       !< global communicator
+   type(MPI_Comm), protected                            :: intercomm  !< intercommunicator
+#else /* !MPIF08 */
+   integer(kind=4), allocatable, dimension(:),   target :: req        !< request array for MPI_Waitall
+   integer(kind=4), allocatable, dimension(:,:), target :: status     !< status array for MPI_Waitall
+   integer(kind=4), protected                           :: comm       !< global communicator
+   integer(kind=4), protected                           :: intercomm  !< intercommunicator
+#endif /* !MPIF08 */
+
    !> \warning Because we use one centralized req(:) and status(:,:) arrays, the routines that are using them should not call each other to avoid any interference.
    !! If you want nested non-blocking communication, only one set of MPI transactions may use these arrays.
    !< All other sets of communication should define their own req(:) and status(:,:) arrays
@@ -78,6 +89,8 @@ module mpisetup
    end interface
 
    !! \todo expand this wrapper to make it more general, unlimited polymorphism will render this obsolete
+   !! Switching to pure mpi_f08 interface should allow for great simplification of these routines.
+   !! Meanwhile we keep that spaggetti to not break compatibility with systems where only mpi interface is available.
    interface piernik_MPI_Bcast
       module procedure MPI_Bcast_single_logical
       module procedure MPI_Bcast_single_string
@@ -126,7 +139,8 @@ contains
    subroutine init_mpi
 
       use constants,     only: cwdlen, I_ONE, pMIN
-      use mpi,           only: MPI_COMM_WORLD, MPI_CHARACTER, MPI_INTEGER, MPI_COMM_NULL, MPI_Wtime
+      use MPIF,          only: MPI_COMM_WORLD, MPI_CHARACTER, MPI_INTEGER, MPI_COMM_NULL, &
+           &                   MPI_Wtime, MPI_Allreduce, MPI_Gather
       use dataio_pub,    only: die, printinfo, msg, ansi_white, ansi_black, tmp_log_file
       use dataio_pub,    only: par_file, lun
       use signalhandler, only: SIGINT, register_sighandler
@@ -156,7 +170,11 @@ contains
 #endif /* ! __INTEL_COMPILER || __GFORTRAN__ */
 
       call MPI_Comm_get_parent(intercomm, mpi_err)
+#ifdef MPIF08
+      is_spawned = (intercomm%mpi_val /= MPI_COMM_NULL%mpi_val)
+#else /* !MPIF08 */
       is_spawned = (intercomm /= MPI_COMM_NULL)
+#endif /* !MPIF08 */
 
       call MPI_Comm_rank(comm, proc, mpi_err)
       call MPI_Comm_size(comm, nproc, mpi_err)
@@ -234,7 +252,9 @@ contains
 
    subroutine setsize_req(nreq)
 
-      use mpi,        only: MPI_STATUS_SIZE
+#ifndef MPIF08
+      use MPIF, only: MPI_STATUS_SIZE
+#endif /* !MPIF08 */
 
       implicit none
 
@@ -252,7 +272,13 @@ contains
          sreq = 0
       endif
 
-      if (sreq < nreq) allocate(req(nreq), status(MPI_STATUS_SIZE, nreq))
+      if (sreq < nreq) then
+#ifdef MPIF08
+         allocate(req(nreq), status(nreq))
+#else /* !MPIF08 */
+         allocate(req(nreq), status(MPI_STATUS_SIZE, nreq))
+#endif /* !MPIF08 */
+      endif
 
    end subroutine setsize_req
 
@@ -265,13 +291,22 @@ contains
    subroutine doublesize_req
 
       use dataio_pub, only: warn, msg, die
-      use mpi,        only: MPI_STATUS_SIZE
+#ifdef MPIF08
+      use MPIF,       only: MPI_Request
+#else
+      use MPIF,       only: MPI_STATUS_SIZE
+#endif /* !MPIF08 */
 
       implicit none
 
       integer :: sreq
+#ifdef MPIF08
+      type(MPI_Request), allocatable, dimension(:) :: new_req    !< new request array for MPI_Waitall
+      type(MPI_Status), allocatable, dimension(:)  :: new_status !< new status array for MPI_Waitall
+#else /* !MPIF08 */
       integer(kind=4), allocatable, dimension(:)   :: new_req    !< new request array for MPI_Waitall
       integer(kind=4), allocatable, dimension(:,:) :: new_status !< new status array for MPI_Waitall
+#endif /* !MPIF08 */
 
       if (.not. allocated(req)) call die("[mpisetup:doublesize_req] req not allocated")
       sreq = size(req)
@@ -279,9 +314,14 @@ contains
 
       write(msg, '(2(a,i6))')"[mpisetup:doublesize_req] Emergency doubling size of req and status from ",sreq," to ",2*sreq
       if (master) call warn(msg)
+#ifdef MPIF08
+      allocate(new_req(2*sreq), new_status(2*sreq))
+      new_status(1:sreq) = status(:)
+#else /* !MPIF08 */
       allocate(new_req(2*sreq), new_status(MPI_STATUS_SIZE, 2*sreq))
-      new_req(1:sreq) = req(:)
       new_status(:, 1:sreq) = status(:,:)
+#endif /* !MPIF08 */
+      new_req(1:sreq) = req(:)
 
       call move_alloc(from=new_req, to=req)
       call move_alloc(from=new_status, to=status)
@@ -321,6 +361,7 @@ contains
       implicit none
 
       call MPI_Barrier(comm, mpi_err)
+
    end subroutine piernik_MPI_Barrier
 
 !-----------------------------------------------------------------------------
@@ -332,13 +373,14 @@ contains
    subroutine MPI_Bcast_single_logical(lvar)
 
       use constants, only: I_ONE
-      use mpi,       only: MPI_LOGICAL
+      use MPIF,      only: MPI_LOGICAL, MPI_Bcast
 
       implicit none
 
       logical, intent(inout) :: lvar   !< logical scalar that will be broadcasted
 
       call MPI_Bcast(lvar, I_ONE, MPI_LOGICAL, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_single_logical
 !-----------------------------------------------------------------------------
 !>
@@ -348,13 +390,14 @@ contains
 !<
    subroutine MPI_Bcast_vec_logical(lvar)
 
-      use mpi, only: MPI_LOGICAL
+      use MPIF, only: MPI_LOGICAL, MPI_Bcast
 
       implicit none
 
       logical, dimension(:), intent(inout) :: lvar   !< logical scalar that will be broadcasted
 
       call MPI_Bcast(lvar, size(lvar), MPI_LOGICAL, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_vec_logical
 !-----------------------------------------------------------------------------
 !>
@@ -364,7 +407,7 @@ contains
 !<
    subroutine MPI_Bcast_single_string(cvar, clen)
 
-      use mpi, only: MPI_CHARACTER
+      use MPIF, only: MPI_CHARACTER, MPI_Bcast
 
       implicit none
 
@@ -372,6 +415,7 @@ contains
       integer,          intent(in)    :: clen   !< length of the cvar
 
       call MPI_Bcast(cvar, clen, MPI_CHARACTER, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_single_string
 !-----------------------------------------------------------------------------
 !>
@@ -381,7 +425,7 @@ contains
 !<
    subroutine MPI_Bcast_vec_string(cvar, clen)
 
-      use mpi, only: MPI_CHARACTER
+      use MPIF, only: MPI_CHARACTER, MPI_Bcast
 
       implicit none
 
@@ -389,6 +433,7 @@ contains
       integer,                        intent(in)    :: clen   !< length of the cvar
 
       call MPI_Bcast(cvar, clen*size(cvar), MPI_CHARACTER, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_vec_string
 !-----------------------------------------------------------------------------
 !>
@@ -399,13 +444,14 @@ contains
    subroutine MPI_Bcast_single_int4(ivar4)
 
       use constants, only: I_ONE
-      use mpi,       only: MPI_INTEGER
+      use MPIF,      only: MPI_INTEGER, MPI_Bcast
 
       implicit none
 
       integer(kind=4), intent(inout) :: ivar4   !< integer scalar that will be broadcasted
 
       call MPI_Bcast(ivar4, I_ONE, MPI_INTEGER, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_single_int4
 !-----------------------------------------------------------------------------
 !>
@@ -416,13 +462,14 @@ contains
    subroutine MPI_Bcast_single_int8(ivar8)
 
       use constants, only: I_ONE
-      use mpi,       only: MPI_INTEGER8
+      use MPIF,      only: MPI_INTEGER8, MPI_Bcast
 
       implicit none
 
       integer(kind=8), intent(inout) :: ivar8   !< integer scalar that will be broadcasted
 
       call MPI_Bcast(ivar8, I_ONE, MPI_INTEGER8, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_single_int8
 !-----------------------------------------------------------------------------
 !>
@@ -433,13 +480,14 @@ contains
    subroutine MPI_Bcast_single_real4(rvar4)
 
       use constants, only: I_ONE
-      use mpi,       only: MPI_REAL
+      use MPIF,      only: MPI_REAL, MPI_Bcast
 
       implicit none
 
       real(kind=4), intent(inout) :: rvar4   !< integer scalar that will be broadcasted
 
       call MPI_Bcast(rvar4, I_ONE, MPI_REAL, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_single_real4
 !-----------------------------------------------------------------------------
 !>
@@ -450,13 +498,14 @@ contains
    subroutine MPI_Bcast_single_real8(rvar8)
 
       use constants, only: I_ONE
-      use mpi,       only: MPI_DOUBLE_PRECISION
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_Bcast
 
       implicit none
 
       real(kind=8), intent(inout) :: rvar8   !< real scalar that will be broadcasted
 
       call MPI_Bcast(rvar8, I_ONE, MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_single_real8
 !-----------------------------------------------------------------------------
 !>
@@ -466,13 +515,14 @@ contains
 !<
    subroutine MPI_Bcast_vec_real4(rvar4)
 
-      use mpi, only: MPI_REAL
+      use MPIF, only: MPI_REAL, MPI_Bcast
 
       implicit none
 
       real(kind=4), dimension(:), intent(inout) :: rvar4   !< real4 vector that will be broadcasted
 
       call MPI_Bcast(rvar4, size(rvar4), MPI_REAL, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_vec_real4
 !-----------------------------------------------------------------------------
 !>
@@ -482,13 +532,14 @@ contains
 !<
    subroutine MPI_Bcast_vec_real8(rvar8)
 
-      use mpi, only: MPI_DOUBLE_PRECISION
+      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_Bcast
 
       implicit none
 
       real(kind=8), dimension(:), intent(inout) :: rvar8   !< real8 vector that will be broadcasted
 
       call MPI_Bcast(rvar8, size(rvar8), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_vec_real8
 !-----------------------------------------------------------------------------
 !>
@@ -498,13 +549,14 @@ contains
 !<
    subroutine MPI_Bcast_vec_int4(ivar4)
 
-      use mpi, only: MPI_INTEGER
+      use MPIF, only: MPI_INTEGER, MPI_Bcast
 
       implicit none
 
       integer(kind=4), dimension(:), intent(inout) :: ivar4   !< int4 vector that will be broadcasted
 
       call MPI_Bcast(ivar4, size(ivar4), MPI_INTEGER, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_vec_int4
 !-----------------------------------------------------------------------------
 !>
@@ -514,13 +566,14 @@ contains
 !<
    subroutine MPI_Bcast_vec_int8(ivar8)
 
-      use mpi, only: MPI_INTEGER8
+      use MPIF, only: MPI_INTEGER8, MPI_Bcast
 
       implicit none
 
       integer(kind=8), dimension(:), intent(inout) :: ivar8   !< int8 vector that will be broadcasted
 
       call MPI_Bcast(ivar8, size(ivar8), MPI_INTEGER8, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_vec_int8
 !-----------------------------------------------------------------------------
 !>
@@ -530,13 +583,14 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_real4(rvar4)
 
-      use mpi, only: MPI_REAL
+      use MPIF, only: MPI_REAL, MPI_Bcast
 
       implicit none
 
       real(kind=4), dimension(:,:), intent(inout) :: rvar4   !< real4 arr2d that will be broadcasted
 
       call MPI_Bcast(rvar4, size(rvar4), MPI_REAL, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr2d_real4
 !-----------------------------------------------------------------------------
 !>
@@ -546,13 +600,14 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_real8(rvar8)
 
-      use mpi, only: MPI_DOUBLE_PRECISION
+      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_Bcast
 
       implicit none
 
       real(kind=8), dimension(:,:), intent(inout) :: rvar8   !< real8 arr2d that will be broadcasted
 
       call MPI_Bcast(rvar8, size(rvar8), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr2d_real8
 !-----------------------------------------------------------------------------
 !>
@@ -562,13 +617,14 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_int4(ivar4)
 
-      use mpi, only: MPI_INTEGER
+      use MPIF, only: MPI_INTEGER, MPI_Bcast
 
       implicit none
 
       integer(kind=4), dimension(:, :), intent(inout) :: ivar4   !< int4 arr2d that will be broadcasted
 
       call MPI_Bcast(ivar4, size(ivar4), MPI_INTEGER, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr2d_int4
 !-----------------------------------------------------------------------------
 !>
@@ -578,13 +634,14 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_int8(ivar8)
 
-      use mpi, only: MPI_INTEGER8
+      use MPIF, only: MPI_INTEGER8, MPI_Bcast
 
       implicit none
 
       integer(kind=8), dimension(:,:), intent(inout) :: ivar8   !< int8 arr2d that will be broadcasted
 
       call MPI_Bcast(ivar8, size(ivar8), MPI_INTEGER8, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr2d_int8
 !-----------------------------------------------------------------------------
 !>
@@ -594,13 +651,14 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_real4(rvar4)
 
-      use mpi, only: MPI_REAL
+      use MPIF, only: MPI_REAL, MPI_Bcast
 
       implicit none
 
       real(kind=4), dimension(:,:,:), intent(inout) :: rvar4   !< real4 arr3d that will be broadcasted
 
       call MPI_Bcast(rvar4, size(rvar4), MPI_REAL, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr3d_real4
 !-----------------------------------------------------------------------------
 !>
@@ -610,13 +668,14 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_real8(rvar8)
 
-      use mpi, only: MPI_DOUBLE_PRECISION
+      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_Bcast
 
       implicit none
 
       real(kind=8), dimension(:,:,:), intent(inout) :: rvar8   !< real8 arr3d that will be broadcasted
 
       call MPI_Bcast(rvar8, size(rvar8), MPI_DOUBLE_PRECISION, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr3d_real8
 !-----------------------------------------------------------------------------
 !>
@@ -626,13 +685,14 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_int4(ivar4)
 
-      use mpi, only: MPI_INTEGER
+      use MPIF, only: MPI_INTEGER, MPI_Bcast
 
       implicit none
 
       integer(kind=4), dimension(:,:, :), intent(inout) :: ivar4   !< int4 arr3d that will be broadcasted
 
       call MPI_Bcast(ivar4, size(ivar4), MPI_INTEGER, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr3d_int4
 !-----------------------------------------------------------------------------
 !>
@@ -642,13 +702,14 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_int8(ivar8)
 
-      use mpi, only: MPI_INTEGER8
+      use MPIF, only: MPI_INTEGER8, MPI_Bcast
 
       implicit none
 
       integer(kind=8), dimension(:,:,:), intent(inout) :: ivar8   !< int8 arr3d that will be broadcasted
 
       call MPI_Bcast(ivar8, size(ivar8), MPI_INTEGER8, FIRST, comm, mpi_err)
+
    end subroutine MPI_Bcast_arr3d_int8
 !-----------------------------------------------------------------------------
 !>
@@ -658,15 +719,23 @@ contains
    subroutine MPI_Allreduce_single_logical(lvar, reduction)
 
       use constants, only: I_ONE, pLOR, pLAND
-      use mpi,       only: MPI_LOGICAL, MPI_IN_PLACE, MPI_LOR, MPI_LAND
+      use MPIF,      only: MPI_LOGICAL, MPI_IN_PLACE, MPI_LOR, MPI_LAND, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       logical,         intent(inout) :: lvar      !< logical that will be reduced
       integer(kind=4), intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pLOR:pLAND), parameter :: mpiop = [MPI_LOR, MPI_LAND]
+#else /* !MPIF08 */
       integer, dimension(pLOR:pLAND), parameter :: mpiop = [MPI_LOR, MPI_LAND]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, lvar, I_ONE, MPI_LOGICAL, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_single_logical
 !-----------------------------------------------------------------------------
 !>
@@ -676,15 +745,23 @@ contains
    subroutine MPI_Allreduce_single_int4(ivar4, reduction)
 
       use constants, only: pSUM, pMAX, I_ONE
-      use mpi,       only: MPI_INTEGER, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_INTEGER, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       integer(kind=4), intent(inout) :: ivar4     !< int4 that will be reduced
       integer(kind=4), intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, ivar4, I_ONE, MPI_INTEGER, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_single_int4
 !-----------------------------------------------------------------------------
 !>
@@ -694,15 +771,23 @@ contains
    subroutine MPI_Allreduce_single_int8(ivar8, reduction)
 
       use constants, only: pSUM, pMAX, I_ONE
-      use mpi,       only: MPI_INTEGER8, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_INTEGER8, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       integer(kind=8), intent(inout) :: ivar8     !< int8 that will be reduced
       integer(kind=4), intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, ivar8, I_ONE, MPI_INTEGER8, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_single_int8
 !-----------------------------------------------------------------------------
 !>
@@ -712,15 +797,23 @@ contains
    subroutine MPI_Allreduce_vec_int4(ivar4, reduction)
 
       use constants, only: pSUM, pMAX
-      use mpi,       only: MPI_INTEGER, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_INTEGER, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       integer(kind=4), dimension(:), intent(inout) :: ivar4     !< int4 that will be reduced
       integer(kind=4),               intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter     :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, ivar4, size(ivar4), MPI_INTEGER, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_vec_int4
 !-----------------------------------------------------------------------------
 !>
@@ -730,15 +823,23 @@ contains
    subroutine MPI_Allreduce_vec_int8(ivar8, reduction)
 
       use constants, only: pSUM, pMAX
-      use mpi,       only: MPI_INTEGER8, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_INTEGER8, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       integer(kind=8), dimension(:), intent(inout) :: ivar8     !< int8 that will be reduced
       integer(kind=4),               intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter     :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, ivar8, size(ivar8), MPI_INTEGER8, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_vec_int8
 !-----------------------------------------------------------------------------
 !>
@@ -748,15 +849,23 @@ contains
    subroutine MPI_Allreduce_single_real4(rvar4, reduction)
 
       use constants, only: pSUM, pMAX, I_ONE
-      use mpi,       only: MPI_REAL, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_REAL, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       real(kind=4),    intent(inout) :: rvar4     !< real4 that will be reduced
       integer(kind=4), intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar4, I_ONE, MPI_REAL, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_single_real4
 !-----------------------------------------------------------------------------
 !>
@@ -766,15 +875,23 @@ contains
    subroutine MPI_Allreduce_single_real8(rvar8, reduction)
 
       use constants, only: pSUM, pMAX, I_ONE
-      use mpi,       only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       real(kind=8),    intent(inout) :: rvar8     !< int8 that will be reduced
       integer(kind=4), intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar8, I_ONE, MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_single_real8
 !-----------------------------------------------------------------------------
 !>
@@ -784,15 +901,23 @@ contains
    subroutine MPI_Allreduce_vec_real4(rvar4, reduction)
 
       use constants, only: pSUM, pMAX
-      use mpi,       only: MPI_REAL, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_REAL, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       real(kind=4), dimension(:), intent(inout) :: rvar4     !< int8 that will be reduced
       integer(kind=4),            intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter  :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar4, size(rvar4), MPI_REAL, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_vec_real4
 !-----------------------------------------------------------------------------
 !>
@@ -802,15 +927,23 @@ contains
    subroutine MPI_Allreduce_vec_real8(rvar8, reduction)
 
       use constants, only: pSUM, pMAX
-      use mpi,       only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       real(kind=8), dimension(:), intent(inout) :: rvar8     !< int8 that will be reduced
       integer(kind=4),            intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter  :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_vec_real8
 !-----------------------------------------------------------------------------
 !>
@@ -820,15 +953,23 @@ contains
    subroutine MPI_Allreduce_arr3d_real8(rvar8, reduction)
 
       use constants, only: pSUM, pMAX
-      use mpi,       only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       real(kind=8), dimension(:,:,:), intent(inout) :: rvar8     !< int8 that will be reduced
       integer(kind=4),                intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter      :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_arr3d_real8
 !-----------------------------------------------------------------------------
 !>
@@ -838,15 +979,23 @@ contains
    subroutine MPI_Allreduce_arr2d_real8(rvar8, reduction)
 
       use constants, only: pSUM, pMAX
-      use mpi,       only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       real(kind=8), dimension(:,:), intent(inout) :: rvar8     !< int8 that will be reduced
       integer(kind=4),              intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter    :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar8, size(rvar8), MPI_DOUBLE_PRECISION, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_arr2d_real8
 !-----------------------------------------------------------------------------
 !>
@@ -856,15 +1005,23 @@ contains
    subroutine MPI_Allreduce_arr2d_real4(rvar4, reduction)
 
       use constants, only: pSUM, pMAX
-      use mpi,       only: MPI_REAL, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX
+      use MPIF,      only: MPI_REAL, MPI_IN_PLACE, MPI_SUM, MPI_MIN, MPI_MAX, MPI_Allreduce
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
       real(kind=4), dimension(:,:), intent(inout) :: rvar4     !< int8 that will be reduced
       integer(kind=4),              intent(in)    :: reduction !< integer to mark a reduction type
+#ifdef MPIF08
+      type(MPI_Op), dimension(pSUM:pMAX), parameter :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#else /* !MPIF08 */
       integer, dimension(pSUM:pMAX), parameter    :: mpiop = [MPI_SUM, MPI_MIN, MPI_MAX]
+#endif /* !MPIF08 */
 
       call MPI_Allreduce(MPI_IN_PLACE, rvar4, size(rvar4), MPI_REAL, mpiop(reduction), comm, mpi_err)
+
    end subroutine MPI_Allreduce_arr2d_real4
 !-----------------------------------------------------------------------------
 !>
@@ -873,7 +1030,7 @@ contains
    subroutine report_to_master(ivar4, only_master)
 
       use constants, only: I_ONE
-      use mpi,       only: MPI_INTEGER
+      use MPIF,      only: MPI_INTEGER, MPI_Send
 
       implicit none
 
@@ -893,12 +1050,13 @@ contains
       tag = proc ! use proc number as tag
 
       call MPI_Send(ivar4, I_ONE, MPI_INTEGER, FIRST, tag, intercomm, mpi_err)
+
    end subroutine report_to_master
 
    subroutine report_string_to_master(str, only_master)
 
       use constants, only: I_ONE
-      use mpi,       only: MPI_INTEGER, MPI_CHARACTER
+      use MPIF,      only: MPI_INTEGER, MPI_CHARACTER, MPI_Send
 
       implicit none
       character(len=*),  intent(in) :: str
@@ -915,6 +1073,7 @@ contains
       buf = len(str, kind=4)
       call MPI_Send(buf, I_ONE, MPI_INTEGER, FIRST, tag, intercomm, mpi_err)
       call MPI_Send(str, buf, MPI_CHARACTER, FIRST, tag, intercomm, mpi_err)
+
    end subroutine report_string_to_master
 
    integer(kind=4) function abort_sigint(signum)
@@ -928,6 +1087,7 @@ contains
       !   "This routine should not be used from within a signal handler."
       call MPI_Abort(comm, 0) ! "I too like to live dangerously." -- Austin Powers
       abort_sigint = signum
+
    end function abort_sigint
 
 end module mpisetup

--- a/src/base/piernik.h
+++ b/src/base/piernik.h
@@ -38,3 +38,8 @@
 #undef HDF5
 #endif /* I_KNOW_WHAT_I_AM_DOING */
 
+#ifdef MPIF08
+#  define MPIF mpi_f08
+#else
+#  define MPIF mpi
+#endif

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -387,7 +387,7 @@ contains
 
       this%ind = 1
       this%arr_ind = 1
-      this%label = label(1:min(cbuff_len, len_trim(label)))
+      this%label = label(1:min(cbuff_len, len_trim(label, kind=4)))
       call this%arrays(this%arr_ind)%arr_init(ev_arr_len)
 
    end subroutine init
@@ -437,7 +437,7 @@ contains
          if (iand(mask, disable_mask) /= 0) return
       endif
 
-      l = label(1:min(cbuff_len, len_trim(label)))
+      l = label(1:min(cbuff_len, len_trim(label, kind=4)))
       call this%next_event(event(l, MPI_Wtime() + bigbang_shift))
 
    end subroutine start
@@ -466,7 +466,7 @@ contains
          if (iand(mask, disable_mask) /= 0) return
       endif
 
-      l = label(1:min(cbuff_len, len_trim(label)))
+      l = label(1:min(cbuff_len, len_trim(label, kind=4)))
       call this%next_event(event(l, -MPI_Wtime() - bigbang_shift))
 
    end subroutine stop
@@ -490,7 +490,7 @@ contains
 
       if (.not. use_profiling) return
 
-      l = label(1:min(cbuff_len, len_trim(label)))
+      l = label(1:min(cbuff_len, len_trim(label, kind=4)))
       call this%next_event(event(l, bigbang + bigbang_shift))
 
    end subroutine set_bb
@@ -598,7 +598,7 @@ contains
       endif
 
       ! send
-      call inflate_req(int(TAG_ARR_T))
+      call inflate_req(int(TAG_ARR_T, kind=4))
       t = TAG_CNT
       ne = I_ZERO
       do ia = lbound(this%arrays, dim=1), ubound(this%arrays, dim=1)
@@ -625,8 +625,8 @@ contains
             call publish_buffers(proc, buflabel, buftime)
             deallocate(buflabel, buftime)
          else
-            call MPI_Isend(buflabel, size(buflabel)*len(buflabel(1)), MPI_CHARACTER,        FIRST, TAG_ARR_L, comm, req(TAG_ARR_L), mpi_err)
-            call MPI_Isend(buftime,  size(buftime),                   MPI_DOUBLE_PRECISION, FIRST, TAG_ARR_T, comm, req(TAG_ARR_T), mpi_err)
+            call MPI_Isend(buflabel, size(buflabel, kind=4)*len(buflabel(1), kind=4), MPI_CHARACTER,        FIRST, TAG_ARR_L, comm, req(TAG_ARR_L), mpi_err)
+            call MPI_Isend(buftime,  size(buftime, kind=4),                           MPI_DOUBLE_PRECISION, FIRST, TAG_ARR_T, comm, req(TAG_ARR_T), mpi_err)
             t = TAG_ARR_T
          endif
       endif
@@ -640,8 +640,8 @@ contains
              if (ne /= 0) then
                 allocate(buflabel(ne), buftime(ne))
                 call check_mem_usage
-                call MPI_Recv(buflabel, size(buflabel)*len(buflabel(1)), MPI_CHARACTER,        p, TAG_ARR_L, comm, MPI_STATUS_IGNORE, mpi_err)
-                call MPI_Recv(buftime,  size(buftime),                   MPI_DOUBLE_PRECISION, p, TAG_ARR_T, comm, MPI_STATUS_IGNORE, mpi_err)
+                call MPI_Recv(buflabel, size(buflabel, kind=4)*len(buflabel(1), kind=4), MPI_CHARACTER,        p, TAG_ARR_L, comm, MPI_STATUS_IGNORE, mpi_err)
+                call MPI_Recv(buftime,  size(buftime, kind=4),                           MPI_DOUBLE_PRECISION, p, TAG_ARR_T, comm, MPI_STATUS_IGNORE, mpi_err)
                 call publish_buffers(p, buflabel, buftime)
                 deallocate(buflabel, buftime)
              endif

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -421,7 +421,7 @@ contains
 
    subroutine start(this, label, mask)
 
-      use mpi,      only: MPI_Wtime
+      use MPIF,     only: MPI_Wtime
       use mpisetup, only: bigbang_shift
 
       implicit none
@@ -450,7 +450,7 @@ contains
 
    subroutine stop(this, label, mask)
 
-      use mpi,      only: MPI_Wtime
+      use MPIF,     only: MPI_Wtime
       use mpisetup, only: bigbang_shift
 
       implicit none
@@ -561,7 +561,7 @@ contains
       use constants,    only: I_ZERO, I_ONE
       use dataio_pub,   only: die, printinfo, msg
       use memory_usage, only: check_mem_usage
-      use mpi,          only: MPI_STATUS_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION
+      use MPIF,         only: MPI_STATUS_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION
       use mpisetup,     only: proc, master, slave, comm, mpi_err, FIRST, LAST, req, status, inflate_req
 
       implicit none

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -561,8 +561,12 @@ contains
       use constants,    only: I_ZERO, I_ONE
       use dataio_pub,   only: die, printinfo, msg
       use memory_usage, only: check_mem_usage
-      use MPIF,         only: MPI_STATUS_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION
+      use MPIF,         only: MPI_STATUS_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION, &
+           &                  MPI_Isend, MPI_Recv, MPI_Waitall
       use mpisetup,     only: proc, master, slave, comm, mpi_err, FIRST, LAST, req, status, inflate_req
+#ifdef MPIF08
+      use MPIF,         only: MPI_Status
+#endif
 
       implicit none
 
@@ -572,7 +576,11 @@ contains
       integer :: ia
       character(len=cbuff_len), dimension(:), allocatable  :: buflabel
       real(kind=8), dimension(:), allocatable :: buftime
+#ifdef MPIF08
+      type(MPI_Status), dimension(:), pointer :: mpistatus
+#else /* !MPIF08 */
       integer(kind=4), dimension(:,:), pointer :: mpistatus
+#endif /* !MPIF08 */
 
       if (.not. use_profiling) return
 
@@ -639,7 +647,11 @@ contains
              endif
          enddo
       else
+#ifdef MPIF08
+         mpistatus => status(:t)
+#else /* !MPIF08 */
          mpistatus => status(:, :t)
+#endif /* !MPIF08 */
          call MPI_Waitall(t, req(:t), mpistatus, mpi_err)
          deallocate(buflabel, buftime)
       endif

--- a/src/base/timer.F90
+++ b/src/base/timer.F90
@@ -296,7 +296,7 @@ contains
 
       use constants,  only: I_ONE, half
       use dataio_pub, only: msg, printinfo
-      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_SUM
+      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_Reduce
       use mpisetup,   only: comm, mpi_err, master, FIRST
 
       implicit none

--- a/src/base/timer.F90
+++ b/src/base/timer.F90
@@ -166,7 +166,7 @@ contains
 
       real function modify_timer(tp,reset)
 
-         use mpi, only: MPI_Wtime
+         use MPIF, only: MPI_Wtime
 
          implicit none
 
@@ -187,7 +187,7 @@ contains
 
       subroutine insert_timer(tp, item)
 
-         use mpi, only: MPI_Wtime
+         use MPIF, only: MPI_Wtime
 
          implicit none
 
@@ -296,7 +296,7 @@ contains
 
       use constants,  only: I_ONE, half
       use dataio_pub, only: msg, printinfo
-      use mpi,        only: MPI_DOUBLE_PRECISION, MPI_SUM
+      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_SUM
       use mpisetup,   only: comm, mpi_err, master, FIRST
 
       implicit none

--- a/src/base/types.F90
+++ b/src/base/types.F90
@@ -44,7 +44,7 @@ module types
       real                      :: assoc
       real,    dimension(ndims) :: coords
       integer, dimension(ndims) :: loc
-      integer                   :: proc
+      integer(kind=4)           :: proc
    end type value
 
 end module types

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -124,7 +124,8 @@ contains
 
       class(cg_level_connected_t), intent(inout)   :: this   !< object invoking type bound procedure
 
-      integer                                      :: g, j, jf, fmax
+      integer                                      :: g, jf, fmax
+      integer(kind=4)                              :: j
       integer(kind=8)                              :: tag
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: coarsened
       integer,         dimension(xdim:zdim, LO:HI) :: enlargement
@@ -132,7 +133,7 @@ contains
       type(grid_container),       pointer          :: cg            !< current grid container
       type(cg_level_connected_t), pointer          :: fine, coarse  !< shortcut
       type :: int_pair
-         integer :: proc
+         integer(kind=4) :: proc
          integer :: n_se
       end type int_pair
       type(int_pair), dimension(:), allocatable    :: ps
@@ -516,7 +517,7 @@ contains
       use cg_list,          only: cg_list_element
       use grid_cont,        only: grid_container
       use mpisetup,         only: comm, mpi_err, req, status, inflate_req, master
-      use MPIF,             only: MPI_DOUBLE_PRECISION
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_Irecv, MPI_Isend, MPI_Waitall
       use named_array,      only: p3
       use named_array_list, only: qna
 #ifdef MPIF08
@@ -572,7 +573,7 @@ contains
             do g = lbound(cg%ri_tgt%seg(:), dim=1), ubound(cg%ri_tgt%seg(:), dim=1)
                nr = nr + I_ONE
                if (nr > size(req, dim=1)) call inflate_req
-               call MPI_Irecv(cg%ri_tgt%seg(g)%buf(1, 1, 1), size(cg%ri_tgt%seg(g)%buf(:, :, :)), MPI_DOUBLE_PRECISION, cg%ri_tgt%seg(g)%proc, cg%ri_tgt%seg(g)%tag, comm, req(nr), mpi_err)
+               call MPI_Irecv(cg%ri_tgt%seg(g)%buf(1, 1, 1), size(cg%ri_tgt%seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, cg%ri_tgt%seg(g)%proc, cg%ri_tgt%seg(g)%tag, comm, req(nr), mpi_err)
             enddo
          endif
          cgl => cgl%nxt
@@ -642,7 +643,7 @@ contains
             endif
             nr = nr + I_ONE
             if (nr > size(req, dim=1)) call inflate_req
-            call MPI_Isend(cg%ro_tgt%seg(g)%buf(1, 1, 1), size(cg%ro_tgt%seg(g)%buf(:, :, :)), MPI_DOUBLE_PRECISION, cg%ro_tgt%seg(g)%proc, cg%ro_tgt%seg(g)%tag, comm, req(nr), mpi_err)
+            call MPI_Isend(cg%ro_tgt%seg(g)%buf(1, 1, 1), size(cg%ro_tgt%seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, cg%ro_tgt%seg(g)%proc, cg%ro_tgt%seg(g)%tag, comm, req(nr), mpi_err)
          enddo
          cgl => cgl%nxt
       enddo
@@ -703,7 +704,7 @@ contains
       use grid_cont,        only: grid_container
       use grid_helpers,     only: f2c
       use mpisetup,         only: comm, mpi_err, req, status, inflate_req, master
-      use MPIF,             only: MPI_DOUBLE_PRECISION
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_Irecv, MPI_Isend, MPI_Waitall
       use named_array_list, only: qna
       use ppp,              only: ppp_main
 #ifdef MPIF08
@@ -771,7 +772,7 @@ contains
             do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
                nr = nr + I_ONE
                if (nr > size(req, dim=1)) call inflate_req
-               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :)), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
+               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
             enddo
          endif
          end associate
@@ -790,7 +791,7 @@ contains
             if (nr > size(req, dim=1)) call inflate_req
             p3d => cg%q(iv)%span(cse)
             seg(g)%buf(:, :, :) = p3d
-            call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :)), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
+            call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
          enddo
          end associate
          cgl => cgl%nxt
@@ -932,7 +933,7 @@ contains
       use domain,         only: dom
       use grid_cont,      only: grid_container
       use grid_helpers,   only: f2c, c2f
-      use MPIF,           only: MPI_DOUBLE_PRECISION
+      use MPIF,           only: MPI_DOUBLE_PRECISION, MPI_Irecv, MPI_Isend, MPI_Waitall
       use mpisetup,       only: comm, mpi_err, req, status, inflate_req, master
       use ppp,            only: ppp_main
 #ifdef MPIF08
@@ -999,7 +1000,7 @@ contains
             do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
                nr = nr + I_ONE
                if (nr > size(req, dim=1)) call inflate_req
-               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :)), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
+               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
             enddo
          endif
          end associate
@@ -1020,7 +1021,7 @@ contains
                nr = nr + I_ONE
                if (nr > size(req, dim=1)) call inflate_req
                seg(g)%buf(:, :, :) = cgl%cg%q(ind)%arr(cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI))
-               call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :)), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
+               call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, comm, req(nr), mpi_err)
             enddo
          endif
          end associate
@@ -1112,13 +1113,13 @@ contains
 
       use cg_list,        only: cg_list_element
       use cg_list_global, only: all_cg
-      use constants,      only: xdim, ydim, zdim, LO, HI, I_ONE, ndims, INVALID
+      use constants,      only: xdim, ydim, zdim, LO, HI, I_ZERO, I_ONE, ndims, INVALID
       use dataio_pub,     only: warn, msg, die
       use domain,         only: dom
       use grid_cont,      only: grid_container
       use grid_helpers,   only: f2c
       use mergebox,       only: wmap  ! this is the last place that uses this module
-      use MPIF,           only: MPI_INTEGER, MPI_INTEGER8
+      use MPIF,           only: MPI_INTEGER, MPI_INTEGER8, MPI_Alltoall, MPI_Alltoallv
       use mpisetup,       only: FIRST, LAST, comm, mpi_err, proc
       use overlap,        only: is_overlap
       use tag_pool,       only: t_pool
@@ -1131,16 +1132,17 @@ contains
       type(cg_level_connected_t), pointer :: coarse
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg            !< current grid container
-      integer :: d, j, b, rp, ls, dd, ix, iy, iz
+      integer :: d, b, rp, dd, ix, iy, iz
+      integer(kind=4) :: j, ls
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: seg, segp, seg2, segp2, segf
       integer(kind=8), dimension(xdim:zdim) :: per, ext_buf
       integer :: mpifc_cnt
       integer(kind=4) :: tag, tag_min, tag_max
       type :: fc_seg !< the absolutely minimal set of data that defines the communication consists of [ grid_id, tag, and, seg ]. The proc numbers are for convenience only.
-         integer :: proc     ! it can be rewritten in a way that does not need this numbet to be explicitly stored, but it is easier to have it
+         integer(kind=4) :: proc     ! it can be rewritten in a way that does not need this number to be explicitly stored, but it is easier to have it
          integer :: grid_id
          integer(kind=4) :: tag
-         integer :: src_proc ! this can be computed on destination process, but it is easier to have it
+         integer(kind=4) :: src_proc ! this can be computed on destination process, but it is easier to have it
          integer(kind=8), dimension(xdim:zdim, LO:HI) :: seg
          integer(kind=8), dimension(xdim:zdim, LO:HI) :: seg2
          integer(kind=8), dimension(xdim:zdim, LO:HI) :: fse
@@ -1166,7 +1168,7 @@ contains
       integer :: max_level
       integer, parameter :: initial_size = 16 ! for seglist
       real, parameter :: grow_ratio = 2.      ! for seglist
-      integer :: isl                          ! current position in seglist
+      integer(kind=4) :: isl                          ! current position in seglist
 
       if (.not. this%need_vb_update) return
 
@@ -1194,7 +1196,7 @@ contains
       tag = tag_min
       mpifc_cnt = 0
       allocate(seglist(initial_size))
-      isl = 0
+      isl = I_ZERO
       cgl => this%first
       do while (associated(cgl))
          cg => cgl%cg
@@ -1262,7 +1264,7 @@ contains
                                           endif
                                           seg2 (:, LO) = segp2(:, LO) + [ ix, iy, iz ] * per(:)
                                           seg2 (:, HI) = segp2(:, HI) + [ ix, iy, iz ] * per(:)
-                                          isl = isl + 1
+                                          isl = isl + I_ONE
                                           if (isl > ubound(seglist, dim=1)) then
                                              allocate(tmp(lbound(seglist(:),dim=1):int(abs(grow_ratio*ubound(seglist(:), dim=1)))))
                                              tmp(:ubound(seglist(:), dim=1)) = seglist(:)
@@ -1284,7 +1286,7 @@ contains
 
          if (allocated(cg%pib_tgt%seg)) deallocate(cg%pib_tgt%seg)
          allocate(cg%pib_tgt%seg(isl-ls))
-         do j = ls+1, isl
+         do j = ls + I_ONE, isl
             associate ( se => cg%pib_tgt%seg(j-ls) )
             se%proc = seglist(j)%proc
             se%tag  = seglist(j)%tag
@@ -1305,7 +1307,7 @@ contains
 
       pscnt = 0
       if (isl > 0) then
-         do j = lbound(seglist, dim=1), isl
+         do j = lbound(seglist, dim=1, kind=4), isl
             pscnt(seglist(j)%proc) = pscnt(seglist(j)%proc) + I_ONE
          enddo
       endif
@@ -1322,9 +1324,9 @@ contains
       allocate(sseg(I_LAST*sum(pscnt)))
       allocate(rseg(I_LAST*sum(prcnt)))
       psind = 0
-      do j = lbound(seglist, dim=1), isl
+      do j = lbound(seglist, dim=1, kind=4), isl
          b = (psdispl(seglist(j)%proc) + psind(seglist(j)%proc)) * I_LAST
-         sseg(b+I_PROC:b+I_LAST) = [ int([seglist(j)%proc, seglist(j)%grid_id], kind=8), int(seglist(j)%tag, kind=8), int(seglist(j)%src_proc, kind=8), seglist(j)%seg, seglist(j)%seg2 ]
+         sseg(b+I_PROC:b+I_LAST) = [ int(seglist(j)%proc, kind=8), int(seglist(j)%grid_id, kind=8), int(seglist(j)%tag, kind=8), int(seglist(j)%src_proc, kind=8), seglist(j)%seg, seglist(j)%seg2 ]
          psind(seglist(j)%proc) = psind(seglist(j)%proc) + I_ONE
       enddo
       ! communicate to the processes with coarse data the segments that are required

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -519,6 +519,9 @@ contains
       use MPIF,             only: MPI_DOUBLE_PRECISION
       use named_array,      only: p3
       use named_array_list, only: qna
+#ifdef MPIF08
+      use MPIF,             only: MPI_Status
+#endif
 
       implicit none
 
@@ -533,7 +536,11 @@ contains
       integer(kind=8), dimension(xdim:zdim)              :: off1
       real                                               :: norm
       integer(kind=4)                                    :: nr
+#ifdef MPIF08
+      type(MPI_Status), dimension(:), pointer            :: mpistatus
+#else /* !MPIF08 */
       integer(kind=4), dimension(:,:), pointer           :: mpistatus
+#endif /* !MPIF08 */
       type(cg_list_element), pointer                     :: cgl
       type(grid_container),  pointer                     :: cg                    !< current grid container
       logical, save                                      :: warned = .false.
@@ -641,7 +648,11 @@ contains
       enddo
 
       if (nr > 0) then
+#ifdef MPIF08
+         mpistatus => status(:nr)
+#else /* !MPIF08 */
          mpistatus => status(:, :nr)
+#endif /* !MPIF08 */
          call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
       endif
 
@@ -695,6 +706,9 @@ contains
       use MPIF,             only: MPI_DOUBLE_PRECISION
       use named_array_list, only: qna
       use ppp,              only: ppp_main
+#ifdef MPIF08
+      use MPIF,             only: MPI_Status
+#endif
 
       implicit none
 
@@ -707,7 +721,11 @@ contains
       integer                                            :: g
       integer(kind=8), dimension(xdim:zdim, LO:HI)       :: cse              !< shortcut for coarse segment
       integer(kind=4)                                    :: nr
-      integer(kind=4), dimension(:, :), pointer          :: mpistatus
+#ifdef MPIF08
+      type(MPI_Status), dimension(:), pointer            :: mpistatus
+#else /* !MPIF08 */
+      integer(kind=4), dimension(:,:), pointer           :: mpistatus
+#endif /* !MPIF08 */
       type(cg_list_element),            pointer          :: cgl
       type(grid_container),             pointer          :: cg               !< current grid container
       real, dimension(:,:,:),           pointer          :: p3d
@@ -779,7 +797,11 @@ contains
       enddo
 
       if (nr > 0) then
+#ifdef MPIF08
+         mpistatus => status(:nr)
+#else /* !MPIF08 */
          mpistatus => status(:, :nr)
+#endif /* !MPIF08 */
          call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
       endif
 
@@ -913,6 +935,9 @@ contains
       use MPIF,           only: MPI_DOUBLE_PRECISION
       use mpisetup,       only: comm, mpi_err, req, status, inflate_req, master
       use ppp,            only: ppp_main
+#ifdef MPIF08
+      use MPIF,         only: MPI_Status
+#endif
 
       implicit none
 
@@ -926,7 +951,11 @@ contains
       type(cg_level_connected_t), pointer :: coarse
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg            !< current grid container
-      integer(kind=4), dimension(:, :), pointer :: mpistatus
+#ifdef MPIF08
+      type(MPI_Status), dimension(:), pointer :: mpistatus
+#else /* !MPIF08 */
+      integer(kind=4), dimension(:,:), pointer :: mpistatus
+#endif /* !MPIF08 */
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: cse, fse ! shortcuts for fine segment and coarse segment
       integer(kind=8), dimension(xdim:zdim) :: per, ext_buf
       integer(kind=4) :: nr
@@ -1000,7 +1029,11 @@ contains
 
       if (nr > 0) then
          call ppp_main%start(pbcw_label, PPP_AMR + PPP_MPI)
+#ifdef MPIF08
+         mpistatus => status(:nr)
+#else /* !MPIF08 */
          mpistatus => status(:, :nr)
+#endif /* !MPIF08 */
          call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
          call ppp_main%stop(pbcw_label, PPP_AMR + PPP_MPI)
       endif

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -516,7 +516,7 @@ contains
       use cg_list,          only: cg_list_element
       use grid_cont,        only: grid_container
       use mpisetup,         only: comm, mpi_err, req, status, inflate_req, master
-      use mpi,              only: MPI_DOUBLE_PRECISION
+      use MPIF,             only: MPI_DOUBLE_PRECISION
       use named_array,      only: p3
       use named_array_list, only: qna
 
@@ -692,7 +692,7 @@ contains
       use grid_cont,        only: grid_container
       use grid_helpers,     only: f2c
       use mpisetup,         only: comm, mpi_err, req, status, inflate_req, master
-      use mpi,              only: MPI_DOUBLE_PRECISION
+      use MPIF,             only: MPI_DOUBLE_PRECISION
       use named_array_list, only: qna
       use ppp,              only: ppp_main
 
@@ -910,7 +910,7 @@ contains
       use domain,         only: dom
       use grid_cont,      only: grid_container
       use grid_helpers,   only: f2c, c2f
-      use mpi,            only: MPI_DOUBLE_PRECISION
+      use MPIF,           only: MPI_DOUBLE_PRECISION
       use mpisetup,       only: comm, mpi_err, req, status, inflate_req, master
       use ppp,            only: ppp_main
 
@@ -1085,7 +1085,7 @@ contains
       use grid_cont,      only: grid_container
       use grid_helpers,   only: f2c
       use mergebox,       only: wmap  ! this is the last place that uses this module
-      use mpi,            only: MPI_INTEGER, MPI_INTEGER8
+      use MPIF,           only: MPI_INTEGER, MPI_INTEGER8
       use mpisetup,       only: FIRST, LAST, comm, mpi_err, proc
       use overlap,        only: is_overlap
       use tag_pool,       only: t_pool

--- a/src/grid/cg_list.F90
+++ b/src/grid/cg_list.F90
@@ -344,13 +344,15 @@ contains
 
    subroutine update_req(this)
 
+      use constants, only: I_TWO
       use mpisetup,  only: inflate_req
 
       implicit none
 
       class(cg_list_t), intent(in)   :: this
 
-      integer                        :: nrq, d, dr, dp
+      integer                        :: d
+      integer(kind=4)                :: nrq, dr, dp
       type(cg_list_element), pointer :: cgl
 
       ! calculate number of boundaries to communicate
@@ -359,7 +361,7 @@ contains
       do while (associated(cgl))
 
          do d = lbound(cgl%cg%i_bnd, dim=1), ubound(cgl%cg%i_bnd, dim=1)
-            if (allocated(cgl%cg%i_bnd(d)%seg)) nrq = nrq + 2 * size(cgl%cg%i_bnd(d)%seg)
+            if (allocated(cgl%cg%i_bnd(d)%seg)) nrq = nrq + I_TWO * size(cgl%cg%i_bnd(d)%seg, kind=4)
          enddo
 
          cgl => cgl%nxt
@@ -371,12 +373,12 @@ contains
       cgl => this%first
       do while (associated(cgl))
          dr = 0
-         if (allocated(cgl%cg%ri_tgt%seg)) dr =      size(cgl%cg%ri_tgt%seg(:), dim=1)
-         if (allocated(cgl%cg%ro_tgt%seg)) dr = dr + size(cgl%cg%ro_tgt%seg(:), dim=1)
+         if (allocated(cgl%cg%ri_tgt%seg)) dr =      size(cgl%cg%ri_tgt%seg(:), dim=1, kind=4)
+         if (allocated(cgl%cg%ro_tgt%seg)) dr = dr + size(cgl%cg%ro_tgt%seg(:), dim=1, kind=4)
 
          dp = 0
-         if (allocated(cgl%cg%pi_tgt%seg)) dp =      size(cgl%cg%pi_tgt%seg(:), dim=1)
-         if (allocated(cgl%cg%po_tgt%seg)) dp = dp + size(cgl%cg%po_tgt%seg(:), dim=1)
+         if (allocated(cgl%cg%pi_tgt%seg)) dp =      size(cgl%cg%pi_tgt%seg(:), dim=1, kind=4)
+         if (allocated(cgl%cg%po_tgt%seg)) dp = dp + size(cgl%cg%po_tgt%seg(:), dim=1, kind=4)
 
          nrq = nrq + max(dr, dp)
 

--- a/src/grid/cg_list_balance.F90
+++ b/src/grid/cg_list_balance.F90
@@ -302,7 +302,7 @@ contains
 
       use constants,       only: ndims, INVALID, I_ONE
       use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, &
-           &                     MPI_Isend, MPI_Recv, MPI_Wait
+           &                     MPI_Isend, MPI_Send, MPI_Recv, MPI_Wait
       use mpisetup,        only: master, slave, FIRST, LAST, comm, req, mpi_err, status, inflate_req
       use sort_piece_list, only: grid_piece_list
 
@@ -354,7 +354,7 @@ contains
 #else /* !MPIF08 */
          call MPI_Wait(req(nreq), status(:, nreq), mpi_err)
 #endif /* !MPIF08 */
-         if (ls > 0) call MPI_Send(gptemp, size(gptemp), MPI_INTEGER8, FIRST, tag_gpt, comm, mpi_err)
+         if (ls > 0) call MPI_Send(gptemp, size(gptemp, kind=4), MPI_INTEGER8, FIRST, tag_gpt, comm, mpi_err)
          deallocate(gptemp)
 
       endif

--- a/src/grid/cg_list_balance.F90
+++ b/src/grid/cg_list_balance.F90
@@ -218,7 +218,7 @@ contains
 
       use constants,       only: pSUM, I_ONE
       use dataio_pub,      only: die
-      use MPIF,            only: MPI_INTEGER
+      use MPIF,            only: MPI_INTEGER, MPI_Gather
       use mpisetup,        only: piernik_MPI_Allreduce, master, FIRST, LAST, comm, mpi_err, nproc
       use sort_piece_list, only: grid_piece_list
 
@@ -301,7 +301,8 @@ contains
    subroutine patches_to_list(this, gp, ls)
 
       use constants,       only: ndims, INVALID, I_ONE
-      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, &
+           &                     MPI_Isend, MPI_Recv, MPI_Wait
       use mpisetup,        only: master, slave, FIRST, LAST, comm, req, mpi_err, status, inflate_req
       use sort_piece_list, only: grid_piece_list
 
@@ -348,7 +349,11 @@ contains
       else
 
          ! send patches to master
+#ifdef MPIF08
+         call MPI_Wait(req(nreq), status(nreq), mpi_err)
+#else /* !MPIF08 */
          call MPI_Wait(req(nreq), status(:, nreq), mpi_err)
+#endif /* !MPIF08 */
          if (ls > 0) call MPI_Send(gptemp, size(gptemp), MPI_INTEGER8, FIRST, tag_gpt, comm, mpi_err)
          deallocate(gptemp)
 
@@ -365,7 +370,8 @@ contains
    subroutine distribute_patches(this, gp, from)
 
       use constants,       only: ndims, I_ONE
-      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, &
+           &                     MPI_Send, MPI_Recv
       use mpisetup,        only: master, FIRST, LAST, comm, mpi_err
       use sort_piece_list, only: grid_piece_list
 

--- a/src/grid/cg_list_balance.F90
+++ b/src/grid/cg_list_balance.F90
@@ -218,7 +218,7 @@ contains
 
       use constants,       only: pSUM, I_ONE
       use dataio_pub,      only: die
-      use mpi,             only: MPI_INTEGER
+      use MPIF,            only: MPI_INTEGER
       use mpisetup,        only: piernik_MPI_Allreduce, master, FIRST, LAST, comm, mpi_err, nproc
       use sort_piece_list, only: grid_piece_list
 
@@ -301,7 +301,7 @@ contains
    subroutine patches_to_list(this, gp, ls)
 
       use constants,       only: ndims, INVALID, I_ONE
-      use mpi,             only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
       use mpisetup,        only: master, slave, FIRST, LAST, comm, req, mpi_err, status, inflate_req
       use sort_piece_list, only: grid_piece_list
 
@@ -365,7 +365,7 @@ contains
    subroutine distribute_patches(this, gp, from)
 
       use constants,       only: ndims, I_ONE
-      use mpi,             only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
       use mpisetup,        only: master, FIRST, LAST, comm, mpi_err
       use sort_piece_list, only: grid_piece_list
 

--- a/src/grid/cg_list_balance.F90
+++ b/src/grid/cg_list_balance.F90
@@ -315,7 +315,7 @@ contains
       integer(kind=8), dimension(:,:), allocatable :: gptemp
       integer :: i
       integer(kind=4) :: p, ss, rls
-      integer, parameter :: nreq = 1
+      integer(kind=4), parameter :: nreq = 1
       integer(kind=4), parameter :: tag_ls = 1, tag_gpt = tag_ls+1
 
       call inflate_req(nreq)
@@ -338,7 +338,7 @@ contains
             call MPI_Recv(rls, I_ONE, MPI_INTEGER, p, tag_ls, comm, MPI_STATUS_IGNORE, mpi_err)
             if (rls > 0) then
                allocate(gptemp(I_OFF:I_END, rls))
-               call MPI_Recv(gptemp, size(gptemp), MPI_INTEGER8, p, tag_gpt, comm, MPI_STATUS_IGNORE, mpi_err)
+               call MPI_Recv(gptemp, size(gptemp, kind=4), MPI_INTEGER8, p, tag_gpt, comm, MPI_STATUS_IGNORE, mpi_err)
                do ss = 1, rls
                   call gp%list(i+ss)%set_gp(gptemp(I_OFF:I_OFF+ndims-1, ss), int(gptemp(I_N_B:I_N_B+ndims-1, ss), kind=4), INVALID, p)
                enddo
@@ -400,7 +400,7 @@ contains
                do s = lbound(gptemp, dim=2, kind=4), ubound(gptemp, dim=2, kind=4)
                   gptemp(:, s) = [ gp%list(s)%off, int(gp%list(s)%n_b, kind=8) ]
                enddo
-               call MPI_Send(gptemp, size(gptemp), MPI_INTEGER8, p, tag_gptR, comm, mpi_err)
+               call MPI_Send(gptemp, size(gptemp, kind=4), MPI_INTEGER8, p, tag_gptR, comm, mpi_err)
                deallocate(gptemp)
             endif
          enddo
@@ -409,7 +409,7 @@ contains
          call MPI_Recv(ls, I_ONE, MPI_INTEGER, FIRST, tag_lsR, comm, MPI_STATUS_IGNORE, mpi_err)
          if (ls>0) then
             allocate(gptemp(I_OFF:I_END,ls))
-            call MPI_Recv(gptemp, size(gptemp), MPI_INTEGER8, FIRST, tag_gptR, comm, MPI_STATUS_IGNORE, mpi_err)
+            call MPI_Recv(gptemp, size(gptemp, kind=4), MPI_INTEGER8, FIRST, tag_gptR, comm, MPI_STATUS_IGNORE, mpi_err)
             do s = lbound(gptemp, dim=2, kind=4), ubound(gptemp, dim=2, kind=4)
                call this%add_patch_one_piece(gptemp(I_N_B:I_N_B+ndims-1, s), gptemp(I_OFF:I_OFF+ndims-1, s))
             enddo

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -325,9 +325,14 @@ contains
       use constants,        only: xdim, ydim, zdim, cor_dim, I_ONE, I_TWO, LO, HI
       use dataio_pub,       only: die
       use merge_segments,   only: IN, OUT
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE, MPI_Irecv, MPI_Isend
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_Irecv, MPI_Isend, MPI_Waitall
       use mpisetup,         only: FIRST, LAST, proc, comm, mpi_err, req, inflate_req
       use named_array_list, only: wna
+#ifdef MPIF08
+      use MPIF,             only: MPI_Status
+#else /* !MPIF08 */
+      use MPIF,             only: MPI_STATUS_SIZE
+#endif /* !MPIF08 */
 
       implicit none
 
@@ -339,7 +344,11 @@ contains
       integer :: i
       integer(kind=4) :: p
       integer(kind=4) :: nr !< index of first free slot in req and status arrays
-      integer(kind=4), allocatable, dimension(:,:) :: mpistatus !< status array for MPI_Waitall
+#ifdef MPIF08
+      type(MPI_Status), allocatable, dimension(:)  :: mpistatus  !< status array for MPI_Waitall
+#else /* !MPIF08 */
+      integer(kind=4), allocatable, dimension(:,:) :: mpistatus  !< status array for MPI_Waitall
+#endif /* !MPIF08 */
 
       if (.not. this%ms%valid) call die("[cg_list_bnd:internal_boundaries_MPI_merged] this%ms%valid .eqv. .false.")
 
@@ -401,7 +410,11 @@ contains
          endif
       enddo
 
+#ifdef MPIF08
+      allocate(mpistatus(nr))
+#else /* !MPIF08 */
       allocate(mpistatus(MPI_STATUS_SIZE, nr))
+#endif /* !MPIF08 */
       call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
       deallocate(mpistatus)
 
@@ -476,9 +489,14 @@ contains
       use dataio_pub,       only: die, warn
       use grid_cont,        only: grid_container
       use grid_cont_bnd,    only: segment
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_Irecv, MPI_Isend, MPI_Waitall
       use mpisetup,         only: comm, mpi_err, req, inflate_req
       use named_array_list, only: wna
+#ifdef MPIF08
+      use MPIF,             only: MPI_Status
+#else /* !MPIF08 */
+      use MPIF,             only: MPI_STATUS_SIZE
+#endif /* !MPIF08 */
 
       implicit none
 
@@ -495,7 +513,11 @@ contains
       real, dimension(:,:,:,:), pointer            :: pa4d
       logical                                      :: active
       type(segment), pointer                       :: i_seg, o_seg !< shortcuts
-      integer(kind=4), allocatable, dimension(:,:) :: mpistatus !< status array for MPI_Waitall
+#ifdef MPIF08
+      type(MPI_Status), allocatable, dimension(:)  :: mpistatus  !< status array for MPI_Waitall
+#else /* !MPIF08 */
+      integer(kind=4), allocatable, dimension(:,:) :: mpistatus  !< status array for MPI_Waitall
+#endif /* !MPIF08 */
 
       nr = 0
       cgl => this%first
@@ -533,7 +555,7 @@ contains
                            allocate(i_seg%buf(i_seg%se(xdim, HI) - i_seg%se(xdim, LO) + 1, &
                                 &             i_seg%se(ydim, HI) - i_seg%se(ydim, LO) + 1, &
                                 &             i_seg%se(zdim, HI) - i_seg%se(zdim, LO) + 1))
-                           call MPI_Irecv(i_seg%buf, size(i_seg%buf), MPI_DOUBLE_PRECISION, i_seg%proc, i_seg%tag, comm, req(nr+I_ONE), mpi_err)
+                           call MPI_Irecv(i_seg%buf, size(i_seg%buf, kind=4), MPI_DOUBLE_PRECISION, i_seg%proc, i_seg%tag, comm, req(nr+I_ONE), mpi_err)
 
                            if (allocated(o_seg%buf)) then
                               call warn("clb:ib allocated o-buf")
@@ -544,7 +566,7 @@ contains
                                 &             o_seg%se(zdim, HI) - o_seg%se(zdim, LO) + 1))
                            pa3d => cg%q(ind)%span(o_seg%se(:,:))
                            o_seg%buf(:,:,:) = pa3d(:,:,:)
-                           call MPI_Isend(o_seg%buf, size(o_seg%buf), MPI_DOUBLE_PRECISION, o_seg%proc, o_seg%tag, comm, req(nr+I_TWO), mpi_err)
+                           call MPI_Isend(o_seg%buf, size(o_seg%buf, kind=4), MPI_DOUBLE_PRECISION, o_seg%proc, o_seg%tag, comm, req(nr+I_TWO), mpi_err)
 
                         else
                            if (ind > ubound(cg%w(:), dim=1) .or. ind < lbound(cg%w(:), dim=1)) call die("[cg_list_bnd:internal_boundaries_MPI_1by1] wrong 4d index")
@@ -557,7 +579,7 @@ contains
                                 &              i_seg%se(xdim, HI) - i_seg%se(xdim, LO) + 1, &
                                 &              i_seg%se(ydim, HI) - i_seg%se(ydim, LO) + 1, &
                                 &              i_seg%se(zdim, HI) - i_seg%se(zdim, LO) + 1))
-                           call MPI_Irecv(i_seg%buf4, size(i_seg%buf4), MPI_DOUBLE_PRECISION, i_seg%proc, i_seg%tag, comm, req(nr+I_ONE), mpi_err)
+                           call MPI_Irecv(i_seg%buf4, size(i_seg%buf4, kind=4), MPI_DOUBLE_PRECISION, i_seg%proc, i_seg%tag, comm, req(nr+I_ONE), mpi_err)
 
                            if (allocated(o_seg%buf4)) then
                               call warn("clb:ib allocated o-buf")
@@ -577,7 +599,7 @@ contains
                            !<
                            pa4d => cg%w(ind)%span(o_seg%se(:,:))
                            o_seg%buf4(:,:,:,:) = pa4d(:,:,:,:)
-                           call MPI_Isend(o_seg%buf4, size(o_seg%buf4), MPI_DOUBLE_PRECISION, o_seg%proc, o_seg%tag, comm, req(nr+I_TWO), mpi_err)
+                           call MPI_Isend(o_seg%buf4, size(o_seg%buf4, kind=4), MPI_DOUBLE_PRECISION, o_seg%proc, o_seg%tag, comm, req(nr+I_TWO), mpi_err)
 
                         endif
                         nr = nr + I_TWO
@@ -592,7 +614,11 @@ contains
          cgl => cgl%nxt
       enddo
 
+#ifdef MPIF08
+      allocate(mpistatus(nr))
+#else /* !MPIF08 */
       allocate(mpistatus(MPI_STATUS_SIZE, nr))
+#endif /* !MPIF08 */
       call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
       deallocate(mpistatus)
 

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -325,7 +325,7 @@ contains
       use constants,        only: xdim, ydim, zdim, cor_dim, I_ONE, I_TWO, LO, HI
       use dataio_pub,       only: die
       use merge_segments,   only: IN, OUT
-      use mpi,              only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE
       use mpisetup,         only: FIRST, LAST, proc, comm, mpi_err, req, inflate_req
       use named_array_list, only: wna
 
@@ -475,7 +475,7 @@ contains
       use dataio_pub,       only: die, warn
       use grid_cont,        only: grid_container
       use grid_cont_bnd,    only: segment
-      use mpi,              only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE
       use mpisetup,         only: comm, mpi_err, req, inflate_req
       use named_array_list, only: wna
 

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -325,7 +325,7 @@ contains
       use constants,        only: xdim, ydim, zdim, cor_dim, I_ONE, I_TWO, LO, HI
       use dataio_pub,       only: die
       use merge_segments,   only: IN, OUT
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_SIZE, MPI_Irecv, MPI_Isend
       use mpisetup,         only: FIRST, LAST, proc, comm, mpi_err, req, inflate_req
       use named_array_list, only: wna
 
@@ -336,7 +336,8 @@ contains
       logical,                          intent(in)    :: tgt3d !< .true. for cg%q, .false. for cg%w
       logical, dimension(xdim:cor_dim), intent(in)    :: dmask !< .true. for the directions we want to exchange
 
-      integer :: p, i
+      integer :: i
+      integer(kind=4) :: p
       integer(kind=4) :: nr !< index of first free slot in req and status arrays
       integer(kind=4), allocatable, dimension(:,:) :: mpistatus !< status array for MPI_Waitall
 
@@ -392,8 +393,8 @@ contains
                   enddo
                endif
                if (nr+I_TWO >  ubound(req(:), dim=1)) call inflate_req
-               call MPI_Irecv(this%ms%sl(p, IN )%buf, size(this%ms%sl(p, IN )%buf), MPI_DOUBLE_PRECISION, p, p,    comm, req(nr+I_ONE), mpi_err)
-               call MPI_Isend(this%ms%sl(p, OUT)%buf, size(this%ms%sl(p, OUT)%buf), MPI_DOUBLE_PRECISION, p, proc, comm, req(nr+I_TWO), mpi_err)
+               call MPI_Irecv(this%ms%sl(p, IN )%buf, size(this%ms%sl(p, IN )%buf, kind=4), MPI_DOUBLE_PRECISION, p, p,    comm, req(nr+I_ONE), mpi_err)
+               call MPI_Isend(this%ms%sl(p, OUT)%buf, size(this%ms%sl(p, OUT)%buf, kind=4), MPI_DOUBLE_PRECISION, p, proc, comm, req(nr+I_TWO), mpi_err)
                nr = nr + I_TWO
             endif
 

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -96,10 +96,14 @@ contains
       use dataio_pub,  only: msg, warn, die
       use domain,      only: dom
       use grid_cont,   only: grid_container
-      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_STATUS_IGNORE, MPI_2DOUBLE_PRECISION, MPI_MINLOC, MPI_MAXLOC, MPI_IN_PLACE
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_STATUS_IGNORE, MPI_2DOUBLE_PRECISION, MPI_MINLOC, MPI_MAXLOC, MPI_IN_PLACE, &
+           &                 MPI_Allreduce, MPI_Send, MPI_Recv
       use mpisetup,    only: comm, mpi_err, master, proc, FIRST
 !      use named_array_list, only: qna
       use types,       only: value
+#ifdef MPIF08
+      use MPIF,      only: MPI_Op
+#endif
 
       implicit none
 
@@ -114,7 +118,11 @@ contains
       type(cg_list_element),  pointer          :: cgl
       real, dimension(:,:,:), pointer          :: tab
       integer,                       parameter :: tag1 = 11, tag2 = tag1 + 1, tag3 = tag2 + 1
+#ifdef MPIF08
+      type(MPI_Op), dimension(MINL:MAXL), parameter :: op = [ MPI_MINLOC, MPI_MAXLOC ]
+#else /* !MPIF08 */
       integer, dimension(MINL:MAXL), parameter :: op = [ MPI_MINLOC, MPI_MAXLOC ]
+#endif /* !MPIF08 */
       enum, bind(C)
          enumerator :: I_V, I_P !< value and proc
       end enum

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -96,7 +96,7 @@ contains
       use dataio_pub,  only: msg, warn, die
       use domain,      only: dom
       use grid_cont,   only: grid_container
-      use mpi,         only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_STATUS_IGNORE, MPI_2DOUBLE_PRECISION, MPI_MINLOC, MPI_MAXLOC, MPI_IN_PLACE
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_STATUS_IGNORE, MPI_2DOUBLE_PRECISION, MPI_MINLOC, MPI_MAXLOC, MPI_IN_PLACE
       use mpisetup,    only: comm, mpi_err, master, proc, FIRST
 !      use named_array_list, only: qna
       use types,       only: value

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -119,9 +119,9 @@ contains
       real, dimension(:,:,:), pointer          :: tab
       integer(kind=4),               parameter :: tag1 = 11, tag2 = tag1 + 1, tag3 = tag2 + 1
 #ifdef MPIF08
-      type(MPI_Op), dimension(MINL:MAXL), parameter :: op = [ MPI_MINLOC, MPI_MAXLOC ]
+      type(MPI_Op) :: op
 #else /* !MPIF08 */
-      integer(kind=4), dimension(MINL:MAXL), parameter :: op = [ MPI_MINLOC, MPI_MAXLOC ]
+      integer(kind=4) :: op
 #endif /* !MPIF08 */
       enum, bind(C)
          enumerator :: I_V, I_P !< value and proc
@@ -134,8 +134,10 @@ contains
       select case (minmax)
          case (MINL)
             prop%val = huge(1.)
+            op = MPI_MINLOC
          case (MAXL)
             prop%val = -huge(1.)
+            op = MPI_MAXLOC
          case default
             prop%val = 0.0   !! set dummy value
             write(msg,*) "[cg_list_dataop:get_extremum]: I don't know what to do with minmax = ", minmax
@@ -173,7 +175,7 @@ contains
 
       v_red(I_P) = real(proc)
 
-      call MPI_Allreduce(MPI_IN_PLACE, v_red, I_ONE, MPI_2DOUBLE_PRECISION, op(minmax), comm, mpi_err)
+      call MPI_Allreduce(MPI_IN_PLACE, v_red, I_ONE, MPI_2DOUBLE_PRECISION, op, comm, mpi_err)
 
       prop%val = v_red(I_V)
       prop%proc = int(v_red(I_P), kind=4)

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -117,11 +117,11 @@ contains
       type(grid_container),   pointer          :: cg_x
       type(cg_list_element),  pointer          :: cgl
       real, dimension(:,:,:), pointer          :: tab
-      integer,                       parameter :: tag1 = 11, tag2 = tag1 + 1, tag3 = tag2 + 1
+      integer(kind=4),               parameter :: tag1 = 11, tag2 = tag1 + 1, tag3 = tag2 + 1
 #ifdef MPIF08
       type(MPI_Op), dimension(MINL:MAXL), parameter :: op = [ MPI_MINLOC, MPI_MAXLOC ]
 #else /* !MPIF08 */
-      integer, dimension(MINL:MAXL), parameter :: op = [ MPI_MINLOC, MPI_MAXLOC ]
+      integer(kind=4), dimension(MINL:MAXL), parameter :: op = [ MPI_MINLOC, MPI_MAXLOC ]
 #endif /* !MPIF08 */
       enum, bind(C)
          enumerator :: I_V, I_P !< value and proc
@@ -176,7 +176,7 @@ contains
       call MPI_Allreduce(MPI_IN_PLACE, v_red, I_ONE, MPI_2DOUBLE_PRECISION, op(minmax), comm, mpi_err)
 
       prop%val = v_red(I_V)
-      prop%proc = int(v_red(I_P))
+      prop%proc = int(v_red(I_P), kind=4)
 
       if (proc == prop%proc) then
          where (.not. dom%has_dir(:)) prop%coords(:) = 0.

--- a/src/grid/cg_list_neighbors.F90
+++ b/src/grid/cg_list_neighbors.F90
@@ -253,7 +253,7 @@ contains
       integer                           :: lh
       integer(kind=8), dimension(ndims) :: n_off     !< neighbor's offset
       integer(kind=8)                   :: n_id      !< neighbor's id
-      integer                           :: n_p       !< neighbor's process
+      integer(kind=4)                   :: n_p       !< neighbor's process
       integer                           :: n_grid_id !< neighbor's grid_id on n_p
       integer                           :: n_dd      !< neighbor's direction
       integer(kind=4)                   :: tag
@@ -408,7 +408,8 @@ contains
 
       type(grid_container),  pointer                  :: cg      !< grid container that we are currently working on
       type(cg_list_element), pointer                  :: cgl
-      integer                                         :: j, b, id, ix, iy, iz
+      integer                                         :: b, id, ix, iy, iz
+      integer(kind=4)                                 :: j
       integer(kind=8)                                 :: n_lbnd_face_cells
       integer(kind=4)                                 :: d, dd, hl, lh, tag
       integer(kind=8), dimension(xdim:zdim)           :: per
@@ -631,7 +632,8 @@ contains
 
       type(cg_list_element), pointer           :: cgl
       integer(kind=8), dimension(xdim:zdim)    :: per
-      integer                                  :: j, b, ix, iy, iz
+      integer(kind=4)                          :: j
+      integer                                  :: b, ix, iy, iz
       integer(kind=8), dimension(ndims, LO:HI) :: box, box_narrow, e_guard, e_guard_wide, whole_level, poff, aux
       integer(kind=4)                          :: d, hl, lh, m_tag
       type(gcpa_t)                             :: l_pse

--- a/src/grid/cg_list_rebalance.F90
+++ b/src/grid/cg_list_rebalance.F90
@@ -200,6 +200,9 @@ contains
       use named_array_list,   only: qna, wna
       use ppp,                only: ppp_main
       use sort_piece_list,    only: grid_piece_list
+#ifdef MPIF08
+      use MPIF,               only: MPI_Status
+#endif
 
       implicit none
 
@@ -213,7 +216,11 @@ contains
       integer(kind=8), dimension(ndims, LO:HI) :: se
       logical :: found
       type(grid_container),  pointer :: cg
+#ifdef MPIF08
+      type(MPI_Status), dimension(:), pointer :: mpistatus
+#else /* !MPIF08 */
       integer(kind=4), dimension(:,:), pointer :: mpistatus
+#endif /* !MPIF08 */
       type :: cglep
          type(cg_list_element), pointer :: p
          real, dimension(:,:,:,:), allocatable :: tbuf
@@ -324,7 +331,11 @@ contains
 
       call ppp_main%start(Wall_label, PPP_AMR + PPP_MPI)
       if (nr > 0) then
+#ifdef MPIF08
+         mpistatus => status(:nr)
+#else /* !MPIF08 */
          mpistatus => status(:, :nr)
+#endif /* !MPIF08 */
          call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
       endif
       call ppp_main%stop(Wall_label, PPP_AMR + PPP_MPI)

--- a/src/grid/cg_list_rebalance.F90
+++ b/src/grid/cg_list_rebalance.F90
@@ -63,7 +63,7 @@ contains
       use refinement,      only: oop_thr
       use sort_piece_list, only: grid_piece_list
 #ifdef DEBUG
-      use mpi,             only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE
       use mpisetup,        only: comm, mpi_err
 #endif /* DEBUG */
 
@@ -195,7 +195,7 @@ contains
       use dataio_pub,         only: die
       use grid_cont,          only: grid_container
       use list_of_cg_lists,   only: all_lists
-      use mpi,                only: MPI_DOUBLE_PRECISION
+      use MPIF,               only: MPI_DOUBLE_PRECISION
       use mpisetup,           only: master, piernik_MPI_Bcast, piernik_MPI_Allreduce, proc, comm, mpi_err, req, status, inflate_req
       use named_array_list,   only: qna, wna
       use ppp,                only: ppp_main

--- a/src/grid/dot.F90
+++ b/src/grid/dot.F90
@@ -104,7 +104,7 @@ contains
       use cg_list,    only: cg_list_element
       use constants,  only: I_ZERO, I_ONE, ndims, LO, HI
       use dataio_pub, only: die
-      use MPIF,       only: MPI_IN_PLACE, MPI_DATATYPE_NULL, MPI_INTEGER, MPI_Allgather
+      use MPIF,       only: MPI_IN_PLACE, MPI_DATATYPE_NULL, MPI_INTEGER, MPI_Allgather, MPI_Allgatherv
       use mpisetup,   only: FIRST, LAST, proc, comm, mpi_err
       use ordering,   only: SFC_order
 
@@ -265,7 +265,7 @@ contains
    subroutine check_blocky(this)
 
       use constants,  only: ndims, LO, HI, pLAND, I_ONE
-      use MPIF,       only: MPI_INTEGER, MPI_REQUEST_NULL, MPI_Waitall
+      use MPIF,       only: MPI_INTEGER, MPI_REQUEST_NULL, MPI_Waitall, MPI_Irecv, MPI_Isend
       use mpisetup,   only: proc, req, status, comm, mpi_err, LAST, inflate_req, slave, piernik_MPI_Allreduce
 
       implicit none
@@ -293,8 +293,8 @@ contains
          endif
       endif
       req = MPI_REQUEST_NULL
-      if (slave)     call MPI_Irecv(shape1, size(shape1), MPI_INTEGER, proc-I_ONE, sh_tag, comm, req(1 ), mpi_err)
-      if (proc<LAST) call MPI_Isend(shape,  size(shape),  MPI_INTEGER, proc+I_ONE, sh_tag, comm, req(nr), mpi_err)
+      if (slave)     call MPI_Irecv(shape1, size(shape1, kind=4), MPI_INTEGER, proc-I_ONE, sh_tag, comm, req(1 ), mpi_err)
+      if (proc<LAST) call MPI_Isend(shape,  size(shape, kind=4),  MPI_INTEGER, proc+I_ONE, sh_tag, comm, req(nr), mpi_err)
 #ifdef MPIF08
       call MPI_Waitall(nr, req(:nr), status(:nr), mpi_err)
 #else /* !MPIF08 */
@@ -378,7 +378,7 @@ contains
 
       class(dot_t),    intent(inout) :: this
       integer(kind=8), intent(in)    :: SFC_id
-      integer,         intent(out)   :: p
+      integer(kind=4), intent(out)   :: p
       integer,         intent(out)   :: grid_id
 
       integer :: ip, il, iu, j, pp_lb, pp_ub
@@ -462,7 +462,7 @@ contains
          do j = i1, i2
             if (this%gse(pp(ip))%c(j)%SFCid == SFC_id) then
                grid_id = j
-               p = pp(ip)
+               p = int(pp(ip), kind=4)
                exit
             endif
          enddo

--- a/src/grid/dot.F90
+++ b/src/grid/dot.F90
@@ -274,7 +274,7 @@ contains
 
       integer(kind=4), dimension(ndims) :: shape, shape1
       integer(kind=4), parameter :: sh_tag = 7
-      integer, parameter :: nr = 2
+      integer(kind=4), parameter :: nr = 2
       integer :: i
 
       call inflate_req(nr)
@@ -317,7 +317,7 @@ contains
 
    subroutine update_SFC_id_range(this, off)
 
-      use constants,  only: LO, HI, ndims
+      use constants,  only: LO, HI, ndims, I_ONE
       use dataio_pub, only: die
       use MPIF,       only: MPI_INTEGER8, MPI_Allgather
       use mpisetup,   only: FIRST, LAST, proc, comm, mpi_err
@@ -350,7 +350,7 @@ contains
       endif
 
       allocate(id_buf(size(this%SFC_id_range)))
-      call MPI_Allgather(this%SFC_id_range(proc, :), HI-LO+1, MPI_INTEGER8, id_buf, HI-LO+1, MPI_INTEGER8, comm, mpi_err)
+      call MPI_Allgather(this%SFC_id_range(proc, :), HI-LO+I_ONE, MPI_INTEGER8, id_buf, HI-LO+I_ONE, MPI_INTEGER8, comm, mpi_err)
       this%SFC_id_range(:, LO) = id_buf(1::2)
       this%SFC_id_range(:, HI) = id_buf(2::2)
 

--- a/src/grid/dot.F90
+++ b/src/grid/dot.F90
@@ -104,7 +104,7 @@ contains
       use cg_list,    only: cg_list_element
       use constants,  only: I_ZERO, I_ONE, ndims, LO, HI
       use dataio_pub, only: die
-      use mpi,        only: MPI_IN_PLACE, MPI_DATATYPE_NULL, MPI_INTEGER
+      use MPIF,       only: MPI_IN_PLACE, MPI_DATATYPE_NULL, MPI_INTEGER
       use mpisetup,   only: FIRST, LAST, proc, comm, mpi_err
       use ordering,   only: SFC_order
 
@@ -265,7 +265,7 @@ contains
    subroutine check_blocky(this)
 
       use constants,  only: ndims, LO, HI, pLAND, I_ONE
-      use mpi,        only: MPI_INTEGER, MPI_REQUEST_NULL
+      use MPIF,       only: MPI_INTEGER, MPI_REQUEST_NULL
       use mpisetup,   only: proc, req, status, comm, mpi_err, LAST, inflate_req, slave, piernik_MPI_Allreduce
 
       implicit none
@@ -315,7 +315,7 @@ contains
 
       use constants,  only: LO, HI, ndims
       use dataio_pub, only: die
-      use mpi,        only: MPI_INTEGER8
+      use MPIF,       only: MPI_INTEGER8
       use mpisetup,   only: FIRST, LAST, proc, comm, mpi_err
       use ordering,   only: SFC_order
 

--- a/src/grid/grid_container_bnd.F90
+++ b/src/grid/grid_container_bnd.F90
@@ -47,7 +47,7 @@ module grid_cont_bnd
 
    !> \brief Specification of segment of data for boundary exchange
    type :: segment
-      integer :: proc                                      !< target process
+      integer(kind=4) :: proc                              !< target process
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: se   !< range
       integer(kind=4) :: tag                               !< unique tag for data exchange
       real, allocatable, dimension(:,:,:)   :: buf         !< buffer for the 3D (scalar) data to be sent or received
@@ -182,7 +182,7 @@ contains
       implicit none
 
       class(bnd_list),                              intent(inout) :: this !< object invoking type-bound procedure
-      integer,                                      intent(in)    :: proc !< process to be communicated
+      integer(kind=4),                              intent(in)    :: proc !< process to be communicated
       integer(kind=8), dimension(xdim:zdim, LO:HI), intent(in)    :: se   !< segment definition
       integer(kind=4),                              intent(in)    :: tag  !< tag for MPI calls
 

--- a/src/grid/grid_container_bnd.F90
+++ b/src/grid/grid_container_bnd.F90
@@ -34,6 +34,9 @@ module grid_cont_bnd
    use grid_cont_na,    only: grid_container_na_t
    use fluxtypes,       only: fluxarray, fluxpoint
    use refinement_flag, only: ref_flag_t
+#ifdef MPIF08
+   use MPIF,            only: MPI_Request
+#endif /* MPIF08 */
 
    implicit none
 
@@ -49,7 +52,12 @@ module grid_cont_bnd
       integer(kind=4) :: tag                               !< unique tag for data exchange
       real, allocatable, dimension(:,:,:)   :: buf         !< buffer for the 3D (scalar) data to be sent or received
       real, allocatable, dimension(:,:,:,:) :: buf4        !< buffer for the 4D (vector) data to be sent or received
+#ifdef MPIF08
+      type(MPI_Request), pointer :: req                    !< request ID, used for most asynchronous communication, such as fine-coarse flux exchanges
+#else /* !MPIF08 */
       integer(kind=4), pointer :: req                      !< request ID, used for most asynchronous communication, such as fine-coarse flux exchanges
+#endif /* !MPIF08 */
+
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: se2  !< auxiliary range, used in cg_level_connected:vertical_bf_prep
       class(grid_container_bnd_t), pointer :: local        !< set this pointer to non-null when the exchange is local
    end type segment

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -239,10 +239,13 @@ contains
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
       use constants,          only: xdim, zdim, LO, HI, I_ONE, I_ZERO
-      use dataio_pub        , only: die, warn
+      use dataio_pub,         only: die, warn
       use domain,             only: dom
       use MPIF,               only: MPI_INTEGER, MPI_STATUS_IGNORE
       use mpisetup,           only: FIRST, LAST, comm, mpi_err, proc, req, status, inflate_req
+#ifdef MPIF08
+      use MPIF,               only: MPI_Status
+#endif
 
       implicit none
 
@@ -260,7 +263,11 @@ contains
       type(pt), dimension(:), allocatable :: pt_list
       integer :: pt_cnt
       integer(kind=4) :: rtag
+#ifdef MPIF08
+      type(MPI_Status), dimension(:), pointer :: mpistatus
+#else /* !MPIF08 */
       integer(kind=4), dimension(:,:), pointer :: mpistatus
+#endif /* !MPIF08 */
 
       if (perimeter > dom%nb) call die("[refinement_update:parents_prevent_derefinement_lev] perimeter > dom%nb")
       if (.not. associated(lev%finer)) then
@@ -331,7 +338,11 @@ contains
       enddo
 
       if (nr > 0) then
+#ifdef MPIF08
+         mpistatus => status(:nr)
+#else /* !MPIF08 */
          mpistatus => status(:, :nr)
+#endif /* !MPIF08 */
          call MPI_Waitall(nr, req(:nr), mpistatus, mpi_err)
       endif
 

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -241,7 +241,7 @@ contains
       use constants,          only: xdim, zdim, LO, HI, I_ONE, I_ZERO
       use dataio_pub        , only: die, warn
       use domain,             only: dom
-      use mpi,                only: MPI_INTEGER, MPI_STATUS_IGNORE
+      use MPIF,               only: MPI_INTEGER, MPI_STATUS_IGNORE
       use mpisetup,           only: FIRST, LAST, comm, mpi_err, proc, req, status, inflate_req
 
       implicit none

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -241,7 +241,8 @@ contains
       use constants,          only: xdim, zdim, LO, HI, I_ONE, I_ZERO
       use dataio_pub,         only: die, warn
       use domain,             only: dom
-      use MPIF,               only: MPI_INTEGER, MPI_STATUS_IGNORE
+      use MPIF,               only: MPI_INTEGER, MPI_STATUS_IGNORE, &
+           &                        MPI_Alltoall, MPI_Isend, MPI_Recv, MPI_Waitall
       use mpisetup,           only: FIRST, LAST, comm, mpi_err, proc, req, status, inflate_req
 #ifdef MPIF08
       use MPIF,               only: MPI_Status
@@ -252,7 +253,8 @@ contains
       type(cg_level_connected_t), pointer, intent(in) :: lev
 
       type(cg_list_element), pointer :: cgl
-      integer :: i, g, nr
+      integer :: i
+      integer(kind=4) :: nr, g
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: se
       integer, parameter :: perimeter = 2
       integer(kind=4), dimension(FIRST:LAST) :: gscnt, grcnt
@@ -261,7 +263,7 @@ contains
          integer(kind=4) :: tag
       end type pt
       type(pt), dimension(:), allocatable :: pt_list
-      integer :: pt_cnt
+      integer(kind=4) :: pt_cnt
       integer(kind=4) :: rtag
 #ifdef MPIF08
       type(MPI_Status), dimension(:), pointer :: mpistatus
@@ -283,7 +285,7 @@ contains
          associate (cg => cgl%cg)
             if (cg%flag%get()) then
                if (allocated(cg%ri_tgt%seg)) then
-                  do g = lbound(cg%ri_tgt%seg(:), dim=1), ubound(cg%ri_tgt%seg(:), dim=1)
+                  do g = lbound(cg%ri_tgt%seg(:), dim=1, kind=4), ubound(cg%ri_tgt%seg(:), dim=1, kind=4)
                      ! clear own derefine flags (single-thread test)
                      se(:, LO) = cg%ri_tgt%seg(g)%se(:, LO) - perimeter * dom%D_
                      se(:, HI) = cg%ri_tgt%seg(g)%se(:, HI) + perimeter * dom%D_
@@ -299,7 +301,7 @@ contains
                               ! create a list of foreign blocks that need not be derefined (proc, grid_id or SFC_id)
                               ! here we use prolongation structures
                               gscnt(fproc) = gscnt(fproc) + I_ONE
-                              pt_cnt = pt_cnt + 1
+                              pt_cnt = pt_cnt + I_ONE
                               if (pt_cnt > size(pt_list)) call die("[refinement_update:parents_prevent_derefinement_lev] pt_cnt > size(pt_list)")
                               pt_list(pt_cnt) = pt(fproc, ftag)
                            endif
@@ -319,15 +321,15 @@ contains
       ! Apparently gscnt/grcnt represent quite sparse matrix, so we better do nonblocking point-to-point than MPI_AlltoAllv
       nr = 0
       if (pt_cnt > 0) then
-         do g = lbound(pt_list, dim=1), pt_cnt
-            nr = nr + 1
+         do g = lbound(pt_list, dim=1, kind=4), pt_cnt
+            nr = nr + I_ONE
             if (nr > size(req, dim=1)) call inflate_req
             call MPI_Isend(pt_list(g)%tag, I_ONE, MPI_INTEGER, pt_list(g)%proc, I_ZERO, comm, req(nr), mpi_err)
             ! OPT: Perhaps it will be more efficient to allocate arrays according to gscnt and send tags in bunches
          enddo
       endif
 
-      do g = lbound(grcnt, dim=1), ubound(grcnt, dim=1)
+      do g = lbound(grcnt, dim=1, kind=4), ubound(grcnt, dim=1, kind=4)
          if (grcnt(g) /= 0) then
             if (g == proc) call die("[refinement_update:parents_prevent_derefinement] MPI_Recv from self")  ! this is not an error but it should've been handled as local thing
             do i = 1, grcnt(g)

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -356,7 +356,7 @@ contains
 
       use constants,           only: I_ONE
       use dataio_pub,          only: msg, printinfo
-      use mpi,                 only: MPI_DOUBLE_PRECISION
+      use MPIF,                only: MPI_DOUBLE_PRECISION
       use mpisetup,            only: master, nproc, FIRST, LAST, comm, mpi_err
       use multigridvars,       only: tot_ts
 #ifdef SELF_GRAV

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -356,7 +356,7 @@ contains
 
       use constants,           only: I_ONE
       use dataio_pub,          only: msg, printinfo
-      use MPIF,                only: MPI_DOUBLE_PRECISION
+      use MPIF,                only: MPI_DOUBLE_PRECISION, MPI_Gather
       use mpisetup,            only: master, nproc, FIRST, LAST, comm, mpi_err
       use multigridvars,       only: tot_ts
 #ifdef SELF_GRAV

--- a/src/scheme/fluidupdate.F90
+++ b/src/scheme/fluidupdate.F90
@@ -59,7 +59,7 @@ contains
 
    subroutine fluid_update
 
-      use constants,        only: RTVD_SPLIT, RIEMANN_SPLIT, HLLC_SPLIT
+      use constants,        only: RTVD_SPLIT, RIEMANN_SPLIT, HLLC_SPLIT, I_ONE, I_TWO
       use dataio_pub,       only: die
       use domain,           only: dom, is_refined
       use global,           only: which_solver
@@ -72,7 +72,7 @@ contains
 
       call ppp_main%start(fu_label)
 
-      if (is_refined .and. (mod(dom%nb, 2) == 1)) call die("[fluidupdate:fluid_update] odd number of guardcells is known to cause inaccuracies in (M)HD and nonconvergence of V-cycles")
+      if (is_refined .and. (mod(dom%nb, I_TWO) == I_ONE)) call die("[fluidupdate:fluid_update] odd number of guardcells is known to cause inaccuracies in (M)HD and nonconvergence of V-cycles")
 
       select case (which_solver)
          case (HLLC_SPLIT)

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -66,7 +66,7 @@ contains
       use constants, only: LO, HI, I_ONE
       use cg_leaves, only: leaves
       use cg_list,   only: cg_list_element
-      use mpi,       only: MPI_DOUBLE_PRECISION
+      use MPIF,      only: MPI_DOUBLE_PRECISION
       use mpisetup,  only: comm, mpi_err, req, inflate_req
 
       implicit none
@@ -112,7 +112,7 @@ contains
       use dataio_pub, only: die
       use fluidindex, only: flind
       use grid_cont,  only: grid_container
-      use mpi,        only: MPI_STATUS_IGNORE
+      use MPIF,       only: MPI_STATUS_IGNORE
       use mpisetup,   only: mpi_err
       use ppp,        only: ppp_main
 
@@ -176,7 +176,7 @@ contains
       use domain,       only: dom
       use grid_cont,    only: grid_container
       use grid_helpers, only: f2c_o
-      use mpi,          only: MPI_DOUBLE_PRECISION
+      use MPIF,         only: MPI_DOUBLE_PRECISION
       use mpisetup,     only: comm, mpi_err, req, inflate_req
       use ppp,          only: ppp_main
 


### PR DESCRIPTION
Here we're working on smooth transition to `use mpi_f08` and keeping it in coexistence with older method `use mpi`.