### PR TITLE
Faster arr4d boundaries

### DIFF
--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -370,9 +370,10 @@ contains
 
    subroutine timestep_fluid(cg, fl, dt, c_fl)
 
-      use cg_level_connected, only: cg_level_connected_t, find_level
+      use cg_level_connected, only: cg_level_connected_t
       use constants,          only: xdim, ydim, zdim, ndims, GEO_RPZ, ndims, small
       use domain,             only: dom
+      use find_lev,           only: find_level
       use fluidtypes,         only: component_fluid
       use global,             only: cfl, use_fargo
       use grid_cont,          only: grid_container

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -523,9 +523,10 @@ contains
 
    subroutine mgg_cg_init(cg)
 
-      use cg_level_connected, only: cg_level_connected_t, find_level
+      use cg_level_connected, only: cg_level_connected_t
       use constants,          only: fft_none
       use dataio_pub,         only: die
+      use find_lev,           only: find_level
       use func,               only: operator(.notequals.)
       use grid_cont,          only: grid_container
       use multigridvars,      only: overrelax

--- a/src/gravity/multigridmultipole.F90
+++ b/src/gravity/multigridmultipole.F90
@@ -455,8 +455,9 @@ contains
    subroutine domain2moments
 
       use cg_leaves,          only: leaves
+      use cg_level_base,      only: base
       use cg_level_finest,    only: finest
-      use cg_level_connected, only: cg_level_connected_t, base_level
+      use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
       use constants,          only: xdim, zdim, GEO_XYZ, zero, base_level_id, PPP_GRAV
       use dataio_pub,         only: die, msg, warn
@@ -485,7 +486,7 @@ contains
          level => finest%find_finest_bnd()
          cgl => level%first
       else if (mpole_level <= base_level_id) then
-         level => base_level
+         level => base%level
          call finest%level%restrict_to_base_q_1var(source)
          do while (level%l%id > mpole_level)
             if (associated(level%coarser)) then

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -139,7 +139,7 @@ contains
          call piernik_MPI_Allreduce(g_cnt, pSUM)
          write(msg(len_trim(msg)+1:),'(i6)') g_cnt
          if (associated(curl, this%coarsest_leaves)) b_cnt = g_cnt
-         call curl%vertical_prep
+         call curl%vertical_prep  ! is it necessary here?
          curl => curl%finer
       enddo
       g_cnt = leaves%cnt

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -87,7 +87,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
-      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, base_level_id, INVALID, tmr_amr, PPP_AMR
+      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, INVALID, tmr_amr, PPP_AMR
       use dataio_pub,         only: msg, printinfo
       use domain,             only: dom
       use list_of_cg_lists,   only: all_lists

--- a/src/grid/cg_level_base.F90
+++ b/src/grid/cg_level_base.F90
@@ -72,7 +72,6 @@ contains
       use dataio_pub,         only: die
       use domain,             only: dom
       use list_of_cg_lists,   only: all_lists
-      use cg_level_connected, only: base_level
 
       implicit none
 
@@ -94,7 +93,6 @@ contains
 
       call this%level%l%init(base_level_id, int(n_d, kind=8), dom%off)
 
-      base_level => this%level
       call all_lists%register(this%level, "Base level")
 
    end subroutine set

--- a/src/grid/cg_level_base.F90
+++ b/src/grid/cg_level_base.F90
@@ -37,11 +37,18 @@ module cg_level_base
    private
    public :: base
 
+   abstract interface
+      subroutine no_args
+         implicit none
+      end subroutine no_args
+   end interface
+
    !! \brief The pointer of the base level and a method to initialize it
    !> \todo Domainshrinking, expanding and crawling should also be implemented here
    type :: cg_level_base_t
       type(cg_level_connected_t), pointer :: level            !< The base level
-    contains
+      procedure(no_args), nopass, pointer :: init_multigrid   !< a pointer to multigrid:init_multigrid or null()
+   contains
       procedure          :: set                               !< initialize the base level
       procedure          :: expand                            !< add one line of blocks in some directions
       procedure, private :: expand_side                       !< add one line of blocks in selected direction
@@ -81,6 +88,7 @@ contains
       if (any(n_d(:) < 1)) call die("[cg_level_base:set] non-positive base grid sizes")
       if (any(dom%has_dir(:) .neqv. (n_d(:) > 1))) call die("[cg_level_base:set] base grid size incompatible with has_dir masks")
 
+      this%init_multigrid => null()  ! it will be set by init_multigrid, if it is included and called
       allocate(this%level)
       call this%level%init_level
 
@@ -102,9 +110,6 @@ contains
       use dataio_pub,        only: msg, warn
       use domain,            only: dom
       use mpisetup,          only: piernik_MPI_Allreduce, master
-#ifdef MULTIGRID
-      use multigrid,         only: init_multigrid
-#endif /* MULTIGRID */
 
       implicit none
 
@@ -134,9 +139,7 @@ contains
             call warn(msg) ! As long as the restart file does not automagically recognize changed parameters, this message should be easily visible
          endif
          call coarsest%delete_coarser_than_base
-#ifdef MULTIGRID
-         call init_multigrid
-#endif /* MULTIGRID */
+         if (associated(this%init_multigrid)) call this%init_multigrid
          call all_fluid_boundaries
          ! the cg%gp and cg%cs_iso2 are updated in refinement_update::update_refinement which should be called right after domain expansion to fix refinement structure
       endif

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -51,7 +51,7 @@ module cg_level_connected
       procedure :: init_level                                 !< common initialization for base level and other levels
 
       ! Prolongation and restriction
-      procedure :: vertical_prep                              !< initialize prolongation and restriction targets
+      procedure :: vertical_prep                              !< initialize prolongation and restriction targets; not PRIVATE because of single call in cg_leaves:update
       procedure :: prolong                                    !< interpolate the grid data which has the flag vital set to this%finer level
       procedure :: restrict                                   !< interpolate the grid data which has the flag vital set from this%coarser level
       procedure :: restrict_to_base                           !< restrict all variables to the base level
@@ -63,7 +63,7 @@ module cg_level_connected
       procedure :: restrict_to_base_w_1var                    !< restrict specified w field to the base level
       procedure :: arr3d_boundaries                           !< Set up all guardcells (internal, external and fine-coarse) for given rank-3 arrays.
       procedure :: arr4d_boundaries                           !< Set up all guardcells (internal, external and fine-coarse) for given rank-4 arrays.
-      procedure :: prolong_bnd_from_coarser                   !< Interpolate boundaries from coarse level at fine-coarse interfaces
+      procedure, private :: prolong_bnd_from_coarser          !< Interpolate boundaries from coarse level at fine-coarse interfaces
       procedure, private :: vertical_b_prep                   !< Initialize prolongation targets for fine-coarse boundary exchange
       procedure, private :: vertical_bf_prep                  !< Initialize prolongation targets for fine->coarse flux exchange
       procedure :: sync_ru                                    !< Synchronize this%recently_changed and set flags for update requests

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -35,7 +35,7 @@ module cg_level_connected
    implicit none
 
    private
-   public :: cg_level_connected_t, base_level
+   public :: cg_level_connected_t
 
    !! \brief A list of all cg of the same resolution with links to coarser and finer levels
    type, extends(cg_level_t) :: cg_level_connected_t
@@ -70,8 +70,6 @@ module cg_level_connected
       procedure :: free_all_cg                                !< Erase all data on the level, leave it empty
 
    end type cg_level_connected_t
-
-   type(cg_level_connected_t), pointer :: base_level !< The pointer to the base level. Do not use it unless referencing through base%level causes circular dependencies.
 
 contains
 

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -49,25 +49,28 @@ module cg_level_connected
 
       ! Level management
       procedure :: init_level                                 !< common initialization for base level and other levels
+      procedure :: sync_ru                                    !< Synchronize this%recently_changed and set flags for update requests
+      procedure :: free_all_cg                                !< Erase all data on the level, leave it empty
 
       ! Prolongation and restriction
       procedure :: vertical_prep                              !< initialize prolongation and restriction targets; not PRIVATE because of single call in cg_leaves:update
+      procedure, private :: vertical_b_prep                   !< Initialize prolongation targets for fine-coarse boundary exchange
+      procedure, private :: vertical_bf_prep                  !< Initialize prolongation targets for fine->coarse flux exchange
+
       procedure :: prolong                                    !< interpolate the grid data which has the flag vital set to this%finer level
+      procedure :: prolong_q_1var                             !< interpolate the grid data in specified q field to this%finer level
+      procedure, private :: prolong_bnd_from_coarser          !< Interpolate boundaries from coarse level at fine-coarse interfaces
+
       procedure :: restrict                                   !< interpolate the grid data which has the flag vital set from this%coarser level
       procedure :: restrict_to_base                           !< restrict all variables to the base level
-      procedure :: prolong_q_1var                             !< interpolate the grid data in specified q field to this%finer level
-      procedure :: restrict_q_1var                            !< interpolate the grid data in specified q field to this%coarser level
-      procedure :: restrict_w_1var                            !< interpolate the grid data in specified w field to this%coarser level
       procedure :: restrict_to_floor_q_1var                   !< restrict specified q field as much as possible
       procedure :: restrict_to_base_q_1var                    !< restrict specified q field to the base level
       procedure :: restrict_to_base_w_1var                    !< restrict specified w field to the base level
+      procedure :: restrict_q_1var                            !< interpolate the grid data in specified q field to this%coarser level
+      procedure :: restrict_w_1var                            !< interpolate the grid data in specified w field to this%coarser level
+
       procedure :: arr3d_boundaries                           !< Set up all guardcells (internal, external and fine-coarse) for given rank-3 arrays.
       procedure :: arr4d_boundaries                           !< Set up all guardcells (internal, external and fine-coarse) for given rank-4 arrays.
-      procedure, private :: prolong_bnd_from_coarser          !< Interpolate boundaries from coarse level at fine-coarse interfaces
-      procedure, private :: vertical_b_prep                   !< Initialize prolongation targets for fine-coarse boundary exchange
-      procedure, private :: vertical_bf_prep                  !< Initialize prolongation targets for fine->coarse flux exchange
-      procedure :: sync_ru                                    !< Synchronize this%recently_changed and set flags for update requests
-      procedure :: free_all_cg                                !< Erase all data on the level, leave it empty
 
    end type cg_level_connected_t
 
@@ -94,6 +97,77 @@ contains
       allocate(this%l)
 
    end subroutine init_level
+
+!>
+!! \brief Synchronize this%recently_changed and set flags for update requests
+!!
+!! \details Enforce update on all levels of refinement.
+!! This is a bit overkill in most cases, but if refinement happens right after domain expansion, some grid_id may change due to radical change of SFC indices.
+!! After change of grid_id, some tags for vertical exchanges change (in cg_level::create after call to dot%update local), so everything requires update.
+!!
+!! Possible solution: keep grid_id constant (but allow recycling old values)
+!! Also important: implement SFC searching for vertical communication to cut costs.
+!<
+
+   subroutine sync_ru(this)
+
+      use constants, only: pLOR, INVALID
+      use mpisetup,  only: piernik_MPI_Allreduce
+
+      implicit none
+
+      class(cg_level_connected_t), target, intent(inout) :: this
+
+      class(cg_level_connected_t), pointer :: curl
+
+      call piernik_MPI_Allreduce(this%recently_changed, pLOR)
+      if (this%recently_changed) then
+         this%need_vb_update = .true.
+         this%ord_prolong_set = INVALID
+         curl => this
+         do while (associated(curl%finer))
+            curl%finer%need_vb_update = .true.
+            curl%finer%ord_prolong_set = INVALID
+            curl => curl%finer
+         enddo
+         curl => this
+         do while (associated(curl%coarser))
+            curl%coarser%need_vb_update = .true.
+            curl%coarser%ord_prolong_set = INVALID
+            curl => curl%coarser
+         enddo
+         this%recently_changed = .false.
+      endif
+
+   end subroutine sync_ru
+
+!> \brief Erase all data on the level, leave it empty
+
+   subroutine free_all_cg(this)
+
+      use cg_list,          only: cg_list_element
+      use grid_cont,        only: grid_container
+      use list_of_cg_lists, only: all_lists
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this
+
+      type(cg_list_element), pointer :: cgl, aux
+      type(grid_container),  pointer :: cg
+
+      call this%cleanup
+      cgl => this%first
+      do while (associated(cgl))
+         aux => cgl
+         cgl => cgl%nxt
+         cg => aux%cg
+         call all_lists%forget(cg)
+      enddo
+      this%recently_changed = .true.
+      call this%sync_ru
+
+   end subroutine free_all_cg
 
 !>
 !! \brief Initialize prolongation and restriction targets. Called from init_multigrid.
@@ -306,761 +380,6 @@ contains
       call ppp_main%stop(vp_label, PPP_AMR)
 
    end subroutine vertical_prep
