### PR TITLE
Remove cg_level_connected::base_level

### DIFF
--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -370,9 +370,10 @@ contains
 
    subroutine timestep_fluid(cg, fl, dt, c_fl)
 
-      use cg_level_connected, only: cg_level_connected_t, find_level
+      use cg_level_connected, only: cg_level_connected_t
       use constants,          only: xdim, ydim, zdim, ndims, GEO_RPZ, ndims, small
       use domain,             only: dom
+      use find_lev,           only: find_level
       use fluidtypes,         only: component_fluid
       use global,             only: cfl, use_fargo
       use grid_cont,          only: grid_container

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -523,9 +523,10 @@ contains
 
    subroutine mgg_cg_init(cg)
 
-      use cg_level_connected, only: cg_level_connected_t, find_level
+      use cg_level_connected, only: cg_level_connected_t
       use constants,          only: fft_none
       use dataio_pub,         only: die
+      use find_lev,           only: find_level
       use func,               only: operator(.notequals.)
       use grid_cont,          only: grid_container
       use multigridvars,      only: overrelax

--- a/src/gravity/multigridmultipole.F90
+++ b/src/gravity/multigridmultipole.F90
@@ -455,8 +455,9 @@ contains
    subroutine domain2moments
 
       use cg_leaves,          only: leaves
+      use cg_level_base,      only: base
       use cg_level_finest,    only: finest
-      use cg_level_connected, only: cg_level_connected_t, base_level
+      use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
       use constants,          only: xdim, zdim, GEO_XYZ, zero, base_level_id, PPP_GRAV
       use dataio_pub,         only: die, msg, warn
@@ -485,7 +486,7 @@ contains
          level => finest%find_finest_bnd()
          cgl => level%first
       else if (mpole_level <= base_level_id) then
-         level => base_level
+         level => base%level
          call finest%level%restrict_to_base_q_1var(source)
          do while (level%l%id > mpole_level)
             if (associated(level%coarser)) then

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -87,7 +87,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
-      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, base_level_id, INVALID, tmr_amr, PPP_AMR
+      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, INVALID, tmr_amr, PPP_AMR
       use dataio_pub,         only: msg, printinfo
       use domain,             only: dom
       use list_of_cg_lists,   only: all_lists

--- a/src/grid/cg_level_base.F90
+++ b/src/grid/cg_level_base.F90
@@ -72,7 +72,6 @@ contains
       use dataio_pub,         only: die
       use domain,             only: dom
       use list_of_cg_lists,   only: all_lists
-      use cg_level_connected, only: base_level
 
       implicit none
 
@@ -94,7 +93,6 @@ contains
 
       call this%level%l%init(base_level_id, int(n_d, kind=8), dom%off)
 
-      base_level => this%level
       call all_lists%register(this%level, "Base level")
 
    end subroutine set

--- a/src/grid/cg_level_base.F90
+++ b/src/grid/cg_level_base.F90
@@ -37,11 +37,18 @@ module cg_level_base
    private
    public :: base
 
+   abstract interface
+      subroutine no_args
+         implicit none
+      end subroutine no_args
+   end interface
+
    !! \brief The pointer of the base level and a method to initialize it
    !> \todo Domainshrinking, expanding and crawling should also be implemented here
    type :: cg_level_base_t
       type(cg_level_connected_t), pointer :: level            !< The base level
-    contains
+      procedure(no_args), nopass, pointer :: init_multigrid   !< a pointer to multigrid:init_multigrid or null()
+   contains
       procedure          :: set                               !< initialize the base level
       procedure          :: expand                            !< add one line of blocks in some directions
       procedure, private :: expand_side                       !< add one line of blocks in selected direction
@@ -81,6 +88,7 @@ contains
       if (any(n_d(:) < 1)) call die("[cg_level_base:set] non-positive base grid sizes")
       if (any(dom%has_dir(:) .neqv. (n_d(:) > 1))) call die("[cg_level_base:set] base grid size incompatible with has_dir masks")
 
+      this%init_multigrid => null()  ! it will be set by init_multigrid, if it is included and called
       allocate(this%level)
       call this%level%init_level
 