-
-!>
-!! \brief interpolate the grid data which has the flag vital set to this%finer level
-!!
-!! The communication is done on 3D arrays. This means that there are as many communication events as there are "vital" arrays present.
-!!
-!! \todo Implement a more efficient alternative to this%prolong_q_1var that would restrict all fields at once
-!! (requires a lot more temporary buffers for a 4D array).
-!<
-   subroutine prolong(this, bnd_type)
-
-      use constants,        only: base_level_id, GEO_RPZ, PPP_AMR
-      use dataio_pub,       only: warn
-      use domain,           only: dom
-      use fluidindex,       only: iarr_all_my
-      use named_array_list, only: qna, wna
-      use ppp,              only: ppp_main
-
-      implicit none
-
-      class(cg_level_connected_t), target, intent(inout) :: this       !< object invoking type-bound procedure
-      integer(kind=4), optional,           intent(in)    :: bnd_type   !< Override default boundary type on external boundaries (useful in multigrid solver).
-
-      integer(kind=4) :: i, iw
-      character(len=*), parameter :: proq_label = "prolong_qna", prow_label = "prolong_wna"
-
-      call ppp_main%start(proq_label, PPP_AMR)
-      do i = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
-         if (qna%lst(i)%vital .and. (qna%lst(i)%multigrid .or. this%l%id >= base_level_id)) call this%prolong_q_1var(i, bnd_type = bnd_type)
-         ! Although we aren't worried too much by nonconservation of psi or multigrid fields here
-         ! but it will be worth checking if cnservative high-order prolongation can help.
-      enddo
-      call ppp_main%stop(proq_label, PPP_AMR)
-
-      call ppp_main%start(prow_label, PPP_AMR)
-      do i = lbound(wna%lst(:), dim=1, kind=4), ubound(wna%lst(:), dim=1, kind=4)
-         if (wna%lst(i)%vital .and. (wna%lst(i)%multigrid .or. this%l%id >= base_level_id)) then
-            qna%lst(qna%wai)%ord_prolong = 0 !> \todo implement high order conservative prolongation and use wna%lst(i)%ord_prolong here
-            if (wna%lst(i)%multigrid) call warn("[cg_level_connected:prolong] mg set for cg%w ???")
-            do iw = 1, wna%lst(i)%dim4
-               call this%wq_copy(i, iw, qna%wai)
-               if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%mul_by_r(qna%wai) ! angular momentum conservation
-               if (.true.) then  !> Quick and dirty fix for cases when cg%ignore_prolongation == .true.
-                  call this%finer%wq_copy(i, iw, qna%wai)
-                  if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%finer%mul_by_r(qna%wai)
-               endif
-               call this%prolong_q_1var(qna%wai, wna%lst(i)%position(iw), bnd_type = bnd_type)
-               if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%finer%div_by_r(qna%wai) ! angular momentum conservation
-               call this%finer%qw_copy(qna%wai, i, iw) !> \todo filter this through cg%ignore_prolongation
-            enddo
-         endif
-      enddo
-      call ppp_main%stop(prow_label, PPP_AMR)
-
-   end subroutine prolong
-
-!>
-!! \brief interpolate the grid data which has the flag vital set from this%coarser level
-!!
-!! \todo Implement a more efficient alternative to this%restrict_q_1var that would restrict all fields at once
-!! (requires a lot more temporary buffers for a 4D array).
-!!
-!<
-   subroutine restrict(this)
-
-      use constants,        only: base_level_id, PPP_AMR
-      use dataio_pub,       only: warn
-      use named_array_list, only: qna, wna
-      use ppp,              only: ppp_main
-
-      implicit none
-
-      class(cg_level_connected_t), target, intent(inout) :: this !< object invoking type-bound procedure
-
-      integer(kind=4) :: i
-      character(len=*), parameter :: resq_label = "restrict_qna", resw_label = "restrict_wna"
-
-      call ppp_main%start(resq_label, PPP_AMR)
-      do i = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
-         if (qna%lst(i)%vital .and. (qna%lst(i)%multigrid .or. this%l%id > base_level_id)) call this%restrict_q_1var(i)
-      enddo
-      call ppp_main%stop(resq_label, PPP_AMR)
-
-      call ppp_main%start(resw_label, PPP_AMR)
-      do i = lbound(wna%lst(:), dim=1, kind=4), ubound(wna%lst(:), dim=1, kind=4)
-         if (wna%lst(i)%vital .and. (wna%lst(i)%multigrid .or. this%l%id > base_level_id)) then
-            if (wna%lst(i)%multigrid) call warn("[cg_level_connected:restrict] mg set for cg%w ???")
-            call this%restrict_w_1var(i)
-         endif
-      enddo
-
-      call ppp_main%stop(resw_label, PPP_AMR)
-
-   end subroutine restrict
-
-!> \brief Restrict all variables to the base level
-
-   recursive subroutine restrict_to_base(this)
-
-      use constants, only: base_level_id
-
-      implicit none
-
-      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
-
-      if (this%l%id <= base_level_id) return
-      call this%restrict
-      call this%coarser%restrict_to_base
-
-   end subroutine restrict_to_base
-
-!> \brief Restrict as much as possible
-
-   recursive subroutine restrict_to_floor_q_1var(this, iv)
-
-      implicit none
-
-      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
-      integer(kind=4),             intent(in)    :: iv   !< variable to be restricted
-
-      if (.not. associated(this%coarser)) return
-      call this%restrict_q_1var(iv)
-      call this%coarser%restrict_to_floor_q_1var(iv)
-
-   end subroutine restrict_to_floor_q_1var
-
-!> \brief Restrict to the base level
-
-   recursive subroutine restrict_to_base_q_1var(this, iv)
-
-      use constants, only: base_level_id
-
-      implicit none
-
-      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
-      integer(kind=4),             intent(in)    :: iv   !< variable to be restricted
-
-      if (this%l%id <= base_level_id) return
-      call this%restrict_q_1var(iv)
-      call this%coarser%restrict_to_base_q_1var(iv)
-
-   end subroutine restrict_to_base_q_1var
-
-   recursive subroutine restrict_to_base_w_1var(this, iv)
-
-      use constants, only: base_level_id
-
-      implicit none
-
-      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
-      integer(kind=4),             intent(in)    :: iv   !< variable to be restricted
-
-      if (this%l%id <= base_level_id) return
-      call this%restrict_w_1var(iv)
-      call this%coarser%restrict_to_base_w_1var(iv)
-
-   end subroutine restrict_to_base_w_1var
-
-!> \brief Quick and dirty restriction of 4D arrays. OPTIMIZE ME!
-
-   subroutine restrict_w_1var(this, i)
-
-      use constants,        only: GEO_RPZ
-      use domain,           only: dom
-      use fluidindex,       only: iarr_all_my
-      use named_array_list, only: qna, wna
-
-      implicit none
-
-      class(cg_level_connected_t), target, intent(inout) :: this  !< object invoking type-bound procedure
-      integer(kind=4),                     intent(in)    :: i     !< variable to be restricted
-
-      integer(kind=4) :: iw
-
-      do iw = 1, wna%lst(i)%dim4
-         call this%wq_copy(i, iw, qna%wai)
-         if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%mul_by_r(qna%wai) ! angular momentum conservation
-         if (.true.) then  ! this is required because we don't use (.not. cg%leafmap) mask in the this%coarser%qw_copy call below
-            call this%coarser%wq_copy(i, iw, qna%wai)
-            if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%coarser%mul_by_r(qna%wai)
-         endif
-         call this%restrict_q_1var(qna%wai, wna%lst(i)%position(iw))
-         if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%coarser%div_by_r(qna%wai) ! angular momentum conservation
-         call this%coarser%qw_copy(qna%wai, i, iw)
-      enddo
-   end subroutine restrict_w_1var
-
-!>
-!! \brief Simplest restriction (averaging).
-!!
-!! \todo implement high order restriction and test its influence on V-cycle convergence rate. Watch f/c boundaries.
-!!
-!! \details Some data can be locally copied without MPI, but this seems to have really little impact on the performance.
-!! Some tests show that purely MPI code without local copies is marginally faster.
-!!
-!! OPT Usually there are many messages that are sent between the same pairs of processes
-!! \todo Sort all messages according to e.g. tag and send/receive aggregated message with everything
-!!
-!! \todo implement local copies without MPI anyway
-!<
-
-   subroutine restrict_q_1var(this, iv, pos)
-
-      use constants,        only: xdim, ydim, zdim, ndims, LO, HI, I_ONE, refinement_factor, VAR_CENTER, GEO_XYZ, GEO_RPZ
-      use dataio_pub,       only: msg, warn, die
-      use domain,           only: dom
-      use cg_list,          only: cg_list_element
-      use grid_cont,        only: grid_container
-      use mpisetup,         only: err_mpi, req, inflate_req, master
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUSES_IGNORE, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend, MPI_Waitall
-      use named_array,      only: p3
-      use named_array_list, only: qna
-
-      implicit none
-
-      class(cg_level_connected_t), target, intent(inout) :: this !< object invoking type-bound procedure
-      integer(kind=4),                     intent(in)    :: iv   !< variable to be restricted
-      integer(kind=4), optional,           intent(in)    :: pos  !< position of the variable within cell
-
-      type(cg_level_connected_t), pointer                :: coarse
-      integer                                            :: g
-      integer(kind=8), dimension(xdim:zdim, LO:HI)       :: fse, cse              !< shortcuts for fine segment and coarse segment
-      integer(kind=8)                                    :: i, j, k, ic, jc, kc
-      integer(kind=8), dimension(xdim:zdim)              :: off1
-      real                                               :: norm
-      integer(kind=4)                                    :: nr
-      type(cg_list_element), pointer                     :: cgl
-      type(grid_container),  pointer                     :: cg                    !< current grid container
-      logical, save                                      :: warned = .false.
-      integer                                            :: position
-
-      position = qna%lst(iv)%position(I_ONE)
-      if (present(pos)) position = pos
-      if (position /= VAR_CENTER .and. .not. warned) then
-         if (master) call warn("[cg_level_connected:restrict_q_1var] Only cell-centered interpolation scheme is implemented. Expect inaccurate results for variables that are placed on faces or corners")
-         warned = .true.
-      endif
-
-      coarse => this%coarser
-      if (.not. associated(coarse)) then ! can't restrict base level
-         write(msg,'(a,i3)')"[cg_level_connected:restrict_q_1var] no coarser level than ", this%l%id
-         call warn(msg)
-         return
-      endif
-
-      call this%vertical_prep
-      call coarse%vertical_prep
-
-      ! be ready to receive everything into right buffers
-      nr = 0
-      cgl => coarse%first
-      do while (associated(cgl))
-         cg => cgl%cg
-         if (allocated(cg%ri_tgt%seg)) then
-            do g = lbound(cg%ri_tgt%seg(:), dim=1), ubound(cg%ri_tgt%seg(:), dim=1)
-               nr = nr + I_ONE
-               if (nr > size(req, dim=1)) call inflate_req
-               call MPI_Irecv(cg%ri_tgt%seg(g)%buf(1, 1, 1), size(cg%ri_tgt%seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, cg%ri_tgt%seg(g)%proc, cg%ri_tgt%seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
-            enddo
-         endif
-         cgl => cgl%nxt
-      enddo
-
-      ! interpolate to coarse buffer and send it
-      norm = 1./refinement_factor**dom%eff_dim
-      cgl => this%first
-      do while (associated(cgl))
-         cg => cgl%cg
-         do g = lbound(cg%ro_tgt%seg(:), dim=1), ubound(cg%ro_tgt%seg(:), dim=1)
-
-            cg%ro_tgt%seg(g)%buf(:, :, :) = 0.
-            fse(:,:) = cg%ro_tgt%seg(g)%se(:,:)
-            off1(:) = mod(cg%ro_tgt%seg(g)%se(:, LO), int(refinement_factor, kind=8))
-            if (all(off1 == 0) .and. all(mod(fse(:, HI)-fse(:, LO), int(refinement_factor, kind=8)) == 1) .and. dom%eff_dim == ndims) then
-               ! This is the easy, even offset/even size case. Happens in AMR and when UG has regular cartesian decomposition.
-               ! It is few times faster than the code for odd cases below
-               select case (dom%geometry_type)
-                  case (GEO_XYZ)
-                     cg%ro_tgt%seg(g)%buf(1:1+(fse(xdim, HI)-fse(xdim, LO))/refinement_factor, &
-                          &               1:1+(fse(ydim, HI)-fse(ydim, LO))/refinement_factor, &
-                          &               1:1+(fse(zdim, HI)-fse(zdim, LO))/refinement_factor) = ( &
-                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
-                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
-                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
-                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
-                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
-                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
-                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
-                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO)+1:fse(zdim, HI):2)) * norm
-                     case (GEO_RPZ)
-                        do i = fse(xdim, LO), fse(xdim, HI)
-                           cg%ro_tgt%seg(g)%buf     (  1+(i            -fse(xdim, LO))/refinement_factor, &
-                                &                    1:1+(fse(ydim, HI)-fse(ydim, LO))/refinement_factor, &
-                                &                    1:1+(fse(zdim, HI)-fse(zdim, LO))/refinement_factor) = &
-                                cg%ro_tgt%seg(g)%buf(  1+(i            -fse(xdim, LO))/refinement_factor, &
-                                &                    1:1+(fse(ydim, HI)-fse(ydim, LO))/refinement_factor, &
-                                &                    1:1+(fse(zdim, HI)-fse(zdim, LO))/refinement_factor) + ( &
-                                cg%q(iv)%arr(i, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
-                                cg%q(iv)%arr(i, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
-                                cg%q(iv)%arr(i, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
-                                cg%q(iv)%arr(i, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO)+1:fse(zdim, HI):2)) * norm * cg%x(i)
-                        enddo
-                  case default
-                     call die("[cg_level_connected:restrict_q_1var] Unknown geometry (1)")
-               end select
-            else
-               ! OPT: Split the problem into the core that can be done by array arithmetic and finish the edges where necessary
-               do k = fse(zdim, LO), fse(zdim, HI)
-                  kc = (k-fse(zdim, LO)+off1(zdim))/refinement_factor + 1
-                  do j = fse(ydim, LO), fse(ydim, HI)
-                     jc = (j-fse(ydim, LO)+off1(ydim))/refinement_factor + 1
-                     do i = fse(xdim, LO), fse(xdim, HI)
-                        ic = (i-fse(xdim, LO)+off1(xdim))/refinement_factor + 1
-                        select case (dom%geometry_type)
-                           case (GEO_XYZ)
-                              cg%ro_tgt%seg(g)%buf(ic, jc, kc) = cg%ro_tgt%seg(g)%buf(ic, jc, kc) + cg%q(iv)%arr(i, j, k) * norm
-                           case (GEO_RPZ)
-                              cg%ro_tgt%seg(g)%buf(ic, jc, kc) = cg%ro_tgt%seg(g)%buf(ic, jc, kc) + cg%q(iv)%arr(i, j, k) * norm * cg%x(i)
-                           case default
-                              call die("[cg_level_connected:restrict_q_1var] Unknown geometry (2)")
-                        end select
-                     enddo
-                  enddo
-               enddo
-            endif
-            nr = nr + I_ONE
-            if (nr > size(req, dim=1)) call inflate_req
-            call MPI_Isend(cg%ro_tgt%seg(g)%buf(1, 1, 1), size(cg%ro_tgt%seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, cg%ro_tgt%seg(g)%proc, cg%ro_tgt%seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
-         enddo
-         cgl => cgl%nxt
-      enddo
-
-      if (nr > 0) call MPI_Waitall(nr, req(:nr), MPI_STATUSES_IGNORE, err_mpi)
-
-      ! copy the received buffers to the right places
-      cgl => coarse%first
-      do while (associated(cgl))
-         cg => cgl%cg
-         if (allocated(cg%ri_tgt%seg)) then
-            where (.not. cg%leafmap(:,:,:)) cg%q(iv)%arr(cg%is:cg%ie, cg%js:cg%je, cg%ks:cg%ke) = 0. ! disables check_dirty
-            do g = lbound(cg%ri_tgt%seg(:), dim=1), ubound(cg%ri_tgt%seg(:), dim=1)
-               cse(:,:) = cg%ri_tgt%seg(g)%se(:,:)
-               select case (dom%geometry_type)
-                  case (GEO_XYZ) ! do nothing
-                  case (GEO_RPZ)
-                     do i = lbound(cg%ri_tgt%seg(g)%buf, dim=1), ubound(cg%ri_tgt%seg(g)%buf, dim=1)
-                        ic = cse(xdim, LO) +i - lbound(cg%ri_tgt%seg(g)%buf, dim=1)
-                        cg%ri_tgt%seg(g)%buf(i, :, :) = cg%ri_tgt%seg(g)%buf(i, :, :) / cg%x(ic)
-                     enddo
-                  case default
-                     call die("[cg_level_connected:restrict_q_1var] Unknown geometry")
-               end select
-               p3 => cg%q(iv)%span(cse)
-               p3 = p3 + cg%ri_tgt%seg(g)%buf(:, :, :) !errors on overlap?
-            enddo
-         endif
-         cgl => cgl%nxt
-      enddo
-
-   end subroutine restrict_q_1var
-
-!>
-!! \brief Perform prolongation of one 3D variable
-!!
-!! \details This routine communicates selected 3D array from coarse to fine grid.
-!! The prolonged data is then copied to the destination if the cg%ignore_prolongation allows it.
-!! OPT: Find a way to prolong only what is really needed.
-!!
-!! OPT Usually there are many messages that are sent between the same pairs of processes
-!! \todo Sort all messages according to e.g. tag and send/receive aggregated message with everything
-!! \todo implement local copies without MPI
-!<
-
-   subroutine prolong_q_1var(this, iv, pos, bnd_type)
-
-      use cg_list,          only: cg_list_element
-      use constants,        only: xdim, ydim, zdim, LO, HI, I_ONE, I_ZERO, VAR_CENTER, ndims, PPP_AMR  !, dirtyH1
-      use dataio_pub,       only: msg, warn
-      use grid_cont,        only: grid_container
-      use grid_helpers,     only: f2c
-      use mpisetup,         only: err_mpi, req, inflate_req, master
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUSES_IGNORE, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend, MPI_Waitall
-      use named_array_list, only: qna
-      use ppp,              only: ppp_main
-
-      implicit none
-
-      class(cg_level_connected_t), target, intent(inout) :: this     !< object invoking type-bound procedure
-      integer(kind=4),                     intent(in)    :: iv       !< variable to be prolonged
-      integer(kind=4), optional,           intent(in)    :: pos      !< position of the variable within cell
-      integer(kind=4), optional,           intent(in)    :: bnd_type !< Override default boundary type on external boundaries (useful in multigrid solver).
-
-      type(cg_level_connected_t), pointer                :: fine
-      integer                                            :: g
-      integer(kind=8), dimension(xdim:zdim, LO:HI)       :: cse              !< shortcut for coarse segment
-      integer(kind=4)                                    :: nr
-      type(cg_list_element),            pointer          :: cgl
-      type(grid_container),             pointer          :: cg               !< current grid container
-      real, dimension(:,:,:),           pointer          :: p3d
-      logical, save                                      :: warned = .false.
-      integer                                            :: position
-      integer(kind=8), dimension(ndims, LO:HI)           :: box_8            !< temporary storage
-      character(len=*), parameter :: pq1_label = "prolong_q1v"
-
-      call ppp_main%start(pq1_label, PPP_AMR)
-
-      position = qna%lst(iv)%position(I_ONE)
-      if (present(pos)) position = pos
-      if (position /= VAR_CENTER .and. .not. warned) then
-         if (master) call warn("[cg_level_connected:prolong_q_1var] Only cell-centered interpolation scheme is implemented. Expect inaccurate results for variables that are placed on faces or corners")
-         warned = .true.
-      endif
-
-      fine => this%finer
-      if (.not. associated(fine)) then ! can't prolong finest level
-         write(msg,'(a,i3)')"[cg_level_connected:prolong_q_1var] no finer level than: ", this%l%id
-         call warn(msg)
-         return
-      endif
-
-      call this%vertical_prep
-      call fine%vertical_prep
-
-!      call fine%set_dirty(iv, (0.895+0.0001*fine%l%id)*dirtyH1) !> \todo filter this through cg%ignore_prolongation
-
-      if (this%ord_prolong_set /= I_ZERO) then
-         !> \todo some variables may need special care on external boundaries
-         call this%arr3d_boundaries(iv, bnd_type = bnd_type)
-      endif
-      call this%check_dirty(iv, "prolong-")
-
-      nr = 0
-      ! be ready to receive everything into right buffers
-      cgl => fine%first
-      do while (associated(cgl))
-         cg => cgl%cg
-         associate( seg => cg%pi_tgt%seg )
-         if (allocated(cg%pi_tgt%seg)) then
-            do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
-               nr = nr + I_ONE
-               if (nr > size(req, dim=1)) call inflate_req
-               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
-            enddo
-         endif
-         end associate
-         cgl => cgl%nxt
-      enddo
-
-      ! send coarse data
-      cgl => this%first
-      do while (associated(cgl))
-         cg => cgl%cg
-         associate( seg => cg%po_tgt%seg )
-         do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
-
-            cse = seg(g)%se
-            nr = nr + I_ONE
-            if (nr > size(req, dim=1)) call inflate_req
-            p3d => cg%q(iv)%span(cse)
-            seg(g)%buf(:, :, :) = p3d
-            call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
-         enddo
-         end associate
-         cgl => cgl%nxt
-      enddo
-
-      if (nr > 0) call MPI_Waitall(nr, req(:nr), MPI_STATUSES_IGNORE, err_mpi)
-
-      ! merge received coarse data into one array and interpolate it into the right place
-      cgl => fine%first
-      do while (associated(cgl))
-         cg => cgl%cg
-         if (allocated(cg%pi_tgt%seg) .and. .not. cg%ignore_prolongation) then
-
-            do g = lbound(cg%pi_tgt%seg(:), dim=1), ubound(cg%pi_tgt%seg(:), dim=1)
-
-               cse = cg%pi_tgt%seg(g)%se
-               cg%prolong_(cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI)) = cg%pi_tgt%seg(g)%buf(:,:,:)
-
-               !> When this%ord_prolong_set /= I_ZERO, the received cg%pi_tgt%seg(:)%buf(:,:,:) may overlap
-               !! The incoming data thus must either contain valid guardcells (even if qna%lst(iv)%ord_prolong == O_INJ)
-               !! or the guardcells must be zeroed before sending data and received buffer should be added to cg%prolong_(:,:,:) not just assigned
-
-            enddo
-
-            box_8 = int(cg%ijkse, kind=8)
-            cse = f2c(box_8)
-            call cg%prolong(iv, cse, p_xyz = .false.) ! prolong directly to cg%q(iv)%arr
-
-         endif
-         cgl => cgl%nxt
-      enddo
-      call ppp_main%stop(pq1_label, PPP_AMR)
-
-      call fine%check_dirty(iv, "prolong+")
-
-   end subroutine prolong_q_1var
-
-!> \brief This routine sets up all guardcells (internal, external and fine-coarse) for given rank-3 arrays.
-
-   subroutine arr3d_boundaries(this, ind, area_type, bnd_type, dir, nocorners)
-
-      use constants,        only: PPP_AMR
-      use named_array_list, only: qna
-      use ppp,              only: ppp_main
-
-      implicit none
-
-      class(cg_level_connected_t), intent(inout) :: this      !< the list on which to perform the boundary exchange
-      integer(kind=4),             intent(in)    :: ind       !< index of cg%q(:) 3d array
-      integer(kind=4), optional,   intent(in)    :: area_type !< defines how do we treat boundaries
-      integer(kind=4), optional,   intent(in)    :: bnd_type  !< Override default boundary type on external boundaries (useful in multigrid solver).
-                                                              !< Note that BND_PER, BND_MPI, BND_SHE and BND_COR aren't external and cannot be overridden
-      integer(kind=4), optional,   intent(in)    :: dir       !< select only this direction
-      logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
-
-      integer(kind=4) :: ord_saved
-      character(len=*), parameter :: a3b_label = "level:arr3d_boundaries", a3bp_label = "level:arr3d_boundaries:prolong"
-
-      call ppp_main%start(a3b_label)
-
-      ord_saved = qna%lst(ind)%ord_prolong
-
-      call this%dirty_boundaries(ind)
-      call ppp_main%start(a3bp_label, PPP_AMR)
-      call this%prolong_bnd_from_coarser(ind, bnd_type=bnd_type, dir=dir, nocorners=nocorners)
-      call ppp_main%stop(a3bp_label, PPP_AMR)
-      call this%level_3d_boundaries(ind, area_type=area_type, bnd_type=bnd_type, dir=dir, nocorners=nocorners)
-      ! The correctness of the sequence of calls above may depend on the implementation of internal boundary exchange
-
-      qna%lst(ind)%ord_prolong = ord_saved
-
-      call ppp_main%stop(a3b_label)
-
-   end subroutine arr3d_boundaries
-
-!> \brief This routine sets up all guardcells (internal, external and fine-coarse) for given rank-4 arrays.
-
-   subroutine arr4d_boundaries(this, ind, area_type, dir, nocorners)
-
-      use constants,        only: base_level_id, PPP_AMR
-      use named_array_list, only: qna, wna
-      use ppp,              only: ppp_main
-
-      implicit none
-
-      class(cg_level_connected_t), intent(inout) :: this      !< the list on which to perform the boundary exchange
-      integer(kind=4),             intent(in)    :: ind       !< index of cg%w(:) 4d array
-      integer(kind=4), optional,   intent(in)    :: area_type !< defines how do we treat boundaries
-      integer(kind=4), optional,   intent(in)    :: dir       !< select only this direction
-      logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
-
-      integer(kind=4) :: iw
-      character(len=*), parameter :: a4b_label = "level:arr4d_boundaries", a4bp_label = "level:arr4d_boundaries:prolong"
-
-      call ppp_main%start(a4b_label)
-
-!      call this%dirty_boundaries(ind)
-!      call this%clear_boundaries(ind, value=10.)
-
-      call ppp_main%start(a4bp_label, PPP_AMR)
-      if (associated(this%coarser) .and. this%l%id > base_level_id) then
-         do iw = 1, wna%lst(ind)%dim4
-            ! here we can use any high order prolongation without destroying conservation
-
-            ! OPT: this is insanely safe but highly inefficient implementation.
-            ! A lot of data is copied there and back through cg%wa
-            ! but only small fraction of it is actually used in boundary prolongation.
-
-            qna%lst(qna%wai)%ord_prolong = wna%lst(ind)%ord_prolong
-            call this%coarser%wq_copy(ind, iw, qna%wai)
-            call this%wq_copy(ind, iw, qna%wai) !> Quick and dirty fix for cases when cg%ignore_prolongation == .true.
-            call this%prolong_bnd_from_coarser(qna%wai, dir=dir, nocorners=nocorners)
-            call this%qw_copy(qna%wai, ind, iw) !> \todo filter this through cg%ignore_prolongation
-         enddo
-      endif
-      call ppp_main%stop(a4bp_label, PPP_AMR)
-
-      call this%level_4d_boundaries(ind, area_type=area_type, dir=dir, nocorners=nocorners)
-
-      call ppp_main%stop(a4b_label)
-
-   end subroutine arr4d_boundaries
-
-!>
-!! \brief Interpolate boundaries from coarse level at fine-coarse interfaces
-!!
-!! \details There are two possible approaches to the problem of prolongation of the data from coarse level to the fine guardcells on the fine-coarse interface
-!! * Interpolate the coarse data only
-!! * interpolate the coarse and fine data
-!! When the order of interpolation is 0 (injection) both methods degenerate into one.
-!! Both methods have their area of applicability amd both should be implemented.
-!! \warning This routine does only the first approach.
-!!
-!! \todo implement local copies without MPI
-!<
-
-   subroutine prolong_bnd_from_coarser(this, ind, bnd_type, dir, nocorners)
-
-      use cg_list,        only: cg_list_element
-      use cg_list_global, only: all_cg
-      use constants,      only: I_ONE, xdim, ydim, zdim, LO, HI, refinement_factor, ndims, O_INJ, base_level_id, PPP_AMR, PPP_MPI  !, dirtyH1
-      use dataio_pub,     only: warn
-      use domain,         only: dom
-      use grid_cont,      only: grid_container
-      use grid_helpers,   only: f2c, c2f
-      use MPIF,           only: MPI_DOUBLE_PRECISION, MPI_STATUSES_IGNORE, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend, MPI_Waitall
-      use mpisetup,       only: err_mpi, req, inflate_req, master
-      use ppp,            only: ppp_main
-
-      implicit none
-
-      class(cg_level_connected_t), intent(inout) :: this      !< the list on which to perform the boundary exchange
-      integer(kind=4),             intent(in)    :: ind       !< index of the prolonged variable
-      integer(kind=4), optional,   intent(in)    :: bnd_type  !< Override default boundary type on external boundaries (useful in multigrid solver).
-                                                              !< Note that BND_PER, BND_MPI, BND_SHE and BND_COR aren't external and cannot be overridden
-      integer(kind=4), optional,   intent(in)    :: dir       !< select only this direction
-      logical,         optional,   intent(in)    :: nocorners !< when .true. then don't care about proper edge and corner update
-
-      type(cg_level_connected_t), pointer :: coarse
-      type(cg_list_element), pointer :: cgl
-      type(grid_container),  pointer :: cg            !< current grid container
-      integer(kind=8), dimension(xdim:zdim, LO:HI) :: cse, fse ! shortcuts for fine segment and coarse segment
-      integer(kind=8), dimension(xdim:zdim) :: per, ext_buf
-      integer(kind=4) :: nr
-      integer :: g
-      logical, allocatable, dimension(:,:,:) :: updatemap
-      integer(kind=8), dimension(ndims, LO:HI)  :: box_8   !< temporary storage
-      logical, save :: firstcall = .true.
-      character(len=*), parameter :: pbc_label = "prolong_bnd_from_coarser" , pbcv_label = "prolong_bnd_from_coarser:vbp", pbcw_label = "prolong_bnd_from_coarser:Waitall"
-
-      if (present(dir)) then
-         if (firstcall .and. master) call warn("[cg_level_connected:prolong_bnd_from_coarser] dir present but not implemented yet")
-      endif
-      if (present(nocorners)) then
-         if (firstcall .and. master) call warn("[cg_level_connected:prolong_bnd_from_coarser] nocorners present but not implemented yet")
-      endif
-
-      firstcall = .false.
-
-      coarse => this%coarser
-
-      if (.not. associated(coarse)) return
-      if (this%l%id == base_level_id) return ! There are no fine/coarse boundaries on the base level by definition
-
-      call ppp_main%start(pbc_label, PPP_AMR)
-      call ppp_main%start(pbcv_label, PPP_AMR)
-      call this%vertical_b_prep
-      call coarse%vertical_b_prep
-      call ppp_main%stop(pbcv_label, PPP_AMR)
-
-      !call this%clear_boundaries(ind, (0.885+0.0001*this%l%id)*dirtyH1) ! not implemented yet
-      ext_buf = dom%D_ * all_cg%ord_prolong_nb ! extension of the buffers due to stencil range
-      if (all_cg%ord_prolong_nb /= O_INJ) call coarse%level_3d_boundaries(ind, bnd_type = bnd_type) ! it is really hard to determine which exchanges can be omitted
-      ! bnd_type = BND_NEGREF above is critical for convergence of multigrid with isolated boundaries.
-
-      nr = 0
-      ! be ready to receive everything into right buffers
-      cgl => this%first
-      do while (associated(cgl))
-         associate ( seg => cgl%cg%pib_tgt%seg )
-         if (allocated(cgl%cg%pib_tgt%seg)) then
-            do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
-               nr = nr + I_ONE
-               if (nr > size(req, dim=1)) call inflate_req
-               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
-            enddo
-         endif
-         end associate
-         cgl => cgl%nxt
-      enddo
-
-      ! send coarse data
-      cgl => coarse%first
-      do while (associated(cgl))
-         associate( seg => cgl%cg%pob_tgt%seg )
-         if (allocated(cgl%cg%pob_tgt%seg)) then
-            do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
-
-               cse = seg(g)%se
-               cse(:, LO) = cse(:, LO) - ext_buf
-               cse(:, HI) = cse(:, HI) + ext_buf
-
-               nr = nr + I_ONE
-               if (nr > size(req, dim=1)) call inflate_req
-               seg(g)%buf(:, :, :) = cgl%cg%q(ind)%arr(cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI))
-               call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
-            enddo
-         endif
-         end associate
-         cgl => cgl%nxt
-      enddo
-
-      if (nr > 0) then
-         call ppp_main%start(pbcw_label, PPP_AMR + PPP_MPI)
-         call MPI_Waitall(nr, req(:nr), MPI_STATUSES_IGNORE, err_mpi)
-         call ppp_main%stop(pbcw_label, PPP_AMR + PPP_MPI)
-      endif
-
-      ! merge received coarse data into one array and interpolate it into the right place
-      per(:) = 0
-      where (dom%periodic(:)) per(:) = coarse%l%n_d(:)
-
-      cgl => this%first
-      do while (associated(cgl))
-         cg => cgl%cg
-
-         associate ( seg => cg%pib_tgt%seg )
-         if (allocated(cg%pib_tgt%seg)) then
-
-            !> \todo restore dirty checks when the implementation will be complete
-            cg%prolong_ = 3. !dirtyH
-            cg%prolong_x = 7.
-            cg%prolong_xy = 15.
-            cg%prolong_xyz = 31.
-
-            if (size(seg) > 0) then ! this if looks to be necessary to prevent polluting on the base level. Strange. \todo Check out why and fix it.
-
-               allocate(updatemap(cg%lhn(xdim, LO):cg%lhn(xdim, HI), cg%lhn(ydim, LO):cg%lhn(ydim, HI), cg%lhn(zdim, LO):cg%lhn(zdim, HI)))
-               updatemap = .false.
-
-               do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
-
-                  cse = seg(g)%se
-                  cse(:, LO) = cse(:, LO) - ext_buf
-                  cse(:, HI) = cse(:, HI) + ext_buf
-                  cg%prolong_(cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI)) = seg(g)%buf(:,:,:)
-
-                  fse = c2f(seg(g)%se)
-                  fse(:, LO) = max(fse(:, LO), int(cg%lhn(:, LO), kind=8))
-                  fse(:, HI) = min(fse(:, HI), int(cg%lhn(:, HI), kind=8))
-                  updatemap(fse(xdim, LO):fse(xdim, HI), fse(ydim, LO):fse(ydim, HI), fse(zdim, LO):fse(zdim, HI)) = .true.
-                  !> When this%ord_prolong_set /= I_ZERO, the received seg(:)%buf(:,:,:) may overlap
-                  !! The incoming data thus must either contain valid guardcells (even if qna%lst(iv)%ord_prolong == O_INJ)
-                  !! or the guardcells must be zeroed before sending data and received buffer should be added to cg%prolong_(:,:,:) not just assigned
-
-               enddo
-
-               box_8 = int(cg%ijkse, kind=8)
-               cse = f2c(box_8)
-               cse(:, LO) = cse(:, LO) - dom%nb*dom%D_(:)/refinement_factor
-               cse(:, HI) = cse(:, HI) + dom%nb*dom%D_(:)/refinement_factor
-
-               call cg%prolong(ind, cse, p_xyz = .true.) ! prolong to auxiliary array cg%prolong_xyz. OPT find a way to avoid unnecessary calculations where .not. updatemap
-
-               where (updatemap) cg%q(ind)%arr = cg%prolong_xyz
-               deallocate(updatemap)
-            endif
-         endif
-         end associate
-         cgl => cgl%nxt
-      enddo
-      call ppp_main%stop(pbc_label, PPP_AMR)
-
-   end subroutine prolong_bnd_from_coarser
 
 !>
 !! \brief Initialize prolongation targets for fine-coarse boundary exchange
@@ -1508,74 +827,758 @@ contains
    end subroutine vertical_bf_prep
 
 !>
-!! \brief Synchronize this%recently_changed and set flags for update requests
+!! \brief interpolate the grid data which has the flag vital set to this%finer level
 !!
-!! \details Enforce update on all levels of refinement.
-!! This is a bit overkill in most cases, but if refinement happens right after domain expansion, some grid_id may change due to radical change of SFC indices.
-!! After change of grid_id, some tags for vertical exchanges change (in cg_level::create after call to dot%update local), so everything requires update.
+!! The communication is done on 3D arrays. This means that there are as many communication events as there are "vital" arrays present.
 !!
-!! Possible solution: keep grid_id constant (but allow recycling old values)
-!! Also important: implement SFC searching for vertical communication to cut costs.
+!! \todo Implement a more efficient alternative to this%prolong_q_1var that would restrict all fields at once
+!! (requires a lot more temporary buffers for a 4D array).
+!<
+   subroutine prolong(this, bnd_type)
+
+      use constants,        only: base_level_id, GEO_RPZ, PPP_AMR
+      use dataio_pub,       only: warn
+      use domain,           only: dom
+      use fluidindex,       only: iarr_all_my
+      use named_array_list, only: qna, wna
+      use ppp,              only: ppp_main
+
+      implicit none
+
+      class(cg_level_connected_t), target, intent(inout) :: this       !< object invoking type-bound procedure
+      integer(kind=4), optional,           intent(in)    :: bnd_type   !< Override default boundary type on external boundaries (useful in multigrid solver).
+
+      integer(kind=4) :: i, iw
+      character(len=*), parameter :: proq_label = "prolong_qna", prow_label = "prolong_wna"
+
+      call ppp_main%start(proq_label, PPP_AMR)
+      do i = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
+         if (qna%lst(i)%vital .and. (qna%lst(i)%multigrid .or. this%l%id >= base_level_id)) call this%prolong_q_1var(i, bnd_type = bnd_type)
+         ! Although we aren't worried too much by nonconservation of psi or multigrid fields here
+         ! but it will be worth checking if cnservative high-order prolongation can help.
+      enddo
+      call ppp_main%stop(proq_label, PPP_AMR)
+
+      call ppp_main%start(prow_label, PPP_AMR)
+      do i = lbound(wna%lst(:), dim=1, kind=4), ubound(wna%lst(:), dim=1, kind=4)
+         if (wna%lst(i)%vital .and. (wna%lst(i)%multigrid .or. this%l%id >= base_level_id)) then
+            qna%lst(qna%wai)%ord_prolong = 0 !> \todo implement high order conservative prolongation and use wna%lst(i)%ord_prolong here
+            if (wna%lst(i)%multigrid) call warn("[cg_level_connected:prolong] mg set for cg%w ???")
+            do iw = 1, wna%lst(i)%dim4
+               call this%wq_copy(i, iw, qna%wai)
+               if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%mul_by_r(qna%wai) ! angular momentum conservation
+               if (.true.) then  !> Quick and dirty fix for cases when cg%ignore_prolongation == .true.
+                  call this%finer%wq_copy(i, iw, qna%wai)
+                  if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%finer%mul_by_r(qna%wai)
+               endif
+               call this%prolong_q_1var(qna%wai, wna%lst(i)%position(iw), bnd_type = bnd_type)
+               if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%finer%div_by_r(qna%wai) ! angular momentum conservation
+               call this%finer%qw_copy(qna%wai, i, iw) !> \todo filter this through cg%ignore_prolongation
+            enddo
+         endif
+      enddo
+      call ppp_main%stop(prow_label, PPP_AMR)
+
+   end subroutine prolong
+
+!>
+!! \brief Perform prolongation of one 3D variable
+!!
+!! \details This routine communicates selected 3D array from coarse to fine grid.
+!! The prolonged data is then copied to the destination if the cg%ignore_prolongation allows it.
+!! OPT: Find a way to prolong only what is really needed.
+!!
+!! OPT Usually there are many messages that are sent between the same pairs of processes
+!! \todo Sort all messages according to e.g. tag and send/receive aggregated message with everything
+!! \todo implement local copies without MPI
 !<
 
-   subroutine sync_ru(this)
-
-      use constants, only: pLOR, INVALID
-      use mpisetup,  only: piernik_MPI_Allreduce
-
-      implicit none
-
-      class(cg_level_connected_t), target, intent(inout) :: this
-
-      class(cg_level_connected_t), pointer :: curl
-
-      call piernik_MPI_Allreduce(this%recently_changed, pLOR)
-      if (this%recently_changed) then
-         this%need_vb_update = .true.
-         this%ord_prolong_set = INVALID
-         curl => this
-         do while (associated(curl%finer))
-            curl%finer%need_vb_update = .true.
-            curl%finer%ord_prolong_set = INVALID
-            curl => curl%finer
-         enddo
-         curl => this
-         do while (associated(curl%coarser))
-            curl%coarser%need_vb_update = .true.
-            curl%coarser%ord_prolong_set = INVALID
-            curl => curl%coarser
-         enddo
-         this%recently_changed = .false.
-      endif
-
-   end subroutine sync_ru
-
-!> \brief Erase all data on the level, leave it empty
-
-   subroutine free_all_cg(this)
+   subroutine prolong_q_1var(this, iv, pos, bnd_type)
 
       use cg_list,          only: cg_list_element
+      use constants,        only: xdim, ydim, zdim, LO, HI, I_ONE, I_ZERO, VAR_CENTER, ndims, PPP_AMR  !, dirtyH1
+      use dataio_pub,       only: msg, warn
       use grid_cont,        only: grid_container
-      use list_of_cg_lists, only: all_lists
+      use grid_helpers,     only: f2c
+      use mpisetup,         only: err_mpi, req, inflate_req, master
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUSES_IGNORE, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend, MPI_Waitall
+      use named_array_list, only: qna
+      use ppp,              only: ppp_main
 
       implicit none
 
-      class(cg_level_connected_t), intent(inout) :: this
+      class(cg_level_connected_t), target, intent(inout) :: this     !< object invoking type-bound procedure
+      integer(kind=4),                     intent(in)    :: iv       !< variable to be prolonged
+      integer(kind=4), optional,           intent(in)    :: pos      !< position of the variable within cell
+      integer(kind=4), optional,           intent(in)    :: bnd_type !< Override default boundary type on external boundaries (useful in multigrid solver).
 
-      type(cg_list_element), pointer :: cgl, aux
-      type(grid_container),  pointer :: cg
+      type(cg_level_connected_t), pointer                :: fine
+      integer                                            :: g
+      integer(kind=8), dimension(xdim:zdim, LO:HI)       :: cse              !< shortcut for coarse segment
+      integer(kind=4)                                    :: nr
+      type(cg_list_element),            pointer          :: cgl
+      type(grid_container),             pointer          :: cg               !< current grid container
+      real, dimension(:,:,:),           pointer          :: p3d
+      logical, save                                      :: warned = .false.
+      integer                                            :: position
+      integer(kind=8), dimension(ndims, LO:HI)           :: box_8            !< temporary storage
+      character(len=*), parameter :: pq1_label = "prolong_q1v"
 
-      call this%cleanup
+      call ppp_main%start(pq1_label, PPP_AMR)
+
+      position = qna%lst(iv)%position(I_ONE)
+      if (present(pos)) position = pos
+      if (position /= VAR_CENTER .and. .not. warned) then
+         if (master) call warn("[cg_level_connected:prolong_q_1var] Only cell-centered interpolation scheme is implemented. Expect inaccurate results for variables that are placed on faces or corners")
+         warned = .true.
+      endif
+
+      fine => this%finer
+      if (.not. associated(fine)) then ! can't prolong finest level
+         write(msg,'(a,i3)')"[cg_level_connected:prolong_q_1var] no finer level than: ", this%l%id
+         call warn(msg)
+         return
+      endif
+
+      call this%vertical_prep
+      call fine%vertical_prep
+
+!      call fine%set_dirty(iv, (0.895+0.0001*fine%l%id)*dirtyH1) !> \todo filter this through cg%ignore_prolongation
+
+      if (this%ord_prolong_set /= I_ZERO) then
+         !> \todo some variables may need special care on external boundaries
+         call this%arr3d_boundaries(iv, bnd_type = bnd_type)
+      endif
+      call this%check_dirty(iv, "prolong-")
+
+      nr = 0
+      ! be ready to receive everything into right buffers
+      cgl => fine%first
+      do while (associated(cgl))
+         cg => cgl%cg
+         associate( seg => cg%pi_tgt%seg )
+         if (allocated(cg%pi_tgt%seg)) then
+            do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
+               nr = nr + I_ONE
+               if (nr > size(req, dim=1)) call inflate_req
+               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+            enddo
+         endif
+         end associate
+         cgl => cgl%nxt
+      enddo
+
+      ! send coarse data
       cgl => this%first
       do while (associated(cgl))
-         aux => cgl
-         cgl => cgl%nxt
-         cg => aux%cg
-         call all_lists%forget(cg)
-      enddo
-      this%recently_changed = .true.
-      call this%sync_ru
+         cg => cgl%cg
+         associate( seg => cg%po_tgt%seg )
+         do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
 
-   end subroutine free_all_cg
+            cse = seg(g)%se
+            nr = nr + I_ONE
+            if (nr > size(req, dim=1)) call inflate_req
+            p3d => cg%q(iv)%span(cse)
+            seg(g)%buf(:, :, :) = p3d
+            call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+         enddo
+         end associate
+         cgl => cgl%nxt
+      enddo
+
+      if (nr > 0) call MPI_Waitall(nr, req(:nr), MPI_STATUSES_IGNORE, err_mpi)
+
+      ! merge received coarse data into one array and interpolate it into the right place
+      cgl => fine%first
+      do while (associated(cgl))
+         cg => cgl%cg
+         if (allocated(cg%pi_tgt%seg) .and. .not. cg%ignore_prolongation) then
+
+            do g = lbound(cg%pi_tgt%seg(:), dim=1), ubound(cg%pi_tgt%seg(:), dim=1)
+
+               cse = cg%pi_tgt%seg(g)%se
+               cg%prolong_(cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI)) = cg%pi_tgt%seg(g)%buf(:,:,:)
+
+               !> When this%ord_prolong_set /= I_ZERO, the received cg%pi_tgt%seg(:)%buf(:,:,:) may overlap
+               !! The incoming data thus must either contain valid guardcells (even if qna%lst(iv)%ord_prolong == O_INJ)
+               !! or the guardcells must be zeroed before sending data and received buffer should be added to cg%prolong_(:,:,:) not just assigned
+
+            enddo
+
+            box_8 = int(cg%ijkse, kind=8)
+            cse = f2c(box_8)
+            call cg%prolong(iv, cse, p_xyz = .false.) ! prolong directly to cg%q(iv)%arr
+
+         endif
+         cgl => cgl%nxt
+      enddo
+      call ppp_main%stop(pq1_label, PPP_AMR)
+
+      call fine%check_dirty(iv, "prolong+")
+
+   end subroutine prolong_q_1var
+
+!>
+!! \brief Interpolate boundaries from coarse level at fine-coarse interfaces
+!!
+!! \details There are two possible approaches to the problem of prolongation of the data from coarse level to the fine guardcells on the fine-coarse interface
+!! * Interpolate the coarse data only
+!! * interpolate the coarse and fine data
+!! When the order of interpolation is 0 (injection) both methods degenerate into one.
+!! Both methods have their area of applicability amd both should be implemented.
+!! \warning This routine does only the first approach.
+!!
+!! \todo implement local copies without MPI
+!<
+
+   subroutine prolong_bnd_from_coarser(this, ind, bnd_type, dir, nocorners)
+
+      use cg_list,        only: cg_list_element
+      use cg_list_global, only: all_cg
+      use constants,      only: I_ONE, xdim, ydim, zdim, LO, HI, refinement_factor, ndims, O_INJ, base_level_id, PPP_AMR, PPP_MPI  !, dirtyH1
+      use dataio_pub,     only: warn
+      use domain,         only: dom
+      use grid_cont,      only: grid_container
+      use grid_helpers,   only: f2c, c2f
+      use MPIF,           only: MPI_DOUBLE_PRECISION, MPI_STATUSES_IGNORE, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend, MPI_Waitall
+      use mpisetup,       only: err_mpi, req, inflate_req, master
+      use ppp,            only: ppp_main
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this      !< the list on which to perform the boundary exchange
+      integer(kind=4),             intent(in)    :: ind       !< index of the prolonged variable
+      integer(kind=4), optional,   intent(in)    :: bnd_type  !< Override default boundary type on external boundaries (useful in multigrid solver).
+                                                              !< Note that BND_PER, BND_MPI, BND_SHE and BND_COR aren't external and cannot be overridden
+      integer(kind=4), optional,   intent(in)    :: dir       !< select only this direction
+      logical,         optional,   intent(in)    :: nocorners !< when .true. then don't care about proper edge and corner update
+
+      type(cg_level_connected_t), pointer :: coarse
+      type(cg_list_element), pointer :: cgl
+      type(grid_container),  pointer :: cg            !< current grid container
+      integer(kind=8), dimension(xdim:zdim, LO:HI) :: cse, fse ! shortcuts for fine segment and coarse segment
+      integer(kind=8), dimension(xdim:zdim) :: per, ext_buf
+      integer(kind=4) :: nr
+      integer :: g
+      logical, allocatable, dimension(:,:,:) :: updatemap
+      integer(kind=8), dimension(ndims, LO:HI)  :: box_8   !< temporary storage
+      logical, save :: firstcall = .true.
+      character(len=*), parameter :: pbc_label = "prolong_bnd_from_coarser" , pbcv_label = "prolong_bnd_from_coarser:vbp", pbcw_label = "prolong_bnd_from_coarser:Waitall"
+
+      if (present(dir)) then
+         if (firstcall .and. master) call warn("[cg_level_connected:prolong_bnd_from_coarser] dir present but not implemented yet")
+      endif
+      if (present(nocorners)) then
+         if (firstcall .and. master) call warn("[cg_level_connected:prolong_bnd_from_coarser] nocorners present but not implemented yet")
+      endif
+
+      firstcall = .false.
+
+      coarse => this%coarser
+
+      if (.not. associated(coarse)) return
+      if (this%l%id == base_level_id) return ! There are no fine/coarse boundaries on the base level by definition
+
+      call ppp_main%start(pbc_label, PPP_AMR)
+      call ppp_main%start(pbcv_label, PPP_AMR)
+      call this%vertical_b_prep
+      call coarse%vertical_b_prep
+      call ppp_main%stop(pbcv_label, PPP_AMR)
+
+      !call this%clear_boundaries(ind, (0.885+0.0001*this%l%id)*dirtyH1) ! not implemented yet
+      ext_buf = dom%D_ * all_cg%ord_prolong_nb ! extension of the buffers due to stencil range
+      if (all_cg%ord_prolong_nb /= O_INJ) call coarse%level_3d_boundaries(ind, bnd_type = bnd_type) ! it is really hard to determine which exchanges can be omitted
+      ! bnd_type = BND_NEGREF above is critical for convergence of multigrid with isolated boundaries.
+
+      nr = 0
+      ! be ready to receive everything into right buffers
+      cgl => this%first
+      do while (associated(cgl))
+         associate ( seg => cgl%cg%pib_tgt%seg )
+         if (allocated(cgl%cg%pib_tgt%seg)) then
+            do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
+               nr = nr + I_ONE
+               if (nr > size(req, dim=1)) call inflate_req
+               call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+            enddo
+         endif
+         end associate
+         cgl => cgl%nxt
+      enddo
+
+      ! send coarse data
+      cgl => coarse%first
+      do while (associated(cgl))
+         associate( seg => cgl%cg%pob_tgt%seg )
+         if (allocated(cgl%cg%pob_tgt%seg)) then
+            do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
+
+               cse = seg(g)%se
+               cse(:, LO) = cse(:, LO) - ext_buf
+               cse(:, HI) = cse(:, HI) + ext_buf
+
+               nr = nr + I_ONE
+               if (nr > size(req, dim=1)) call inflate_req
+               seg(g)%buf(:, :, :) = cgl%cg%q(ind)%arr(cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI))
+               call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+            enddo
+         endif
+         end associate
+         cgl => cgl%nxt
+      enddo
+
+      if (nr > 0) then
+         call ppp_main%start(pbcw_label, PPP_AMR + PPP_MPI)
+         call MPI_Waitall(nr, req(:nr), MPI_STATUSES_IGNORE, err_mpi)
+         call ppp_main%stop(pbcw_label, PPP_AMR + PPP_MPI)
+      endif
+
+      ! merge received coarse data into one array and interpolate it into the right place
+      per(:) = 0
+      where (dom%periodic(:)) per(:) = coarse%l%n_d(:)
+
+      cgl => this%first
+      do while (associated(cgl))
+         cg => cgl%cg
+
+         associate ( seg => cg%pib_tgt%seg )
+         if (allocated(cg%pib_tgt%seg)) then
+
+            !> \todo restore dirty checks when the implementation will be complete
+            cg%prolong_ = 3. !dirtyH
+            cg%prolong_x = 7.
+            cg%prolong_xy = 15.
+            cg%prolong_xyz = 31.
+
+            if (size(seg) > 0) then ! this if looks to be necessary to prevent polluting on the base level. Strange. \todo Check out why and fix it.
+
+               allocate(updatemap(cg%lhn(xdim, LO):cg%lhn(xdim, HI), cg%lhn(ydim, LO):cg%lhn(ydim, HI), cg%lhn(zdim, LO):cg%lhn(zdim, HI)))
+               updatemap = .false.
+
+               do g = lbound(seg(:), dim=1), ubound(seg(:), dim=1)
+
+                  cse = seg(g)%se
+                  cse(:, LO) = cse(:, LO) - ext_buf
+                  cse(:, HI) = cse(:, HI) + ext_buf
+                  cg%prolong_(cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI)) = seg(g)%buf(:,:,:)
+
+                  fse = c2f(seg(g)%se)
+                  fse(:, LO) = max(fse(:, LO), int(cg%lhn(:, LO), kind=8))
+                  fse(:, HI) = min(fse(:, HI), int(cg%lhn(:, HI), kind=8))
+                  updatemap(fse(xdim, LO):fse(xdim, HI), fse(ydim, LO):fse(ydim, HI), fse(zdim, LO):fse(zdim, HI)) = .true.
+                  !> When this%ord_prolong_set /= I_ZERO, the received seg(:)%buf(:,:,:) may overlap
+                  !! The incoming data thus must either contain valid guardcells (even if qna%lst(iv)%ord_prolong == O_INJ)
+                  !! or the guardcells must be zeroed before sending data and received buffer should be added to cg%prolong_(:,:,:) not just assigned
+
+               enddo
+
+               box_8 = int(cg%ijkse, kind=8)
+               cse = f2c(box_8)
+               cse(:, LO) = cse(:, LO) - dom%nb*dom%D_(:)/refinement_factor
+               cse(:, HI) = cse(:, HI) + dom%nb*dom%D_(:)/refinement_factor
+
+               call cg%prolong(ind, cse, p_xyz = .true.) ! prolong to auxiliary array cg%prolong_xyz. OPT find a way to avoid unnecessary calculations where .not. updatemap
+
+               where (updatemap) cg%q(ind)%arr = cg%prolong_xyz
+               deallocate(updatemap)
+            endif
+         endif
+         end associate
+         cgl => cgl%nxt
+      enddo
+      call ppp_main%stop(pbc_label, PPP_AMR)
+
+   end subroutine prolong_bnd_from_coarser
+
+!>
+!! \brief interpolate the grid data which has the flag vital set from this%coarser level
+!!
+!! \todo Implement a more efficient alternative to this%restrict_q_1var that would restrict all fields at once
+!! (requires a lot more temporary buffers for a 4D array).
+!!
+!<
+   subroutine restrict(this)
+
+      use constants,        only: base_level_id, PPP_AMR
+      use dataio_pub,       only: warn
+      use named_array_list, only: qna, wna
+      use ppp,              only: ppp_main
+
+      implicit none
+
+      class(cg_level_connected_t), target, intent(inout) :: this !< object invoking type-bound procedure
+
+      integer(kind=4) :: i
+      character(len=*), parameter :: resq_label = "restrict_qna", resw_label = "restrict_wna"
+
+      call ppp_main%start(resq_label, PPP_AMR)
+      do i = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
+         if (qna%lst(i)%vital .and. (qna%lst(i)%multigrid .or. this%l%id > base_level_id)) call this%restrict_q_1var(i)
+      enddo
+      call ppp_main%stop(resq_label, PPP_AMR)
+
+      call ppp_main%start(resw_label, PPP_AMR)
+      do i = lbound(wna%lst(:), dim=1, kind=4), ubound(wna%lst(:), dim=1, kind=4)
+         if (wna%lst(i)%vital .and. (wna%lst(i)%multigrid .or. this%l%id > base_level_id)) then
+            if (wna%lst(i)%multigrid) call warn("[cg_level_connected:restrict] mg set for cg%w ???")
+            call this%restrict_w_1var(i)
+         endif
+      enddo
+
+      call ppp_main%stop(resw_label, PPP_AMR)
+
+   end subroutine restrict
+
+!> \brief Restrict all variables to the base level
+
+   recursive subroutine restrict_to_base(this)
+
+      use constants, only: base_level_id
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
+
+      if (this%l%id <= base_level_id) return
+      call this%restrict
+      call this%coarser%restrict_to_base
+
+   end subroutine restrict_to_base
+
+!> \brief Restrict as much as possible
+
+   recursive subroutine restrict_to_floor_q_1var(this, iv)
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
+      integer(kind=4),             intent(in)    :: iv   !< variable to be restricted
+
+      if (.not. associated(this%coarser)) return
+      call this%restrict_q_1var(iv)
+      call this%coarser%restrict_to_floor_q_1var(iv)
+
+   end subroutine restrict_to_floor_q_1var
+
+!> \brief Restrict to the base level
+
+   recursive subroutine restrict_to_base_q_1var(this, iv)
+
+      use constants, only: base_level_id
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
+      integer(kind=4),             intent(in)    :: iv   !< variable to be restricted
+
+      if (this%l%id <= base_level_id) return
+      call this%restrict_q_1var(iv)
+      call this%coarser%restrict_to_base_q_1var(iv)
+
+   end subroutine restrict_to_base_q_1var
+
+   recursive subroutine restrict_to_base_w_1var(this, iv)
+
+      use constants, only: base_level_id
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this !< object invoking type-bound procedure
+      integer(kind=4),             intent(in)    :: iv   !< variable to be restricted
+
+      if (this%l%id <= base_level_id) return
+      call this%restrict_w_1var(iv)
+      call this%coarser%restrict_to_base_w_1var(iv)
+
+   end subroutine restrict_to_base_w_1var
+
+!>
+!! \brief Simplest restriction (averaging).
+!!
+!! \todo implement high order restriction and test its influence on V-cycle convergence rate. Watch f/c boundaries.
+!!
+!! \details Some data can be locally copied without MPI, but this seems to have really little impact on the performance.
+!! Some tests show that purely MPI code without local copies is marginally faster.
+!!
+!! OPT Usually there are many messages that are sent between the same pairs of processes
+!! \todo Sort all messages according to e.g. tag and send/receive aggregated message with everything
+!!
+!! \todo implement local copies without MPI anyway
+!<
+
+   subroutine restrict_q_1var(this, iv, pos)
+
+      use constants,        only: xdim, ydim, zdim, ndims, LO, HI, I_ONE, refinement_factor, VAR_CENTER, GEO_XYZ, GEO_RPZ
+      use dataio_pub,       only: msg, warn, die
+      use domain,           only: dom
+      use cg_list,          only: cg_list_element
+      use grid_cont,        only: grid_container
+      use mpisetup,         only: err_mpi, req, inflate_req, master
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUSES_IGNORE, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend, MPI_Waitall
+      use named_array,      only: p3
+      use named_array_list, only: qna
+
+      implicit none
+
+      class(cg_level_connected_t), target, intent(inout) :: this !< object invoking type-bound procedure
+      integer(kind=4),                     intent(in)    :: iv   !< variable to be restricted
+      integer(kind=4), optional,           intent(in)    :: pos  !< position of the variable within cell
+
+      type(cg_level_connected_t), pointer                :: coarse
+      integer                                            :: g
+      integer(kind=8), dimension(xdim:zdim, LO:HI)       :: fse, cse              !< shortcuts for fine segment and coarse segment
+      integer(kind=8)                                    :: i, j, k, ic, jc, kc
+      integer(kind=8), dimension(xdim:zdim)              :: off1
+      real                                               :: norm
+      integer(kind=4)                                    :: nr
+      type(cg_list_element), pointer                     :: cgl
+      type(grid_container),  pointer                     :: cg                    !< current grid container
+      logical, save                                      :: warned = .false.
+      integer                                            :: position
+
+      position = qna%lst(iv)%position(I_ONE)
+      if (present(pos)) position = pos
+      if (position /= VAR_CENTER .and. .not. warned) then
+         if (master) call warn("[cg_level_connected:restrict_q_1var] Only cell-centered interpolation scheme is implemented. Expect inaccurate results for variables that are placed on faces or corners")
+         warned = .true.
+      endif
+
+      coarse => this%coarser
+      if (.not. associated(coarse)) then ! can't restrict base level
+         write(msg,'(a,i3)')"[cg_level_connected:restrict_q_1var] no coarser level than ", this%l%id
+         call warn(msg)
+         return
+      endif
+
+      call this%vertical_prep
+      call coarse%vertical_prep
+
+      ! be ready to receive everything into right buffers
+      nr = 0
+      cgl => coarse%first
+      do while (associated(cgl))
+         cg => cgl%cg
+         if (allocated(cg%ri_tgt%seg)) then
+            do g = lbound(cg%ri_tgt%seg(:), dim=1), ubound(cg%ri_tgt%seg(:), dim=1)
+               nr = nr + I_ONE
+               if (nr > size(req, dim=1)) call inflate_req
+               call MPI_Irecv(cg%ri_tgt%seg(g)%buf(1, 1, 1), size(cg%ri_tgt%seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, cg%ri_tgt%seg(g)%proc, cg%ri_tgt%seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+            enddo
+         endif
+         cgl => cgl%nxt
+      enddo
+
+      ! interpolate to coarse buffer and send it
+      norm = 1./refinement_factor**dom%eff_dim
+      cgl => this%first
+      do while (associated(cgl))
+         cg => cgl%cg
+         do g = lbound(cg%ro_tgt%seg(:), dim=1), ubound(cg%ro_tgt%seg(:), dim=1)
+
+            cg%ro_tgt%seg(g)%buf(:, :, :) = 0.
+            fse(:,:) = cg%ro_tgt%seg(g)%se(:,:)
+            off1(:) = mod(cg%ro_tgt%seg(g)%se(:, LO), int(refinement_factor, kind=8))
+            if (all(off1 == 0) .and. all(mod(fse(:, HI)-fse(:, LO), int(refinement_factor, kind=8)) == 1) .and. dom%eff_dim == ndims) then
+               ! This is the easy, even offset/even size case. Happens in AMR and when UG has regular cartesian decomposition.
+               ! It is few times faster than the code for odd cases below
+               select case (dom%geometry_type)
+                  case (GEO_XYZ)
+                     cg%ro_tgt%seg(g)%buf(1:1+(fse(xdim, HI)-fse(xdim, LO))/refinement_factor, &
+                          &               1:1+(fse(ydim, HI)-fse(ydim, LO))/refinement_factor, &
+                          &               1:1+(fse(zdim, HI)-fse(zdim, LO))/refinement_factor) = ( &
+                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
+                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
+                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
+                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
+                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
+                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
+                          cg%q(iv)%arr(fse(xdim, LO):fse(xdim, HI)-1:2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
+                          cg%q(iv)%arr(fse(xdim, LO)+1:fse(xdim, HI):2, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO)+1:fse(zdim, HI):2)) * norm
+                     case (GEO_RPZ)
+                        do i = fse(xdim, LO), fse(xdim, HI)
+                           cg%ro_tgt%seg(g)%buf     (  1+(i            -fse(xdim, LO))/refinement_factor, &
+                                &                    1:1+(fse(ydim, HI)-fse(ydim, LO))/refinement_factor, &
+                                &                    1:1+(fse(zdim, HI)-fse(zdim, LO))/refinement_factor) = &
+                                cg%ro_tgt%seg(g)%buf(  1+(i            -fse(xdim, LO))/refinement_factor, &
+                                &                    1:1+(fse(ydim, HI)-fse(ydim, LO))/refinement_factor, &
+                                &                    1:1+(fse(zdim, HI)-fse(zdim, LO))/refinement_factor) + ( &
+                                cg%q(iv)%arr(i, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
+                                cg%q(iv)%arr(i, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO):fse(zdim, HI)-1:2) + &
+                                cg%q(iv)%arr(i, fse(ydim, LO):fse(ydim, HI)-1:2, fse(zdim, LO)+1:fse(zdim, HI):2) + &
+                                cg%q(iv)%arr(i, fse(ydim, LO)+1:fse(ydim, HI):2, fse(zdim, LO)+1:fse(zdim, HI):2)) * norm * cg%x(i)
+                        enddo
+                  case default
+                     call die("[cg_level_connected:restrict_q_1var] Unknown geometry (1)")
+               end select
+            else
+               ! OPT: Split the problem into the core that can be done by array arithmetic and finish the edges where necessary
+               do k = fse(zdim, LO), fse(zdim, HI)
+                  kc = (k-fse(zdim, LO)+off1(zdim))/refinement_factor + 1
+                  do j = fse(ydim, LO), fse(ydim, HI)
+                     jc = (j-fse(ydim, LO)+off1(ydim))/refinement_factor + 1
+                     do i = fse(xdim, LO), fse(xdim, HI)
+                        ic = (i-fse(xdim, LO)+off1(xdim))/refinement_factor + 1
+                        select case (dom%geometry_type)
+                           case (GEO_XYZ)
+                              cg%ro_tgt%seg(g)%buf(ic, jc, kc) = cg%ro_tgt%seg(g)%buf(ic, jc, kc) + cg%q(iv)%arr(i, j, k) * norm
+                           case (GEO_RPZ)
+                              cg%ro_tgt%seg(g)%buf(ic, jc, kc) = cg%ro_tgt%seg(g)%buf(ic, jc, kc) + cg%q(iv)%arr(i, j, k) * norm * cg%x(i)
+                           case default
+                              call die("[cg_level_connected:restrict_q_1var] Unknown geometry (2)")
+                        end select
+                     enddo
+                  enddo
+               enddo
+            endif
+            nr = nr + I_ONE
+            if (nr > size(req, dim=1)) call inflate_req
+            call MPI_Isend(cg%ro_tgt%seg(g)%buf(1, 1, 1), size(cg%ro_tgt%seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, cg%ro_tgt%seg(g)%proc, cg%ro_tgt%seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+         enddo
+         cgl => cgl%nxt
+      enddo
+
+      if (nr > 0) call MPI_Waitall(nr, req(:nr), MPI_STATUSES_IGNORE, err_mpi)
+
+      ! copy the received buffers to the right places
+      cgl => coarse%first
+      do while (associated(cgl))
+         cg => cgl%cg
+         if (allocated(cg%ri_tgt%seg)) then
+            where (.not. cg%leafmap(:,:,:)) cg%q(iv)%arr(cg%is:cg%ie, cg%js:cg%je, cg%ks:cg%ke) = 0. ! disables check_dirty
+            do g = lbound(cg%ri_tgt%seg(:), dim=1), ubound(cg%ri_tgt%seg(:), dim=1)
+               cse(:,:) = cg%ri_tgt%seg(g)%se(:,:)
+               select case (dom%geometry_type)
+                  case (GEO_XYZ) ! do nothing
+                  case (GEO_RPZ)
+                     do i = lbound(cg%ri_tgt%seg(g)%buf, dim=1), ubound(cg%ri_tgt%seg(g)%buf, dim=1)
+                        ic = cse(xdim, LO) +i - lbound(cg%ri_tgt%seg(g)%buf, dim=1)
+                        cg%ri_tgt%seg(g)%buf(i, :, :) = cg%ri_tgt%seg(g)%buf(i, :, :) / cg%x(ic)
+                     enddo
+                  case default
+                     call die("[cg_level_connected:restrict_q_1var] Unknown geometry")
+               end select
+               p3 => cg%q(iv)%span(cse)
+               p3 = p3 + cg%ri_tgt%seg(g)%buf(:, :, :) !errors on overlap?
+            enddo
+         endif
+         cgl => cgl%nxt
+      enddo
+
+   end subroutine restrict_q_1var
+
+!> \brief Quick and dirty restriction of 4D arrays. OPTIMIZE ME!
+
+   subroutine restrict_w_1var(this, i)
+
+      use constants,        only: GEO_RPZ
+      use domain,           only: dom
+      use fluidindex,       only: iarr_all_my
+      use named_array_list, only: qna, wna
+
+      implicit none
+
+      class(cg_level_connected_t), target, intent(inout) :: this  !< object invoking type-bound procedure
+      integer(kind=4),                     intent(in)    :: i     !< variable to be restricted
+
+      integer(kind=4) :: iw
+
+      do iw = 1, wna%lst(i)%dim4
+         call this%wq_copy(i, iw, qna%wai)
+         if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%mul_by_r(qna%wai) ! angular momentum conservation
+         if (.true.) then  ! this is required because we don't use (.not. cg%leafmap) mask in the this%coarser%qw_copy call below
+            call this%coarser%wq_copy(i, iw, qna%wai)
+            if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%coarser%mul_by_r(qna%wai)
+         endif
+         call this%restrict_q_1var(qna%wai, wna%lst(i)%position(iw))
+         if (dom%geometry_type == GEO_RPZ .and. i == wna%fi .and. any(iw == iarr_all_my)) call this%coarser%div_by_r(qna%wai) ! angular momentum conservation
+         call this%coarser%qw_copy(qna%wai, i, iw)
+      enddo
+   end subroutine restrict_w_1var
+
+!> \brief This routine sets up all guardcells (internal, external and fine-coarse) for given rank-3 arrays.
+
+   subroutine arr3d_boundaries(this, ind, area_type, bnd_type, dir, nocorners)
+
+      use constants,        only: PPP_AMR
+      use named_array_list, only: qna
+      use ppp,              only: ppp_main
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this      !< the list on which to perform the boundary exchange
+      integer(kind=4),             intent(in)    :: ind       !< index of cg%q(:) 3d array
+      integer(kind=4), optional,   intent(in)    :: area_type !< defines how do we treat boundaries
+      integer(kind=4), optional,   intent(in)    :: bnd_type  !< Override default boundary type on external boundaries (useful in multigrid solver).
+                                                              !< Note that BND_PER, BND_MPI, BND_SHE and BND_COR aren't external and cannot be overridden
+      integer(kind=4), optional,   intent(in)    :: dir       !< select only this direction
+      logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
+
+      integer(kind=4) :: ord_saved
+      character(len=*), parameter :: a3b_label = "level:arr3d_boundaries", a3bp_label = "level:arr3d_boundaries:prolong"
+
+      call ppp_main%start(a3b_label)
+
+      ord_saved = qna%lst(ind)%ord_prolong
+
+      call this%dirty_boundaries(ind)
+      call ppp_main%start(a3bp_label, PPP_AMR)
+      call this%prolong_bnd_from_coarser(ind, bnd_type=bnd_type, dir=dir, nocorners=nocorners)
+      call ppp_main%stop(a3bp_label, PPP_AMR)
+      call this%level_3d_boundaries(ind, area_type=area_type, bnd_type=bnd_type, dir=dir, nocorners=nocorners)
+      ! The correctness of the sequence of calls above may depend on the implementation of internal boundary exchange
+
+      qna%lst(ind)%ord_prolong = ord_saved
+
+      call ppp_main%stop(a3b_label)
+
+   end subroutine arr3d_boundaries
+
+!> \brief This routine sets up all guardcells (internal, external and fine-coarse) for given rank-4 arrays.
+
+   subroutine arr4d_boundaries(this, ind, area_type, dir, nocorners)
+
+      use constants,        only: base_level_id, PPP_AMR
+      use named_array_list, only: qna, wna
+      use ppp,              only: ppp_main
+
+      implicit none
+
+      class(cg_level_connected_t), intent(inout) :: this      !< the list on which to perform the boundary exchange
+      integer(kind=4),             intent(in)    :: ind       !< index of cg%w(:) 4d array
+      integer(kind=4), optional,   intent(in)    :: area_type !< defines how do we treat boundaries
+      integer(kind=4), optional,   intent(in)    :: dir       !< select only this direction
+      logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
+
+      integer(kind=4) :: iw
+      character(len=*), parameter :: a4b_label = "level:arr4d_boundaries", a4bp_label = "level:arr4d_boundaries:prolong"
+
+      call ppp_main%start(a4b_label)
+
+!      call this%dirty_boundaries(ind)
+!      call this%clear_boundaries(ind, value=10.)
+
+      call ppp_main%start(a4bp_label, PPP_AMR)
+      if (associated(this%coarser) .and. this%l%id > base_level_id) then
+         do iw = 1, wna%lst(ind)%dim4
+            ! here we can use any high order prolongation without destroying conservation
+
+            ! OPT: this is insanely safe but highly inefficient implementation.
+            ! A lot of data is copied there and back through cg%wa
+            ! but only small fraction of it is actually used in boundary prolongation.
+
+            qna%lst(qna%wai)%ord_prolong = wna%lst(ind)%ord_prolong
+            call this%coarser%wq_copy(ind, iw, qna%wai)
+            call this%wq_copy(ind, iw, qna%wai) !> Quick and dirty fix for cases when cg%ignore_prolongation == .true.
+            call this%prolong_bnd_from_coarser(qna%wai, dir=dir, nocorners=nocorners)
+            call this%qw_copy(qna%wai, ind, iw) !> \todo filter this through cg%ignore_prolongation
+         enddo
+      endif
+      call ppp_main%stop(a4bp_label, PPP_AMR)
+
+      call this%level_4d_boundaries(ind, area_type=area_type, dir=dir, nocorners=nocorners)
+
+      call ppp_main%stop(a4b_label)
+
+   end subroutine arr4d_boundaries
 
 end module cg_level_connected

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -1171,6 +1171,13 @@ contains
                   call cg%prolong(merge(qna%wai, ind, present(sub)), seg(g)%se, p_xyz = present(sub))  ! prolong rank-4 to auxiliary array cg%prolong_xyz.
                   ! qna%wai is required only for indirect determination of prolongation order (TOO QUIRKY)
                   ! The cg%prolong above consumes about half of the prolong_bnd_from_coarser execution time
+                  ! ToDo: implement special cases, especially O_INJ and O_LIN, perhaps O_I2 too,
+                  ! at least for for 3D (precompute full stencils), watch for even/odd issues
+                  ! For higher orders should issue a one-time warning
+
+                  ! OPT: in many cases (like in (M)HD directionally split solver we don't need all f/c guardcells.
+                  ! Implement efficient directional selection and avoid updating edge/corner f/c when not strictly necessary.
+                  ! Full corner update is important in multigrid and may be important for divB cleaning.
 
                   if (present(sub)) cg%w(ind)%arr(sub, fse(xdim, LO):fse(xdim, HI), fse(ydim, LO):fse(ydim, HI), fse(zdim, LO):fse(zdim, HI)) = &
                        &           cg%prolong_xyz(     fse(xdim, LO):fse(xdim, HI), fse(ydim, LO):fse(ydim, HI), fse(zdim, LO):fse(zdim, HI))

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -870,6 +870,11 @@ contains
       if (associated(this%coarser) .and. this%l%id > base_level_id) then
          do iw = 1, wna%lst(ind)%dim4
             ! here we can use any high order prolongation without destroying conservation
+
+            ! OPT: this is insanely safe but highly inefficient implementation.
+            ! A lot of data is copied there and back through cg%wa
+            ! but only small fraction of it is actually used in boundary prolongation.
+
             qna%lst(qna%wai)%ord_prolong = wna%lst(ind)%ord_prolong
             call this%coarser%wq_copy(ind, iw, qna%wai)
             call this%wq_copy(ind, iw, qna%wai) !> Quick and dirty fix for cases when cg%ignore_prolongation == .true.

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -35,7 +35,7 @@ module cg_level_connected
    implicit none
 
    private
-   public :: cg_level_connected_t, base_level, find_level
+   public :: cg_level_connected_t, base_level
 
    !! \brief A list of all cg of the same resolution with links to coarser and finer levels
    type, extends(cg_level_t) :: cg_level_connected_t
@@ -1568,41 +1568,5 @@ contains
       call this%sync_ru
 
    end subroutine free_all_cg
-
-!> \brief Find pointer to a level given by level_id
-
-   function find_level(level_id) result(lev_p)
-
-      use dataio_pub, only: die
-
-      implicit none
-
-      integer(kind=4), intent(in) :: level_id         !< level number (relative to base level)
-
-      type(cg_level_connected_t), pointer :: lev_p, curl
-
-      nullify(lev_p)
-      curl => base_level
-      if (level_id >= base_level%l%id) then
-         do while (associated(curl))
-            if (curl%l%id == level_id) then
-               lev_p => curl
-               exit
-            endif
-            curl => curl%finer
-         enddo
-      else
-         do while (associated(curl))
-            if (curl%l%id == level_id) then
-               lev_p => curl
-               exit
-            endif
-            curl => curl%coarser
-         enddo
-      endif
-
-      if (.not. associated(lev_p)) call die("[cg_level_connected:find_level] Cannot find level")
-
-   end function find_level
 
 end module cg_level_connected

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -823,20 +823,22 @@ contains
       logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       integer(kind=4) :: ord_saved
-      character(len=*), parameter :: a3b_label = "level:arr3d_boundaries"
+      character(len=*), parameter :: a3b_label = "level:arr3d_boundaries", a3bp_label = "level:arr3d_boundaries:prolong"
 
-      call ppp_main%start(a3b_label, PPP_AMR)
+      call ppp_main%start(a3b_label)
 
       ord_saved = qna%lst(ind)%ord_prolong
 
       call this%dirty_boundaries(ind)
+      call ppp_main%start(a3bp_label, PPP_AMR)
       call this%prolong_bnd_from_coarser(ind, bnd_type=bnd_type, dir=dir, nocorners=nocorners)
+      call ppp_main%stop(a3bp_label, PPP_AMR)
       call this%level_3d_boundaries(ind, area_type=area_type, bnd_type=bnd_type, dir=dir, nocorners=nocorners)
       ! The correctness of the sequence of calls above may depend on the implementation of internal boundary exchange
 
       qna%lst(ind)%ord_prolong = ord_saved
 
-      call ppp_main%stop(a3b_label, PPP_AMR)
+      call ppp_main%stop(a3b_label)
 
    end subroutine arr3d_boundaries
 
@@ -857,12 +859,14 @@ contains
       logical,         optional,   intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       integer(kind=4) :: iw
-      character(len=*), parameter :: a4b_label = "level:arr4d_boundaries"
+      character(len=*), parameter :: a4b_label = "level:arr4d_boundaries", a4bp_label = "level:arr4d_boundaries:prolong"
 
-      call ppp_main%start(a4b_label, PPP_AMR)
+      call ppp_main%start(a4b_label)
 
 !      call this%dirty_boundaries(ind)
 !      call this%clear_boundaries(ind, value=10.)
+
+      call ppp_main%start(a4bp_label, PPP_AMR)
       if (associated(this%coarser) .and. this%l%id > base_level_id) then
          do iw = 1, wna%lst(ind)%dim4
             ! here we can use any high order prolongation without destroying conservation
@@ -873,9 +877,11 @@ contains
             call this%qw_copy(qna%wai, ind, iw) !> \todo filter this through cg%ignore_prolongation
          enddo
       endif
+      call ppp_main%stop(a4bp_label, PPP_AMR)
+
       call this%level_4d_boundaries(ind, area_type=area_type, dir=dir, nocorners=nocorners)
 
-      call ppp_main%stop(a4b_label, PPP_AMR)
+      call ppp_main%stop(a4b_label)
 
    end subroutine arr4d_boundaries
 

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -1190,7 +1190,7 @@ contains
                cse(:, LO) = cse(:, LO) - dom%nb*dom%D_(:)/refinement_factor
                cse(:, HI) = cse(:, HI) + dom%nb*dom%D_(:)/refinement_factor
 
-               call cg%prolong(qna%wai, cse, p_xyz = .true.)  ! prolong to auxiliary array cg%prolong_xyz.
+               call cg%prolong(merge(qna%wai, ind, present(sub)), cse, p_xyz = .true.)  ! prolong to auxiliary array cg%prolong_xyz.
                ! qna%wai is required only for indirect determination of prolongation order (TOO QUIRKY)
                ! OPT Find a way to avoid unnecessary calculations where .not. updatemap
                ! The cg%prolong above consumes about half of the prolong_bnd_from_coarser execution time

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -211,8 +211,9 @@ contains
       logical,         optional, intent(in)    :: nocorners !< .when .true. then don't care about proper edge and corner update
 
       logical, dimension(xdim:cor_dim) :: dmask
-      character(len=*), parameter :: ibl_label = "internal_boundaries_MPI_local", ibm_label = "internal_boundaries_MPI_merged", ib1_label = "internal_boundaries_MPI_1by1"
+      character(len=*), parameter :: ib_label = "internal_boundaries", ibl_label = "internal_boundaries_local", ibm_label = "internal_boundaries_MPI_merged", ib1_label = "internal_boundaries_MPI_1by1"
 
+      call ppp_main%start(ib_label)
       dmask(xdim:zdim) = dom%has_dir
       if (present(dir)) then
          dmask(xdim:zdim) = .false.
@@ -222,9 +223,9 @@ contains
       dmask(cor_dim) = .true.
       if (present(nocorners)) dmask(cor_dim) = .not. nocorners
 
-      call ppp_main%start(ibl_label, PPP_AMR)
+      call ppp_main%start(ibl_label)
       call internal_boundaries_local(this, ind, tgt3d, dmask)
-      call ppp_main%stop(ibl_label, PPP_AMR)
+      call ppp_main%stop(ibl_label)
 
       if (this%ms%valid) then
          call ppp_main%start(ibm_label, PPP_AMR)
@@ -235,6 +236,7 @@ contains
          call internal_boundaries_MPI_1by1(this, ind, tgt3d, dmask)
          call ppp_main%stop(ib1_label, PPP_AMR)
       endif
+      call ppp_main%stop(ib_label)
 
    end subroutine internal_boundaries
 
@@ -820,6 +822,7 @@ contains
       use fluidindex,            only: iarr_all_dn
       use grid_cont,             only: grid_container
       use named_array_list,      only: wna
+      use ppp,                   only: ppp_main
 #ifdef COSM_RAYS
       use initcosmicrays,        only: smallecr
       use fluidindex,            only: iarr_all_crs
@@ -839,8 +842,11 @@ contains
       logical, save                           :: frun = .true.
       integer(kind=4)                         :: side, ssign, ib
       type(cg_list_element), pointer          :: cgl
+      character(len=*), parameter             :: bu_label = "bnd_u"
 
       if (.not. any([xdim, ydim, zdim] == dir)) call die("[cg_list_bnd:bnd_u] Invalid direction.")
+
+      call ppp_main%start(bu_label)
 
       if (frun) then
          call init_fluidboundaries
@@ -907,6 +913,8 @@ contains
          enddo
          cgl => cgl%nxt
       enddo
+
+      call ppp_main%stop(bu_label)
 
    contains
 
@@ -1005,6 +1013,7 @@ contains
       use grid_cont,             only: grid_container
       use mpisetup,              only: master
       use named_array_list,      only: wna
+      use ppp,                   only: ppp_main
 
       implicit none
 
@@ -1017,6 +1026,9 @@ contains
       logical, save,   dimension(ndims,LO:HI) :: bnd_not_provided = .false.
       integer(kind=4), dimension(ndims,LO:HI) :: l, r
       type(cg_list_element), pointer          :: cgl
+      character(len=*), parameter             :: bb_label = "bnd_b"
+
+      call ppp_main%start(bb_label)
 
 ! Non-MPI boundary conditions
       if (frun) then
@@ -1062,6 +1074,8 @@ contains
          enddo
          cgl => cgl%nxt
       enddo
+
+      call ppp_main%stop(bb_label)
 
       contains
 

--- a/src/grid/find_level.F90
+++ b/src/grid/find_level.F90
@@ -1,0 +1,78 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+#include "piernik.h"
+
+!> \brief This module provides a function to find a pointer to a level based on level ID
+
+module find_lev
+
+   implicit none
+
+   private
+   public :: find_level
+
+contains
+
+!> \brief Find pointer to a level given by level_id
+
+   function find_level(level_id) result(lev_p)
+
+      use cg_level_base,      only: base
+      use cg_level_connected, only: cg_level_connected_t
+      use dataio_pub,         only: die
+
+      implicit none
+
+      integer(kind=4), intent(in) :: level_id         !< level number (relative to base level)
+
+      type(cg_level_connected_t), pointer :: lev_p, curl
+
+      nullify(lev_p)
+      curl => base%level
+      if (level_id >= base%level%l%id) then
+         do while (associated(curl))
+            if (curl%l%id == level_id) then
+               lev_p => curl
+               exit
+            endif
+            curl => curl%finer
+         enddo
+      else
+         do while (associated(curl))
+            if (curl%l%id == level_id) then
+               lev_p => curl
+               exit
+            endif
+            curl => curl%coarser
+         enddo
+      endif
+
+      if (.not. associated(lev_p)) call die("[find_level:find_level] Cannot find level")
+
+   end function find_level
+
+end module

--- a/src/grid/grid_container_prolong.F90
+++ b/src/grid/grid_container_prolong.F90
@@ -161,15 +161,22 @@ contains
 !!\n  "scatter" approach: loop over coarse cells, each one contributes weighted values to 10**3 fine cells (1000*n_coarse multiplications, roughly equal to cost of gather)
 !!\n  "directionally split" approach: do the prolongation (either gather or scatter type) first in x direction (10*n_coarse multiplications -> 2*n_coarse intermediate cells
 !!                                  result), then in y direction (10*2*n_coarse multiplications -> 4*n_coarse intermediate cells result), then in z direction
-!!                                  (10*4*n_coarse multiplications -> 8*n_coarse = n_fine cells result). Looks like 70*n_coarse multiplications.
+!!                                  (10*4*n_coarse multiplications -> 8*n_coarse = n_fine cells result). Looks like 70*n_coarse multiplications, alt least for large blocks
 !!                                  Will require two additional arrays for intermediate results.
-!!\n  "FFT" approach: do the convolution in Fourier space. Unfortunately it is not periodic box, so we cannot use power of 2 FFT sizes. No idea how fast or slow this can be.
+!!
+!! In 2D and 3d by using precomputed multidimensional stencils and by rearranging terms it is possible to reduce number of multiplications.
+!! In case of quartic stencil it is possible to reduce to 35*n_fine multiplications for general case and just 10*n_fine multiplications for antisymmetric case.
+!!
+!!\n  "FFT" approach: do the convolution in Fourier space. Unfortunately it is not periodic box, so it would have to be padded proportionally to the stencil size
+!! and it often won't use power of 2 FFT sizes. No idea how fast or slow this can be.
 !!\n
 !!\n For AMR or nested grid low-order prolongation schemes (injection and linear interpolation at least) are known to produce artifacts
 !! on fine-coarse boundaries. For uniform grid the simplest operators are probably the fastest and give best V-cycle convergence rates.
 !! \n
 !! \n For conservative prolongation in AMR one needs additional stencils that aren't centered on the given cell to make sure that the whole contribution from coarse grid
 !! is deposited on the fine grid and nothing is lost in fine guardcells.
+!!
+!! Perhaps a routine generator would be more optimal solution
 !<
 
    subroutine prolong(this, ind, cse, p_xyz)
@@ -230,25 +237,25 @@ contains
             P_3 = 0.;            P_2 = 0.;           P_1 = -7./128.;      P0 = 105./128.;     P1 = 35./128.;      P2 = -5./128.;      P3 = 0.
             !  linsolve_by_lu(matrix([1,1,1,1], [-4, 0, 4, 4*2], [(-4)**2/2!, 0, (4**2)/2!, (2*4)**2/2!], [(-4)**3/3!, 0, 4**3/3!, (2*4)**3/3!]), matrix([1], [1], [1/2!], [1/3!]));
          case (O_D2)
-          ! P_3 = 0.;            P_2 = 0.;           P_1 = 0.;            P0 = 21./32.;       P1 = 14./32.;       P2 = -3./32.;       P3 = 0.
+          ! P_3 = 0.;            P_2 = 0.;           P_1 = 0.;            P0 = 21./32.;       P1 = 14./32.;       P2 = -3./32.;       P3 = 0.  ! asymmetric case
             !  linsolve_by_lu(matrix([1,1,1],[0, 4, 8], [0,8,32]), matrix([1],[1],[1/2.]));
             P_3 = 0.;            P_2 = 0.;           P_1 = -3./32.;       P0 = 30./32.;       P1 = 5./32.;        P2 = 0.;            P3 = 0.
             !  linsolve_by_lu(matrix([1,1,1], [-4, 0, 4], [(-4)**2/2!, 0, (4**2)/2!]), matrix([1], [1], [1/2!]));
-          ! P_3 = 0.;            P_2 = 5./32.;       P_1 = -18./32.;      P0 = 45./32.;       P1 = 0.;            P2 = 0.;            P3 = 0.
+          ! P_3 = 0.;            P_2 = 5./32.;       P_1 = -18./32.;      P0 = 45./32.;       P1 = 0.;            P2 = 0.;            P3 = 0.  ! asymmetric case
             !  linsolve_by_lu(matrix([1,1,1],[-8, -4, 0], [32, 8,0]), matrix([1],[1],[1/2.]));
          case (O_LIN)
             P_3 = 0.;            P_2 = 0.;           P_1 = 0.;            P0 = 3./4.;         P1 = 1./4.;         P2 = 0.;            P3 = 0.
             !  linsolve_by_lu(matrix([1,1], [0, 4]), matrix([1], [1]));
-          ! P_3 = 0.;            P_2 = 0.;           P_1 = -1./4.;        P0 = 5./4.;         P1 = 0.;            P2 = 0.;            P3 = 0.
+          ! P_3 = 0.;            P_2 = 0.;           P_1 = -1./4.;        P0 = 5./4.;         P1 = 0.;            P2 = 0.;            P3 = 0.  ! asymmetric case
             !  linsolve_by_lu(matrix([1,1],[-4, 0]), matrix([1],[1]));
          case (O_INJ)
             P_3 = 0.;            P_2 = 0.;           P_1 = 0.;            P0 = 1.;            P1 = 0.;            P2 = 0.;            P3 = 0.
          case (O_I2)
             P_3 = 0.;            P_2 = 0.;           P_1 = -1./8.;        P0 = 1.;            P1 = 1./8.;         P2 = 0.;            P3 = 0.
             !  linsolve_by_lu(matrix([4,4,4], [((-2)**2-(-6)**2)/2!, ((2)**2-(-2)**2)/2!, ((6)**2-(2)**2)/2!], [((-2)**3-(-6)**3)/3!, ((2)**3-(-2)**3)/3!, ((6)**3-(2)**3)/3!]), matrix([4],[2*2**2/2!],[2*2**3/3!]));
-          ! P_3 = 0.;            P_2 = 0.;           P_1 = 0.;            P0 = 5./8.;         P1 = 4./8.;         P2 = -1./8.;        P3 = 0.
+          ! P_3 = 0.;            P_2 = 0.;           P_1 = 0.;            P0 = 5./8.;         P1 = 4./8.;         P2 = -1./8.;        P3 = 0.  ! asymmetric case
             !  linsolve_by_lu(matrix([4,4,4],[0,16,(10**2-6**2)/2!],[8/3,104/3,(10**3-6**3)/3!]), matrix([4],[4],[8/3]));
-          ! P_3 = 0.;            P_2 = 1./8.;        P_1 = -4./8.;        P0 = 11./8.;        P1 = 0.;            P2 = 0.;            P3 = 0.
+          ! P_3 = 0.;            P_2 = 1./8.;        P_1 = -4./8.;        P0 = 11./8.;        P1 = 0.;            P2 = 0.;            P3 = 0.  ! asymmetric case
             !  linsolve_by_lu(matrix([4,4,4],[-(10**2-6**2)/2!, -16, 0],[(10**3-6**3)/3!, 104/3, 8/3]), matrix([4],[4],[8/3]));
          case (O_I3)
             P_3 = 0.;            P_2 = 0.;           P_1 = -5./64.;       P0 = 55./64;        P1 = 17./64.;       P2 = -3./64.;       P3 = 0.

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -194,7 +194,7 @@ contains
       use cg_list,            only: cg_list_element
       use cg_level_base,      only: base
       use cg_level_coarsest,  only: coarsest
-      use cg_level_connected, only: cg_level_connected_t, base_level
+      use cg_level_connected, only: cg_level_connected_t
       use cg_level_finest,    only: finest
       use constants,          only: PIERNIK_INIT_GRID, I_ONE, refinement_factor
       use dataio_pub,         only: printinfo, warn, die, code_progress, msg
@@ -225,8 +225,8 @@ contains
       endif
 
       do j = 0, level_incredible
-         if (any((mod(base_level%l%n_d(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .or. base_level%l%n_d(:)/refinement_factor**(j+1) < minsize(:)) .and. dom%has_dir(:))) exit
-         if (any((mod(base_level%l%off(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .and. dom%has_dir(:)))) exit
+         if (any((mod(base%level%l%n_d(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .or. base%level%l%n_d(:)/refinement_factor**(j+1) < minsize(:)) .and. dom%has_dir(:))) exit
+         if (any((mod(base%level%l%off(:), int(refinement_factor, kind=8)**(j+1)) /= 0 .and. dom%has_dir(:)))) exit
       enddo
       if (level_depth > j) then
          if (master) then
@@ -260,7 +260,7 @@ contains
          curl => curl%coarser ! descend until null() is encountered
       enddo
 
-      curl => base_level%coarser
+      curl => base%level%coarser
       do while (associated(curl))
          if (master) then
             if (curl%l%id == -level_depth .and. single_base) then

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -192,6 +192,7 @@ contains
    subroutine init_multigrid
 
       use cg_list,            only: cg_list_element
+      use cg_level_base,      only: base
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t, base_level
       use cg_level_finest,    only: finest
@@ -210,12 +211,13 @@ contains
       integer(kind=4)       :: j
 
       type(cg_list_element), pointer :: cgl
-      type(cg_level_connected_t), pointer :: curl          !< current level (a pointer sliding along the linked list) and temporary level
-      type(grid_container),  pointer :: cg            !< current grid container
+      type(cg_level_connected_t), pointer :: curl  !< current level (a pointer sliding along the linked list) and temporary level
+      type(grid_container),  pointer :: cg         !< current grid container
 
       if (code_progress < PIERNIK_INIT_GRID) call die("[multigrid:init_multigrid] grid, geometry, constants or arrays not initialized")
       ! This check is too weak (geometry), arrays are required only for multigrid_gravity
 
+      base%init_multigrid => init_multigrid
 
       if (level_depth <= 0) then
          if (master) call warn("[multigrid:init_multigrid] level_depth < 1: solving on a single grid may be extremely slow")

--- a/src/scheme/rtvd_split/solve_cg_rtvd.F90
+++ b/src/scheme/rtvd_split/solve_cg_rtvd.F90
@@ -50,10 +50,11 @@ contains
    subroutine solve_cg_rtvd(cg, cdim, istep, fargo_vel)
 
       use bfc_bcc,            only: interpolate_mag_field
-      use cg_level_connected, only: cg_level_connected_t, find_level
+      use cg_level_connected, only: cg_level_connected_t
       use constants,          only: pdims, LO, HI, uh_n, cs_i2_n, ORTHO1, ORTHO2, VEL_CR, VEL_RES, ydim, rk_coef
       use dataio_pub,         only: die
       use domain,             only: dom
+      use find_lev,           only: find_level
       use fluidindex,         only: flind, iarr_all_swp, nmag, iarr_all_dn, iarr_all_mx
       use fluxtypes,          only: ext_fluxes
       use global,             only: dt, use_fargo


### PR DESCRIPTION
It looks like `prolong_bnd_from_coarser` was very inefficient in AMR simulations due to incomplete rank-4 implementation (with workaround through `cg%wa`).
A bit more direct approach (still component-wise) resulted in factor of 2 speedup of a 3D sedov problem with 3 levels of refinemet.

There is another big factor to gain in optimizing the way of calculating fine guardcells over coarse boundary. Some easy gains were done in eaf63af but real improvement will be easier to achieve with MPI-2 communication.