@@ -102,9 +110,6 @@ contains
       use dataio_pub,        only: msg, warn
       use domain,            only: dom
       use mpisetup,          only: piernik_MPI_Allreduce, master
-#ifdef MULTIGRID
-      use multigrid,         only: init_multigrid
-#endif /* MULTIGRID */
 
       implicit none
 
@@ -134,9 +139,7 @@ contains
             call warn(msg) ! As long as the restart file does not automagically recognize changed parameters, this message should be easily visible
          endif
          call coarsest%delete_coarser_than_base
-#ifdef MULTIGRID
-         call init_multigrid
-#endif /* MULTIGRID */
+         if (associated(this%init_multigrid)) call this%init_multigrid
          call all_fluid_boundaries
          ! the cg%gp and cg%cs_iso2 are updated in refinement_update::update_refinement which should be called right after domain expansion to fix refinement structure
       endif

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -35,7 +35,7 @@ module cg_level_connected
    implicit none
 
    private
-   public :: cg_level_connected_t, base_level
+   public :: cg_level_connected_t
 
    !! \brief A list of all cg of the same resolution with links to coarser and finer levels
    type, extends(cg_level_t) :: cg_level_connected_t
@@ -70,8 +70,6 @@ module cg_level_connected
       procedure :: free_all_cg                                !< Erase all data on the level, leave it empty
 
    end type cg_level_connected_t
-
-   type(cg_level_connected_t), pointer :: base_level !< The pointer to the base level. Do not use it unless referencing through base%level causes circular dependencies.
 
 contains
 

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -35,7 +35,7 @@ module cg_level_connected
    implicit none
 
    private
-   public :: cg_level_connected_t, base_level, find_level
+   public :: cg_level_connected_t, base_level
 
    !! \brief A list of all cg of the same resolution with links to coarser and finer levels
    type, extends(cg_level_t) :: cg_level_connected_t
@@ -1568,41 +1568,5 @@ contains
       call this%sync_ru
 
    end subroutine free_all_cg
-
-!> \brief Find pointer to a level given by level_id
-
-   function find_level(level_id) result(lev_p)
-
-      use dataio_pub, only: die
-
-      implicit none
-
-      integer(kind=4), intent(in) :: level_id         !< level number (relative to base level)
-
-      type(cg_level_connected_t), pointer :: lev_p, curl
-
-      nullify(lev_p)
-      curl => base_level
-      if (level_id >= base_level%l%id) then
-         do while (associated(curl))
-            if (curl%l%id == level_id) then
-               lev_p => curl
-               exit
-            endif
-            curl => curl%finer
-         enddo
-      else
-         do while (associated(curl))
-            if (curl%l%id == level_id) then
-               lev_p => curl
-               exit
-            endif
-            curl => curl%coarser
-         enddo
-      endif
-
-      if (.not. associated(lev_p)) call die("[cg_level_connected:find_level] Cannot find level")
-
-   end function find_level
 
 end module cg_level_connected

--- a/src/grid/find_level.F90
+++ b/src/grid/find_level.F90
@@ -1,0 +1,78 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+#include "piernik.h"
+
+!> \brief This module provides a function to find a pointer to a level based on level ID
+
+module find_lev
+
+   implicit none
+
+   private
+   public :: find_level
+
+contains
+
+!> \brief Find pointer to a level given by level_id
+
+   function find_level(level_id) result(lev_p)
+
+      use cg_level_base,      only: base
+      use cg_level_connected, only: cg_level_connected_t
+      use dataio_pub,         only: die
+
+      implicit none
+
+      integer(kind=4), intent(in) :: level_id         !< level number (relative to base level)
+
+      type(cg_level_connected_t), pointer :: lev_p, curl
+
+      nullify(lev_p)
+      curl => base%level
+      if (level_id >= base%level%l%id) then
+         do while (associated(curl))
+            if (curl%l%id == level_id) then
+               lev_p => curl
+               exit
+            endif
+            curl => curl%finer
+         enddo
+      else
+         do while (associated(curl))
+            if (curl%l%id == level_id) then
+               lev_p => curl
+               exit
+            endif
+            curl => curl%coarser
+         enddo
+      endif
+
+      if (.not. associated(lev_p)) call die("[find_level:find_level] Cannot find level")
+
+   end function find_level
+
+end module

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -194,7 +194,7 @@ contains
       use cg_list,            only: cg_list_element
       use cg_level_base,      only: base
       use cg_level_coarsest,  only: coarsest
-      use cg_level_connected, only: cg_level_connected_t, base_level
+      use cg_level_connected, only: cg_level_connected_t
       use cg_level_finest,    only: finest
       use constants,          only: PIERNIK_INIT_GRID, I_ONE, refinement_factor
       use dataio_pub,         only: printinfo, warn, die, code_progress, msg
@@ -225,8 +225,8 @@ contains
       endif
 
       do j = 0, level_incredible
-         if (any((mod(base_level%l%n_d(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .or. base_level%l%n_d(:)/refinement_factor**(j+1) < minsize(:)) .and. dom%has_dir(:))) exit
-         if (any((mod(base_level%l%off(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .and. dom%has_dir(:)))) exit
+         if (any((mod(base%level%l%n_d(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .or. base%level%l%n_d(:)/refinement_factor**(j+1) < minsize(:)) .and. dom%has_dir(:))) exit
+         if (any((mod(base%level%l%off(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .and. dom%has_dir(:)))) exit
       enddo
       if (level_depth > j) then
          if (master) then
@@ -260,7 +260,7 @@ contains
          curl => curl%coarser ! descend until null() is encountered
       enddo
 
-      curl => base_level%coarser
+      curl => base%level%coarser
       do while (associated(curl))
          if (master) then
             if (curl%l%id == -level_depth .and. single_base) then

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -192,6 +192,7 @@ contains
    subroutine init_multigrid
 
       use cg_list,            only: cg_list_element
+      use cg_level_base,      only: base
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t, base_level
       use cg_level_finest,    only: finest
@@ -210,12 +211,13 @@ contains
       integer(kind=4)       :: j
 
       type(cg_list_element), pointer :: cgl
-      type(cg_level_connected_t), pointer :: curl          !< current level (a pointer sliding along the linked list) and temporary level
-      type(grid_container),  pointer :: cg            !< current grid container
+      type(cg_level_connected_t), pointer :: curl  !< current level (a pointer sliding along the linked list) and temporary level
+      type(grid_container),  pointer :: cg         !< current grid container
 
       if (code_progress < PIERNIK_INIT_GRID) call die("[multigrid:init_multigrid] grid, geometry, constants or arrays not initialized")
       ! This check is too weak (geometry), arrays are required only for multigrid_gravity
 
+      base%init_multigrid => init_multigrid
 
       if (level_depth <= 0) then
          if (master) call warn("[multigrid:init_multigrid] level_depth < 1: solving on a single grid may be extremely slow")

--- a/src/scheme/rtvd_split/solve_cg_rtvd.F90
+++ b/src/scheme/rtvd_split/solve_cg_rtvd.F90
@@ -50,10 +50,11 @@ contains
    subroutine solve_cg_rtvd(cg, cdim, istep, fargo_vel)
 
       use bfc_bcc,            only: interpolate_mag_field
-      use cg_level_connected, only: cg_level_connected_t, find_level
+      use cg_level_connected, only: cg_level_connected_t
       use constants,          only: pdims, LO, HI, uh_n, cs_i2_n, ORTHO1, ORTHO2, VEL_CR, VEL_RES, ydim, rk_coef
       use dataio_pub,         only: die
       use domain,             only: dom
+      use find_lev,           only: find_level
       use fluidindex,         only: flind, iarr_all_swp, nmag, iarr_all_dn, iarr_all_mx
       use fluxtypes,          only: ext_fluxes
       use global,             only: dt, use_fargo


### PR DESCRIPTION
There was a workaround for years due to circular dependency through `cg_level_base::expand`. Now it should be possible to use `base%level` everywhere instead. 