### PR TITLE
Sweeps optimization

### DIFF
--- a/problems/3body/problem.par
+++ b/problems/3body/problem.par
@@ -51,7 +51,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/advection_test/initproblem.F90
+++ b/problems/advection_test/initproblem.F90
@@ -281,7 +281,7 @@ contains
       use constants,        only: ndims, I_ONE, I_TWO, I_THREE, dpi
       use dataio_pub,       only: warn
       use div_B,            only: print_divB_norm
-      use global,           only: force_cc_mag
+      use global,           only: cc_mag
       use mpisetup,         only: master
 #endif /* MAGNETIC */
 
@@ -302,7 +302,7 @@ contains
       kk = 0.
       where (dom%D_ > 0) kk = divB_k * dpi / dom%L_
       right_face = 1
-      if (force_cc_mag) right_face = 0
+      if (cc_mag) right_face = 0
       r02 = divBb_r0**2
 #endif /* MAGNETIC */
 
@@ -346,7 +346,7 @@ contains
                      select case (dom%eff_dim)
                         case (I_ONE) ! can't do anything fancy, just set up something non-zero
                            cg%b(:, i, j, k) = cg%b(:, i, j, k) + divB0_amp
-                           if (force_cc_mag) then
+                           if (cc_mag) then
                               if (dom%D_x == 1) then
                                  cg%b(:, i, j, k) = cg%b(:, i, j, k) + divBs_amp * [ kk(xdim)*cx, 1., 1. ]
                               else if (dom%D_y == 1) then
@@ -367,7 +367,7 @@ contains
                            ! [sin(x)*sin(y), cos(x)*cos(y), 0] should produce divB == 0. for XY case (curl([0, 0, -sin(x)*cos(y)]))
                            ! The div(B) is really close to numerical noise around 0 only in the case of exactly the same resolution per sine wave in all directions.
                            ! If the resolutions of sine waves don't match, then numerical estimates of mixed derivatives of the vector potential don't cancel out and only high-order estimates of div(b) are close to 0.
-                           if (force_cc_mag) then
+                           if (cc_mag) then
                               if (dom%D_z == 0) then
                                  cg%b(:, i, j, k) = cg%b(:, i, j, k) + &
                                       divB0_amp * [ kk(ydim)*sx*sy, kk(xdim)*cx*cy, 1. ] + &
@@ -399,7 +399,7 @@ contains
                         case (I_THREE)
                            ! curl([sin(x)*sin(y)*sin(z), sin(x)*sin(y)*sin(z), sin(x)*sin(y)*sin(z)]) should produce div(B) == 0, but see the notes for 2D case.
                            ! setting up a div(B)-free field in flattened domain requires careful choice of kk(:)
-                           if (force_cc_mag) then
+                           if (cc_mag) then
                               cg%b(:, i, j, k) = cg%b(:, i, j, k) + divB0_amp * [ &
                                    kk(ydim)*cx*sy*cz - kk(zdim)*cx*cy*sz, &
                                    kk(zdim)*cx*cy*sz - kk(xdim)*sx*cy*cz, &
@@ -460,7 +460,7 @@ contains
          cg%u(fl%ien,:,:,:) = max(smallei, pulse_pres / fl%gam_1 + 0.5 * sum(cg%u(fl%imx:fl%imz,:,:,:)**2,1) / cg%u(fl%idn,:,:,:))
 
 #if defined MAGNETIC && defined IONIZED
-         if (force_cc_mag) then
+         if (cc_mag) then
             cg%u(fl%ien,:,:,:) = cg%u(fl%ien,:,:,:) + emag(cg%b(xdim,:,:,:), cg%b(ydim,:,:,:), cg%b(zdim,:,:,:))
          else
             cg%u(fl%ien, cg%is:cg%ie, cg%js:cg%je, cg%ks:cg%ke) = cg%u(fl%ien, cg%is:cg%ie, cg%js:cg%je, cg%ks:cg%ke) + &

--- a/problems/blob/problem.par
+++ b/problems/blob/problem.par
@@ -57,7 +57,6 @@
     cfl    = 0.9
     smalld = 1.e-10
     smallei= 1.e-10
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/blob/problem.par.AMR
+++ b/problems/blob/problem.par.AMR
@@ -57,7 +57,6 @@
     cfl    = 0.9
     smalld = 1.e-10
     smallei= 1.e-10
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/blob/problem.par.wt3_hi
+++ b/problems/blob/problem.par.wt3_hi
@@ -53,7 +53,6 @@
     cfl    = 0.9
     smalld = 1.e-10
     smallei= 1.e-10
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/blob/problem.par.wt3_med
+++ b/problems/blob/problem.par.wt3_med
@@ -53,7 +53,6 @@
     cfl    = 0.9
     smalld = 1.e-10
     smallei= 1.e-10
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/crtest/problem.par
+++ b/problems/crtest/problem.par
@@ -49,7 +49,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/crtest/problem.par.build
+++ b/problems/crtest/problem.par.build
@@ -45,7 +45,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/crtest/problem.par.debug
+++ b/problems/crtest/problem.par.debug
@@ -45,7 +45,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/crtest/problem.par.expanding_domain
+++ b/problems/crtest/problem.par.expanding_domain
@@ -47,7 +47,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/crtest/problem.par.refined
+++ b/problems/crtest/problem.par.refined
@@ -49,7 +49,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
     solver_str = "Riemann"
  /

--- a/problems/crtest/problem.par.refinements
+++ b/problems/crtest/problem.par.refinements
@@ -49,7 +49,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
     solver_str = "Riemann"
  /

--- a/problems/crwind/problem.par
+++ b/problems/crwind/problem.par
@@ -52,7 +52,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/crwind/problem.par.build
+++ b/problems/crwind/problem.par.build
@@ -51,7 +51,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/crwind/problem.par.highres
+++ b/problems/crwind/problem.par.highres
@@ -51,7 +51,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/crwind/problem.par.lowres
+++ b/problems/crwind/problem.par.lowres
@@ -51,7 +51,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/crwind/problem.par.smalltest
+++ b/problems/crwind/problem.par.smalltest
@@ -50,7 +50,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/divvtest/problem.par
+++ b/problems/divvtest/problem.par
@@ -47,7 +47,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/dustblob/problem.par
+++ b/problems/dustblob/problem.par
@@ -60,7 +60,6 @@
     cfl    = 0.9
     smalld = 1.e-6
     smallei= 1.e-4
-    integration_order = 2
     limiter= 'vanleer'
     dt_initial = 1.e-5
  /

--- a/problems/dustblob/problem.par.AMR
+++ b/problems/dustblob/problem.par.AMR
@@ -60,7 +60,6 @@
     cfl    = 0.5
     smalld = 1.e-6
     smallei= 1.e-4
-    integration_order = 2
     limiter= 'vanleer'
     dt_initial = 1.e-4
     dt_max_grow = 1.25

--- a/problems/dustwave/problem.par
+++ b/problems/dustwave/problem.par
@@ -45,7 +45,6 @@
     cfl    = 0.9
     smalld = 1.e-8
     smallei= 1.e-8
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/dustybox/problem.par
+++ b/problems/dustybox/problem.par
@@ -48,7 +48,6 @@
     smalld = 1.e-8
     smallei= 1.e-8
     dt_initial = 1.e-8
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/fargo_test/problem.par
+++ b/problems/fargo_test/problem.par
@@ -66,7 +66,6 @@
     use_smalld = .true.
     smalld = 5.e-7
     relax_time = 5.0
-    integration_order = 2
     limiter= 'vanleer'
     cfr_smooth = 0.01
     geometry25D = .false.

--- a/problems/field_loop_mhd/initproblem.F90
+++ b/problems/field_loop_mhd/initproblem.F90
@@ -147,7 +147,7 @@ contains
     use fluidindex,  only: flind
     use fluidtypes,  only: component_fluid
     use func,        only: ekin, emag
-    use global,      only: force_cc_mag
+    use global,      only: cc_mag
 
     implicit none
 
@@ -176,7 +176,7 @@ contains
                 cg%u(fl%imy,i,j,k) = vy*cg%u(fl%idn,i,j,k)
                 cg%u(fl%imz,i,j,k) = zero
                 ! Mangetic field
-                if (force_cc_mag) then
+                if (cc_mag) then
                    if ( sqrt(cg%x(i)*cg%x(i) + cg%y(j)*cg%y(j) ) .le. R ) then
                       cg%b(xdim,i,j,k) = -A0*cg%y(j)/(sqrt(cg%x(i)*cg%x(i) + cg%y(j)*cg%y(j) )) !  dA_z/dy
                       cg%b(ydim,i,j,k) =  A0*cg%x(i)/(sqrt(cg%x(i)*cg%x(i) + cg%y(j)*cg%y(j) )) ! -dA_z/dx

--- a/problems/kepler/problem.par
+++ b/problems/kepler/problem.par
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-6
     smallei= 1.e-6
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/kepler/problem.par.2d
+++ b/problems/kepler/problem.par.2d
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-3
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/kepler/problem.par.build
+++ b/problems/kepler/problem.par.build
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-6
     smallei= 1.e-6
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/kepler/problem.par.kep
+++ b/problems/kepler/problem.par.kep
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-4
     smallei= 1.e-4
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/khi/problem.par
+++ b/problems/khi/problem.par
@@ -45,7 +45,6 @@
     cfl    = 0.9
     smalld = 1.e-6
     smallei= 1.e-4
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/lingrav/problem.par
+++ b/problems/lingrav/problem.par
@@ -50,7 +50,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter= 'vanleer'
   /
 

--- a/problems/magnetic_rotor/initproblem.F90
+++ b/problems/magnetic_rotor/initproblem.F90
@@ -141,7 +141,7 @@ contains
     use fluidindex,  only: flind
     use fluidtypes,  only: component_fluid
     use func,        only: ekin, emag
-!    use global,      only: force_cc_mag
+!    use global,      only: cc_mag
 
     implicit none
 
@@ -201,7 +201,7 @@ contains
                 cg%u(fl%ien,i,j,k) = uni_pres/fl%gam_1 + ekin(cg%u(fl%imx,i,j,k), cg%u(fl%imy,i,j,k), cg%u(fl%imz,i,j,k), cg%u(fl%idn,i,j,k)) + &
                                              emag(cg%b(xdim,i,j,k), cg%b(ydim,i,j,k), cg%b(zdim,i,j,k))
 
-                !if (force_cc_mag) then
+                !if (cc_mag) then
 
                     cg%b(xdim,i,j,k) = Bx
                     cg%b(ydim,i,j,k) = zero

--- a/problems/mcrtest/problem.par
+++ b/problems/mcrtest/problem.par
@@ -48,7 +48,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/mcrtest/problem.par.build
+++ b/problems/mcrtest/problem.par.build
@@ -46,7 +46,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/mcrtest/problem.par.build2
+++ b/problems/mcrtest/problem.par.build2
@@ -48,7 +48,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
     disallow_negatives = .false.
  /

--- a/problems/mcrtest/problem.par.refined
+++ b/problems/mcrtest/problem.par.refined
@@ -49,7 +49,6 @@
     cfl    = 0.5
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
     disallow_negatives = .false.
     solver_str = "Riemann"

--- a/problems/mcrwind/problem.par
+++ b/problems/mcrwind/problem.par
@@ -52,7 +52,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/mcrwind/problem.par.build
+++ b/problems/mcrwind/problem.par.build
@@ -54,7 +54,6 @@
     cfl          = 0.65
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = "vanleer"
     divB_0       = "CT"
     repeat_step = .true.

--- a/problems/mcrwind/problem.par.highres
+++ b/problems/mcrwind/problem.par.highres
@@ -53,7 +53,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/mcrwind/problem.par.lowres
+++ b/problems/mcrwind/problem.par.lowres
@@ -53,7 +53,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/mcrwind/problem.par.multigrid
+++ b/problems/mcrwind/problem.par.multigrid
@@ -52,7 +52,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/mcrwind/problem.par.multisn_wind
+++ b/problems/mcrwind/problem.par.multisn_wind
@@ -52,7 +52,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = "vanleer"
   /
 

--- a/problems/mcrwind/problem.par.selfgrav
+++ b/problems/mcrwind/problem.par.selfgrav
@@ -53,7 +53,6 @@
     cfl          = 0.5
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/mcrwind/problem.par.singlesn_test
+++ b/problems/mcrwind/problem.par.singlesn_test
@@ -52,7 +52,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = "vanleer"
   /
 

--- a/problems/mcrwind/problem.par.smalltest
+++ b/problems/mcrwind/problem.par.smalltest
@@ -52,7 +52,6 @@
     cfl          = 0.9
     smalld       = 1.e-5
     smallei      = 1.e-4
-    integration_order = 2
     limiter      = 'vanleer'
   /
 

--- a/problems/otvortex/problem.par
+++ b/problems/otvortex/problem.par
@@ -52,7 +52,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/otvortex/problem.par.build
+++ b/problems/otvortex/problem.par.build
@@ -58,7 +58,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/otvortex/problem.par.fluxlimiter_test
+++ b/problems/otvortex/problem.par.fluxlimiter_test
@@ -52,7 +52,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
  /
 
  $GRAVITY

--- a/problems/particle_map_test/problem.par
+++ b/problems/particle_map_test/problem.par
@@ -51,7 +51,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/roche/problem.par
+++ b/problems/roche/problem.par
@@ -56,7 +56,6 @@
     cfl    = 0.7
     smalld = 1.e-6
     smallei= 1.e-7
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/sedov/problem.par.AMR
+++ b/problems/sedov/problem.par.AMR
@@ -53,7 +53,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/sedov/problem.par._vulnerable_to_deadlock_in_refinement_after_domain_expansion_
+++ b/problems/sedov/problem.par._vulnerable_to_deadlock_in_refinement_after_domain_expansion_
@@ -56,7 +56,6 @@
     cfl    = 0.7
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/sedov/problem.par.build
+++ b/problems/sedov/problem.par.build
@@ -57,7 +57,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/sedov/problem.par.build-outflow
+++ b/problems/sedov/problem.par.build-outflow
@@ -58,7 +58,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/sedov/problem.par.expanding_domain
+++ b/problems/sedov/problem.par.expanding_domain
@@ -53,7 +53,6 @@
     cfl    = 0.7
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj1a
+++ b/problems/shock1d_rj/problem.par.rj1a
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj1b
+++ b/problems/shock1d_rj/problem.par.rj1b
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj2a
+++ b/problems/shock1d_rj/problem.par.rj2a
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj2b
+++ b/problems/shock1d_rj/problem.par.rj2b
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj3a
+++ b/problems/shock1d_rj/problem.par.rj3a
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj3b
+++ b/problems/shock1d_rj/problem.par.rj3b
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj4a
+++ b/problems/shock1d_rj/problem.par.rj4a
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj4b
+++ b/problems/shock1d_rj/problem.par.rj4b
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj4c
+++ b/problems/shock1d_rj/problem.par.rj4c
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/shock1d_rj/problem.par.rj4d
+++ b/problems/shock1d_rj/problem.par.rj4d
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/slab/problem.par
+++ b/problems/slab/problem.par
@@ -51,7 +51,6 @@
     cfl    = 0.7
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/slab/problem.par.2d
+++ b/problems/slab/problem.par.2d
@@ -50,7 +50,6 @@
     cfl    = 0.7
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/stream/problem_BA.par
+++ b/problems/stream/problem_BA.par
@@ -61,7 +61,6 @@
     cfr_smooth = 0.1
     smalld = 1.e-4
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
     geometry25D = .true.
  /

--- a/problems/stream/problem_lin.par
+++ b/problems/stream/problem_lin.par
@@ -68,7 +68,6 @@
     cfr_smooth = 0.1
     smalld = 1.e-4
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'vanleer'
     geometry25D = .true.
  /

--- a/problems/stream3D/problem.par
+++ b/problems/stream3D/problem.par
@@ -60,7 +60,6 @@
     cfr_smooth = 0.1
     smalld = 1.e-6
     smallei= 1.e-6
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/problems/streaming_global/problem.par
+++ b/problems/streaming_global/problem.par
@@ -66,7 +66,6 @@
     use_smalld = .true.
     smalld = 5.e-7
     relax_time = 10.0
-    integration_order = 2
     limiter= 'vanleer'
     cfr_smooth = 0.01
     geometry25D = .true.

--- a/problems/streaming_global/problem.par.AMR
+++ b/problems/streaming_global/problem.par.AMR
@@ -61,7 +61,6 @@
     use_smalld = .true.
     smalld = 5.e-7
     relax_time = 0.00001
-    integration_order = 2
     limiter= 'vanleer'
     cfr_smooth = 0.01
     geometry25D = .false.

--- a/problems/streaming_global/problem.par.build
+++ b/problems/streaming_global/problem.par.build
@@ -67,7 +67,6 @@
     use_smalld = .true.
     smalld = 5.e-7
     relax_time = 5.0
-    integration_order = 2
     limiter= 'vanleer'
     cfr_smooth = 0.01
     geometry25D = .true.

--- a/problems/tearing/problem.par.build
+++ b/problems/tearing/problem.par.build
@@ -51,7 +51,6 @@
     cfl    = 0.4
     smalld = 1.e-5
     smallei= 1.e-5
-    integration_order  = 2
     limiter= 'vanleer'
  /
 

--- a/problems/turbulence/problem.par
+++ b/problems/turbulence/problem.par
@@ -50,7 +50,6 @@
     cfl    = 0.8
     smalld = 1.e-3
     smallei= 1.e-5
-    integration_order = 2
     limiter= 'moncen'
  /
 

--- a/problems/wind/problem.par
+++ b/problems/wind/problem.par
@@ -53,7 +53,6 @@
     cfl    = 0.8
     smalld = 1.e-20
     smallei= 1.e-20
-    integration_order = 2
     limiter= 'vanleer'
  /
 

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -98,7 +98,7 @@ contains
       use constants,  only: dsetnamelen, singlechar
       use dataio_pub, only: warn
       use fluids_pub, only: has_ion, has_dst, has_neu
-      use global,     only: force_cc_mag
+      use global,     only: cc_mag
       use mpisetup,   only: master
 #ifdef COSM_RAYS
       use dataio_pub, only: msg
@@ -154,13 +154,13 @@ contains
                if (has_neu) call append_var('ethn')
                if (has_ion) call append_var('ethi')
             case ("divb", "divB")
-               if (force_cc_mag) then
+               if (cc_mag) then
                   call append_var("divbc")
                else
                   call append_var("divbf")
                endif
             case ("divb4", "divb6", "divb8")
-               if (force_cc_mag) then
+               if (cc_mag) then
                   fc = "c"
                else
                   fc = "f"

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -275,7 +275,7 @@ contains
       use constants,   only: xdim, ydim, zdim, half, two, I_TWO, I_FOUR, I_SIX, I_EIGHT
       use div_B,       only: divB_c_IO
       use domain,      only: dom
-      use global,      only: force_cc_mag
+      use global,      only: cc_mag
 #endif /* MAGNETIC */
 
       implicit none
@@ -307,7 +307,7 @@ contains
            &                    emag(half*(cg%b(xdim, cg%is:cg%ie, cg%js:cg%je, cg%ks:cg%ke) + cg%b(xdim, cg%is+dom%D_x:cg%ie+dom%D_x, cg%js        :cg%je,         cg%ks        :cg%ke        )), &
            &                         half*(cg%b(ydim, cg%is:cg%ie, cg%js:cg%je, cg%ks:cg%ke) + cg%b(ydim, cg%is        :cg%ie,         cg%js+dom%D_y:cg%je+dom%D_y, cg%ks        :cg%ke        )), &
            &                         half*(cg%b(zdim, cg%is:cg%ie, cg%js:cg%je, cg%ks:cg%ke) + cg%b(zdim, cg%is        :cg%ie,         cg%js        :cg%je,         cg%ks+dom%D_z:cg%ke+dom%D_z))), &
-           &                    force_cc_mag))  ! fortran way of constructing ternary operators
+           &                    cc_mag))  ! fortran way of constructing ternary operators
 #else /* !MAGNETIC */
       associate(emag_c => 0.)
 #endif /* !MAGNETIC */
@@ -370,7 +370,7 @@ contains
             tab(:,:,:) =  merge(atan2(cg%b(ydim, RNG), cg%b(xdim, RNG)), &
                  &              atan2(cg%b(ydim, RNG) + cg%b(ydim, cg%is        :cg%ie,         cg%js+dom%D_y:cg%je+dom%D_y, cg%ks        :cg%ke        ), &
                  &                    cg%b(xdim, RNG) + cg%b(xdim, cg%is+dom%D_x:cg%ie+dom%D_x, cg%js        :cg%je,         cg%ks        :cg%ke        )),  &
-                 &              force_cc_mag)
+                 &              cc_mag)
             ! ToDo: magi - inclination
             ! ToDo: curlb - nabla x B
 !! ToDo: autodetect centering, add option for dumping both just in case

--- a/src/base/all_boundaries.F90
+++ b/src/base/all_boundaries.F90
@@ -51,12 +51,10 @@ contains
 
       implicit none
 
-!      if (all(cg%bnd(:,:) /= BND_USER)) then
       call all_fluid_boundaries
 #ifdef MAGNETIC
       call all_mag_boundaries
 #endif /* MAGNETIC */
-!      endif
 
    end subroutine all_bnd
 

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -132,7 +132,7 @@ contains
 !!   <tr><td>use_smalld       </td><td>.true. </td><td>logical value                        </td><td>\copydoc global::use_smalld       </td></tr>
 !!   <tr><td>smallei          </td><td>1.e-10 </td><td>real value                           </td><td>\copydoc global::smallei          </td></tr>
 !!   <tr><td>smallc           </td><td>1.e-10 </td><td>real value                           </td><td>\copydoc global::smallc           </td></tr>
-!!   <tr><td>integration_order</td><td>2      </td><td>1 or 2 (or 3 - currently unavailable)</td><td>\copydoc global::integration_order</td></tr>
+!!   <tr><td>integration_order</td><td>2      </td><td>1 or 2                               </td><td>\copydoc global::integration_order</td></tr>
 !!   <tr><td>cfr_smooth       </td><td>0.0    </td><td>real value                           </td><td>\copydoc global::cfr_smooth       </td></tr>
 !!   <tr><td>dt_initial       </td><td>-1.    </td><td>positive real value or -1. .. 0.     </td><td>\copydoc global::dt_initial       </td></tr>
 !!   <tr><td>dt_max_grow      </td><td>2.     </td><td>real value, should be > 1.           </td><td>\copydoc global::dt_max_grow      </td></tr>

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -44,7 +44,7 @@ module global
         &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, repeat_step, skip_sweep, geometry25D, &
         &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, do_external_corners, prefer_merged_MPI, &
-        &    divB_0_method, force_cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fluid_prolong, which_solver
+        &    divB_0_method, cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fluid_prolong, which_solver
 
    logical         :: cfl_violated             !< True when cfl condition is violated
    logical         :: dn_negative = .false.
@@ -58,7 +58,7 @@ module global
    integer(kind=4) :: nstep, nstep_saved
    real            :: t, dt, dt_old, dtm, t_saved
    integer         :: divB_0_method            !< encoded method of making div(B) = 0 (currently DIVB_CT or DIVB_HDC)
-   logical         :: force_cc_mag             !< treat magnetic field as cell-centered in the Riemann solver (temporary hack)
+   logical         :: cc_mag                   !< use cell-centered magnetic field
    integer(kind=4) :: psi_bnd                  !< BND_INVALID or enforce some other psi boundary
    integer         :: tstep_attempt            !< /= 0 when we retry timesteps
    integer         :: which_solver             !< one of RTVD_SPLIT, HLLC_SPLIT or RIEMANN_SPLIT
@@ -418,13 +418,13 @@ contains
       endif
 
       !> reshape_b should carefully check things here
-      force_cc_mag = .false.
+      cc_mag = .false.
       select case (divB_0_method)
          case (DIVB_HDC)
-            force_cc_mag = .true.
+            cc_mag = .true.
             if (ch_grid .and. master) call warn("[global] ch_grid = .true. is risky")
          case (DIVB_CT)
-            force_cc_mag = .false.
+            cc_mag = .false.
          case default
             call die("[global:init_global] unrecognized divergence cleaning method.")
       end select
@@ -466,7 +466,7 @@ contains
                 call die("    The div(B) constraint is maintaineded by Uknown Something.")
          end select
 
-         if (force_cc_mag) then
+         if (cc_mag) then
             call printinfo("    Magnetic field is cell-centered.")
          else
             call printinfo("    Magnetic field is face-centered (staggered).")

--- a/src/fluids/cosmicrays/multigrid_diffusion.F90
+++ b/src/fluids/cosmicrays/multigrid_diffusion.F90
@@ -111,7 +111,7 @@ contains
       use domain,           only: dom
       use fluidindex,       only: flind
       use func,             only: operator(.notequals.)
-      use global,           only: force_cc_mag
+      use global,           only: cc_mag
       use mpisetup,         only: master, slave, nproc, ibuff, rbuff, lbuff, cbuff, piernik_MPI_Bcast
       use multigridvars,    only: single_base
       use named_array_list, only: qna
@@ -247,9 +247,9 @@ contains
 
       !> \todo consider adding multigrid = .true. to the b-field (re-register it?)
       pia => pos
-      pos = merge(VAR_CENTER, VAR_XFACE, force_cc_mag) ; call all_cg%reg_var(diff_bx_n, multigrid = .true., position = pia)
-      pos = merge(VAR_CENTER, VAR_YFACE, force_cc_mag) ; call all_cg%reg_var(diff_by_n, multigrid = .true., position = pia)
-      pos = merge(VAR_CENTER, VAR_ZFACE, force_cc_mag) ; call all_cg%reg_var(diff_bz_n, multigrid = .true., position = pia)
+      pos = merge(VAR_CENTER, VAR_XFACE, cc_mag) ; call all_cg%reg_var(diff_bx_n, multigrid = .true., position = pia)
+      pos = merge(VAR_CENTER, VAR_YFACE, cc_mag) ; call all_cg%reg_var(diff_by_n, multigrid = .true., position = pia)
+      pos = merge(VAR_CENTER, VAR_ZFACE, cc_mag) ; call all_cg%reg_var(diff_bz_n, multigrid = .true., position = pia)
       idiffb(xdim) = qna%ind(diff_bx_n)
       idiffb(ydim) = qna%ind(diff_by_n)
       idiffb(zdim) = qna%ind(diff_bz_n)

--- a/src/fluids/ionized/initionized.F90
+++ b/src/fluids/ionized/initionized.F90
@@ -92,7 +92,7 @@ contains
       use constants, only: xdim, ydim, zdim, half
       use domain,    only: dom
       use func,      only: emag
-      use global,    only: force_cc_mag
+      use global,    only: cc_mag
 #else /* !MAGNETIC */
       use constants, only: zero
 #endif /* !MAGNETIC */
@@ -110,7 +110,7 @@ contains
       real :: pmag, p, ps
 
 #ifdef MAGNETIC
-      if (force_cc_mag) then
+      if (cc_mag) then
          pmag = emag(b(xdim,i,j,k), b(ydim,i,j,k), b(zdim,i,j,k))
       else
          bx = half*(b(xdim,i,j,k) + b(xdim, i+dom%D_x, j,         k        ))

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -249,6 +249,7 @@ contains
    subroutine leaf_arr4d_boundaries(this, ind, area_type, dir, nocorners)
 
       use cg_level_connected, only: cg_level_connected_t
+      use cg_level_finest,    only: finest
       use constants,          only: O_INJ
       use named_array_list,   only: wna
       use ppp,                only: ppp_main
@@ -271,10 +272,11 @@ contains
       if (present(nocorners)) nc=nocorners
       if (wna%lst(ind)%ord_prolong /= O_INJ) nc = .false.
 
-      curl => this%coarsest_leaves
+      curl => finest%level
       do while (associated(curl))
-         call curl%level_4d_boundaries(ind, area_type=area_type, dir=dir, nocorners=nocorners)
-         curl => curl%finer
+         if (this%coarsest_leaves%l%id <= curl%l%id) &
+              call curl%level_4d_boundaries(ind, area_type=area_type, dir=dir, nocorners=nocorners)
+         curl => curl%coarser
       enddo
 
       curl => this%coarsest_leaves

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -61,6 +61,9 @@ module cg_leaves
       procedure :: balance_and_update      !< Rebalance if required and update
       procedure :: leaf_arr3d_boundaries   !< Wrapper routine to set up all guardcells (internal, external and fine-coarse) for given rank-3 arrays on leaves
       procedure :: leaf_arr4d_boundaries   !< Wrapper routine to set up all guardcells (internal, external and fine-coarse) for given rank-4 arrays on leaves
+      procedure :: prioritized_cg          !< Returna a leaves list with different ordering of cg to optimize fine->coarse flux transfer
+      procedure :: leaf_only_cg            !< Returna a leaves list without fully covered cg
+
    end type cg_leaves_t
 
    !>
@@ -289,5 +292,101 @@ contains
       call ppp_main%stop(l4b_label)
 
    end subroutine leaf_arr4d_boundaries
+
+!>
+!! \brief Change the order of cg to optimize fine->coarse flux transfer.
+!!
+!! * Put these cg which have something to send, but aren't waiting for receives.
+!! * Then put remaining cg which have something to send.
+!! * Then put remaining cg which have any leaf (active) cells.
+!! * Fully covered cg should optionally be appended at the end just in case.
+!<
+
+   function prioritized_cg(this, dir, covered_too) result(sorted_leaves)
+
+      use cg_list,        only: cg_list_element
+      use cg_list_dataop, only: cg_list_dataop_t
+
+      implicit none
+
+      class(cg_leaves_t), intent(in) :: this  !< object invoking type-bound procedure
+      integer(kind=4),    intent(in) :: dir
+      logical, optional,  intent(in) :: covered_too
+
+      type(cg_list_dataop_t), pointer :: sorted_leaves
+      type(cg_list_element),  pointer :: cgl
+
+      allocate(sorted_leaves)
+      call sorted_leaves%init_new("sorted_leaves")
+
+      cgl => this%first
+      do while (associated(cgl))
+         cgl%cg%processed = .false.
+         if (cgl%cg%is_sending_fc_flux(dir) .and. .not. cgl%cg%is_receiving_fc_flux(dir)) then
+            call sorted_leaves%add(cgl%cg)
+            cgl%cg%processed = .true.
+         endif
+         cgl => cgl%nxt
+      enddo
+
+      cgl => this%first
+      do while (associated(cgl))
+         if (.not. cgl%cg%processed) then
+            if (cgl%cg%is_sending_fc_flux(dir)) then
+               call sorted_leaves%add(cgl%cg)
+               cgl%cg%processed = .true.
+            endif
+         endif
+         cgl => cgl%nxt
+      enddo
+
+      cgl => this%first
+      do while (associated(cgl))
+         if (.not. cgl%cg%processed) then
+            if (cgl%cg%has_leaves()) then
+               call sorted_leaves%add(cgl%cg)
+               cgl%cg%processed = .true.
+           endif
+         endif
+         cgl => cgl%nxt
+      enddo
+
+      if (covered_too) then
+         cgl => this%first
+         do while (associated(cgl))
+            if (.not. cgl%cg%processed) then
+               call sorted_leaves%add(cgl%cg)
+               cgl%cg%processed = .true.
+            endif
+            cgl => cgl%nxt
+         enddo
+      endif
+
+   end function prioritized_cg
+
+!> \brief Returna a leaves list without fully covered cg
+
+   function leaf_only_cg(this) result(selected_leaves)
+
+      use cg_list,        only: cg_list_element
+      use cg_list_dataop, only: cg_list_dataop_t
+
+      implicit none
+
+      class(cg_leaves_t), intent(in) :: this  !< object invoking type-bound procedure
+
+      type(cg_list_dataop_t), pointer :: selected_leaves
+      type(cg_list_element), pointer :: cgl
+
+      allocate(selected_leaves)
+      call selected_leaves%init_new("non-covered_leaves")
+
+      cgl => this%first
+      do while (associated(cgl))
+         if (cgl%cg%has_leaves()) call selected_leaves%add(cgl%cg)
+         cgl => cgl%nxt
+      enddo
+
+   end function leaf_only_cg
 
 end module cg_leaves

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -957,7 +957,7 @@ contains
       use dataio_pub,            only: msg, warn, die
       use domain,                only: dom
       use fluidboundaries_funcs, only: user_fluidbnd
-      use global,                only: force_cc_mag
+      use global,                only: cc_mag
       use grid_cont,             only: grid_container
       use mpisetup,              only: master
       use named_array_list,      only: wna
@@ -1000,7 +1000,7 @@ contains
                case (BND_USER)
                   call user_fluidbnd(dir, side, cg, wn=wna%bi)
                case (BND_FC, BND_MPI_FC)
-                  if (.not. force_cc_mag) &
+                  if (.not. cc_mag) &
                        call die("[cg_list_bnd:bnd_b] fine-coarse interfaces not implemented yet for face-centered B field.")
                case (BND_COR)
                   if (dir == zdim) then
@@ -1029,7 +1029,7 @@ contains
 
          subroutine outflow_b(cg, dir, side)
 
-            ! use global,                only: force_cc_mag
+            ! use global,                only: cc_mag
             use grid_cont,             only: grid_container
 
             implicit none
@@ -1052,7 +1052,7 @@ contains
             !
             !   it = cg%ijkse(dir, side) - pm_one * i + (side - LO)
             !
-            ! when force_cc_mag is .false. in evaluation of dir-component of magnetic field
+            ! when cc_mag is .false. in evaluation of dir-component of magnetic field
             ! for more strict external boundary treatment.
 
             ! BEWARE: this kind of boundaries does not guarantee div(B) == 0 .

--- a/src/grid/cg_list_global.F90
+++ b/src/grid/cg_list_global.F90
@@ -237,7 +237,7 @@ contains
 #endif /* ISO */
 #ifdef MAGNETIC
       use constants,  only: mag_n, magh_n, ndims, AT_OUT_B, VAR_XFACE, VAR_YFACE, VAR_ZFACE, VAR_CENTER, psi_n, psih_n
-      use global,     only: force_cc_mag, ord_mag_prolong
+      use global,     only: cc_mag, ord_mag_prolong
 #endif /* MAGNETIC */
 
       implicit none
@@ -249,7 +249,7 @@ contains
       integer(kind=4), dimension(ndims), parameter :: xyz_center = [ VAR_CENTER, VAR_CENTER, VAR_CENTER ]
       integer(kind=4), dimension(ndims) :: pia
 
-      pia = merge(xyz_center, xyz_face, force_cc_mag)
+      pia = merge(xyz_center, xyz_face, cc_mag)
 #endif /* MAGNETIC */
 
       if (code_progress < PIERNIK_INIT_FLUIDS) call die("[cg_list_global:register_fluids] Fluids are not yet initialized")
@@ -262,7 +262,7 @@ contains
       call this%reg_var(mag_n,  vital = .true.,  dim4 = ndims, ord_prolong = ord_mag_prolong, restart_mode = AT_OUT_B, position=pia)  !! Main array of magnetic field's components, "b"
       call this%reg_var(magh_n, vital = .false., dim4 = ndims) !! Array for copy of magnetic field's components, "b" used in half-timestep in RK2
 
-      if (force_cc_mag) then
+      if (cc_mag) then
          call this%reg_var(psi_n,  vital = .true., ord_prolong = ord_mag_prolong, restart_mode = AT_OUT_B)  !! an array for div B cleaning
          call this%reg_var(psih_n, vital = .false.)  !! its copy for use in RK2
       endif

--- a/src/grid/grid_container_bnd.F90
+++ b/src/grid/grid_container_bnd.F90
@@ -89,11 +89,12 @@ module grid_cont_bnd
 
    contains
 
-      procedure          :: init_gc_bnd         !< Initialization
-      procedure          :: cleanup_bnd         !< Deallocate all internals
-      procedure          :: set_fluxpointers    !< Calculate fluxes incoming from fine grid for 1D solver
-      procedure          :: save_outfluxes      !< Collect outgoing fine fluxes, do curvilinear scaling and store in appropriate array
-      procedure          :: refinemap2SFC_list  !< create list of SFC indices to be created from refine flags
+      procedure :: init_gc_bnd         !< Initialization
+      procedure :: cleanup_bnd         !< Deallocate all internals
+      procedure :: set_fluxpointers    !< Calculate fluxes incoming from fine grid for 1D solver
+      procedure :: save_outfluxes      !< Collect outgoing fine fluxes, do curvilinear scaling and store in appropriate array
+      procedure :: refinemap2SFC_list  !< Create list of SFC indices to be created from refine flags
+      procedure :: has_leaves          !< Returns .true. if there are any non-covered cells on this
 
    end type grid_container_bnd_t
 
@@ -375,5 +376,17 @@ contains
       call this%flag%clear
 
    end subroutine refinemap2SFC_list
+
+!> \brief Returns .true. if there are any non-covered cells on this
+
+   pure logical function has_leaves(this)
+
+      implicit none
+
+      class(grid_container_bnd_t), intent(in) :: this
+
+      has_leaves = any(this%leafmap)
+
+   end function has_leaves
 
 end module grid_cont_bnd

--- a/src/magnetic/divB.F90
+++ b/src/magnetic/divB.F90
@@ -148,7 +148,7 @@ contains
       use constants,  only: GEO_XYZ
       use dataio_pub, only: msg, die, warn
       use domain,     only: dom
-      use global,     only: force_cc_mag
+      use global,     only: cc_mag
 
       implicit none
 
@@ -188,7 +188,7 @@ contains
          if (dom%nb < ord/2) call die("[divB:divB] Not enough guardcells for requested approximation order")  ! assumed stencils on uniform grid
       endif
 
-      ccB = force_cc_mag
+      ccB = cc_mag
       if (present(cell_centered)) ccB = cell_centered
 
       call divB_init  ! it should be BOTH safe and cheap to call it multiple times

--- a/src/scheme/Riemann_Solver/solve_cg_riemann.F90
+++ b/src/scheme/Riemann_Solver/solve_cg_riemann.F90
@@ -116,7 +116,7 @@ contains
       use constants,        only: pdims, xdim, zdim, ORTHO1, ORTHO2, LO, HI, psi_n, uh_n, magh_n, psih_n, INVALID, rk_coef, psidim, cs_i2_n
       use fluidindex,       only: flind, iarr_all_dn, iarr_all_mx, iarr_all_swp, iarr_mag_swp
       use fluxtypes,        only: ext_fluxes
-      use global,           only: dt, force_cc_mag
+      use global,           only: dt, cc_mag
       use grid_cont,        only: grid_container
       use named_array_list, only: wna, qna
       use sources,          only: all_sources, care_for_positives
@@ -173,7 +173,7 @@ contains
             u(:, iarr_all_swp(ddim,:)) = transpose(pu(:,:))
 
             pb => cg%w(wna%bi)%get_sweep(ddim,i1,i2)
-            if (force_cc_mag) then
+            if (cc_mag) then
                pb0 => cg%w(bhi)%get_sweep(ddim,i1,i2)
                b0(:, iarr_mag_swp(ddim,:)) = transpose(pb0(:,:))
                b(:, iarr_mag_swp(ddim,:)) = transpose(pb(:,:))
@@ -212,7 +212,7 @@ contains
 
             call cg%save_outfluxes(ddim, i1, i2, eflx)
             pu(:,:) = transpose(u1(:, iarr_all_swp(ddim,:)))
-            if (force_cc_mag) pb(:,:) = transpose(b1(:, iarr_mag_swp(ddim,:))) ! ToDo figure out how to manage CT energy fixup without extra storage
+            if (cc_mag) pb(:,:) = transpose(b1(:, iarr_mag_swp(ddim,:))) ! ToDo figure out how to manage CT energy fixup without extra storage
             if (psii /= INVALID) ppsi = b1(:, psidim)
          enddo
       enddo

--- a/src/scheme/Riemann_Solver/solve_cg_riemann.F90
+++ b/src/scheme/Riemann_Solver/solve_cg_riemann.F90
@@ -171,6 +171,7 @@ contains
             pu0 => cg%w(uhi)%get_sweep(ddim,i1,i2)
             pu => cg%w(wna%fi)%get_sweep(ddim,i1,i2)
             if (istep == first_stage(integration_order)) pu0 = pu
+            ! such copy is a bit faster than whole copy of u and we don't have to modify all the source routines
 
             u0(:, iarr_all_swp(ddim,:)) = transpose(pu0(:,:))
             u(:, iarr_all_swp(ddim,:)) = transpose(pu(:,:))

--- a/src/scheme/Riemann_Solver/solve_cg_riemann.F90
+++ b/src/scheme/Riemann_Solver/solve_cg_riemann.F90
@@ -113,10 +113,11 @@ contains
    subroutine solve_cg_ub(cg, ddim, istep)
 
       use bfc_bcc,          only: interpolate_mag_field
-      use constants,        only: pdims, xdim, zdim, ORTHO1, ORTHO2, LO, HI, psi_n, uh_n, magh_n, psih_n, INVALID, rk_coef, psidim, cs_i2_n
+      use constants,        only: pdims, xdim, zdim, ORTHO1, ORTHO2, LO, HI, psi_n, uh_n, magh_n, psih_n, INVALID, &
+           &                      rk_coef, psidim, cs_i2_n, first_stage
       use fluidindex,       only: flind, iarr_all_dn, iarr_all_mx, iarr_all_swp, iarr_mag_swp
       use fluxtypes,        only: ext_fluxes
-      use global,           only: dt, cc_mag
+      use global,           only: dt, cc_mag, integration_order
       use grid_cont,        only: grid_container
       use named_array_list, only: wna, qna
       use sources,          only: all_sources, care_for_positives
@@ -168,13 +169,17 @@ contains
 
             ! transposition for compatibility with RTVD-based routines
             pu0 => cg%w(uhi)%get_sweep(ddim,i1,i2)
-            u0(:, iarr_all_swp(ddim,:)) = transpose(pu0(:,:))
             pu => cg%w(wna%fi)%get_sweep(ddim,i1,i2)
+            if (istep == first_stage(integration_order)) pu0 = pu
+
+            u0(:, iarr_all_swp(ddim,:)) = transpose(pu0(:,:))
             u(:, iarr_all_swp(ddim,:)) = transpose(pu(:,:))
 
             pb => cg%w(wna%bi)%get_sweep(ddim,i1,i2)
+            pb0 => cg%w(bhi)%get_sweep(ddim,i1,i2)
+            if (istep == first_stage(integration_order)) pb0 = pb
+
             if (cc_mag) then
-               pb0 => cg%w(bhi)%get_sweep(ddim,i1,i2)
                b0(:, iarr_mag_swp(ddim,:)) = transpose(pb0(:,:))
                b(:, iarr_mag_swp(ddim,:)) = transpose(pb(:,:))
             else
@@ -195,8 +200,10 @@ contains
             vx = u(:, iarr_all_mx) / u(:, iarr_all_dn) ! this may also be useful for gravitational acceleration
             if (psii > INVALID) then
                ppsi0 => cg%q(psihi)%get_sweep(ddim,i1,i2)
-               b0(:, psidim) = ppsi0(:)
                ppsi => cg%q(psii)%get_sweep(ddim,i1,i2)
+               if (istep == first_stage(integration_order)) ppsi0 = ppsi
+
+               b0(:, psidim) = ppsi0(:)
                b1(:, psidim) = ppsi(:)
 
                call solve(u0, b0, u1, b1, cs2, rk_coef(istep) * dt/cg%dl(ddim), eflx)
@@ -223,10 +230,10 @@ contains
 
    subroutine solve_cg_u(cg, ddim, istep)
 
-      use constants,        only: pdims, ORTHO1, ORTHO2, LO, HI, uh_n, rk_coef, cs_i2_n
+      use constants,        only: pdims, ORTHO1, ORTHO2, LO, HI, uh_n, rk_coef, cs_i2_n, first_stage
       use fluidindex,       only: flind, iarr_all_dn, iarr_all_mx, iarr_all_swp
       use fluxtypes,        only: ext_fluxes
-      use global,           only: dt
+      use global,           only: dt, integration_order
       use grid_cont,        only: grid_container
       use named_array_list, only: wna, qna
       use sources,          only: all_sources, care_for_positives
@@ -264,8 +271,10 @@ contains
 
             ! transposition for compatibility with RTVD-based routines
             pu0 => cg%w(uhi)%get_sweep(ddim,i1,i2)
-            u0(:, iarr_all_swp(ddim,:)) = transpose(pu0(:,:))
             pu => cg%w(wna%fi)%get_sweep(ddim,i1,i2)
+            if (istep == first_stage(integration_order)) pu0 = pu
+
+            u0(:, iarr_all_swp(ddim,:)) = transpose(pu0(:,:))
             u(:, iarr_all_swp(ddim,:)) = transpose(pu(:,:))
             if (i_cs_iso2 > 0) cs2 => cg%q(i_cs_iso2)%get_sweep(ddim,i1,i2)
 

--- a/src/scheme/ct.F90
+++ b/src/scheme/ct.F90
@@ -192,7 +192,7 @@ contains
 
       use constants,   only: ndims, I_ONE
       use dataio_pub,  only: die
-      use global,      only: force_cc_mag
+      use global,      only: cc_mag
 #ifdef RESISTIVE
       use resistivity, only: diffuseb
 #endif /* RESISTIVE */
@@ -203,7 +203,7 @@ contains
 
       integer(kind=4)             :: bdir, dstep
 
-      if (force_cc_mag) call die("[ct:magfield] forcing cell-centered magnetic field is not allowed for constrained transport")
+      if (cc_mag) call die("[ct:magfield] cell-centered magnetic field is not allowed for constrained transport")
 
       do dstep = 0, 1
          bdir  = I_ONE + mod(dir+dstep,ndims)
@@ -330,7 +330,7 @@ contains
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
       use dataio_pub,       only: die
-      use global,           only: force_cc_mag
+      use global,           only: cc_mag
       use grid_cont,        only: grid_container
       use all_boundaries,   only: all_mag_boundaries
       use user_hooks,       only: custom_emf_bnd
@@ -351,7 +351,7 @@ contains
       real, dimension(:,:,:), pointer :: wcu
 #endif /* RESISTIVE */
 
-      if (force_cc_mag) call die("[ct:mag_add] forcing cell-centered magnetic field is not allowed for constrained transport")
+      if (cc_mag) call die("[ct:mag_add] cell-centered magnetic field is not allowed for constrained transport")
 
       cgl => leaves%first
       do while (associated(cgl))

--- a/src/scheme/rtvd_split/solve_cg_rtvd.F90
+++ b/src/scheme/rtvd_split/solve_cg_rtvd.F90
@@ -122,7 +122,10 @@ contains
             if (i_cs_iso2 > 0) cs2 => cg%q(i_cs_iso2)%get_sweep(cdim,i1,i2)
 
             u (:, iarr_all_swp(cdim,:)) = transpose(pu (:,:))
+
             if (istep == first_stage(integration_order)) pu0 = pu
+            ! such copy is a bit faster than whole copy of u and we don't have to modify all the source routines
+
             u0(:, iarr_all_swp(cdim,:)) = transpose(pu0(:,:))
             if (use_fargo .and. cdim == ydim) then
                if (fargo_vel == VEL_RES) then

--- a/src/scheme/rtvd_split/solve_cg_rtvd.F90
+++ b/src/scheme/rtvd_split/solve_cg_rtvd.F90
@@ -51,13 +51,13 @@ contains
 
       use bfc_bcc,            only: interpolate_mag_field
       use cg_level_connected, only: cg_level_connected_t
-      use constants,          only: pdims, LO, HI, uh_n, cs_i2_n, ORTHO1, ORTHO2, VEL_CR, VEL_RES, ydim, rk_coef
+      use constants,          only: pdims, LO, HI, uh_n, cs_i2_n, ORTHO1, ORTHO2, VEL_CR, VEL_RES, ydim, rk_coef, first_stage
       use dataio_pub,         only: die
       use domain,             only: dom
       use find_lev,           only: find_level
       use fluidindex,         only: flind, iarr_all_swp, nmag, iarr_all_dn, iarr_all_mx
       use fluxtypes,          only: ext_fluxes
-      use global,             only: dt, use_fargo
+      use global,             only: dt, use_fargo, integration_order
       use grid_cont,          only: grid_container
       use gridgeometry,       only: set_geo_coeffs
       use named_array_list,   only: qna, wna
@@ -122,6 +122,7 @@ contains
             if (i_cs_iso2 > 0) cs2 => cg%q(i_cs_iso2)%get_sweep(cdim,i1,i2)
 
             u (:, iarr_all_swp(cdim,:)) = transpose(pu (:,:))
+            if (istep == first_stage(integration_order)) pu0 = pu
             u0(:, iarr_all_swp(cdim,:)) = transpose(pu0(:,:))
             if (use_fargo .and. cdim == ydim) then
                if (fargo_vel == VEL_RES) then
@@ -158,10 +159,9 @@ contains
             ! istep is important only for balsara and selfgravity
 
             call care_for_positives(cg%n_(cdim), u1, b, cg, cdim, i1, i2)
-            u(:,:) = u1(:,:)
             call cg%save_outfluxes(cdim, i1, i2, eflx)
 
-            pu(:,:) = transpose(u(:, iarr_all_swp(cdim,:)))
+            pu(:,:) = transpose(u1(:, iarr_all_swp(cdim,:)))
             nullify(pu,pu0,cs2)
          enddo
       enddo

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -431,6 +431,7 @@ contains
          call update_boundaries(cdim, istep)
       enddo
 
+      call sl%delete
       deallocate(sl)
 
       call ppp_main%stop(sweep_label(cdim))

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -259,12 +259,6 @@ contains
       integer(kind=4), intent(in) :: cdim
       integer,         intent(in) :: istep
 
-      if (divB_0_method == DIVB_HDC) then
-#ifdef MAGNETIC
-         call all_mag_boundaries ! ToDo: take care of psi boundaries
-#endif /* MAGNETIC */
-      endif
-
       if (dom%has_dir(cdim)) then
          if (sweeps_mgu) then
             if (istep == first_stage(integration_order)) then
@@ -282,6 +276,12 @@ contains
                call all_fluid_boundaries !(nocorners = .true., dir = cdim)
             ! endif
          endif
+      endif
+
+      if (divB_0_method == DIVB_HDC) then
+#ifdef MAGNETIC
+         call all_mag_boundaries ! ToDo: take care of psi boundaries
+#endif /* MAGNETIC */
       endif
 
    end subroutine update_boundaries

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -372,9 +372,6 @@ contains
       cgl => leaves%first
       do while (associated(cgl))
          call prepare_sources(cgl%cg)
-         cgl%cg%w(uhi)%arr = cgl%cg%u
-         if (bhi  > INVALID) cgl%cg%w(bhi)%arr = cgl%cg%b
-         if (psii > INVALID) cgl%cg%q(psihi)%arr = cgl%cg%q(psii)%arr
          cgl => cgl%nxt
       enddo
 

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -341,7 +341,7 @@ contains
       integer                        :: uhi, bhi, psii, psihi
       procedure(solve_cg_sub), pointer :: solve_cg => null()
       character(len=*), dimension(ndims), parameter :: sweep_label = [ "sweep_x", "sweep_y", "sweep_z" ]
-      character(len=*), parameter :: solve_cgs_label = "solve_bunch_of_cg", cg_label = "solve_cg", copy_u_label = "copy_u"
+      character(len=*), parameter :: solve_cgs_label = "solve_bunch_of_cg", cg_label = "solve_cg", init_src_label = "init_src"
 
       call ppp_main%start(sweep_label(cdim))
 
@@ -375,18 +375,18 @@ contains
 
       sl => leaves%prioritized_cg(cdim, covered_too = .true.)
       ! We can't just skip the covered cg because it affects divvel (or
-      ! other things that rely on data computed on coarse cells and not
+      ! other things that rely on data computed on coarse cells and are not
       ! restricted from fine blocks).
 !      sl => leaves%leaf_only_cg()
 
-      call ppp_main%start(copy_u_label)
+      call ppp_main%start(init_src_label)
       ! for use with GLM divergence cleaning we also make a copy of b and psi fields
       cgl => leaves%first
       do while (associated(cgl))
          call prepare_sources(cgl%cg)
          cgl => cgl%nxt
       enddo
-      call ppp_main%stop(copy_u_label)
+      call ppp_main%stop(init_src_label)
 
       ! This is the loop over Runge-Kutta stages
       do istep = first_stage(integration_order), last_stage(integration_order)

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -273,10 +273,13 @@ contains
                call all_fluid_boundaries(nocorners = .true.)
             endif
          else
+            ! nocorners and dir = cdim can be used safely only when ord_fluid_prolong == 0 .and. cc_mag
+            ! essential speedups here are possible but it requires c/f boundary prolongation that does not require corners
+
             ! if (istep == first_stage(integration_order)) then
-            !    call all_fluid_boundaries(nocorners = .true.) ! nocorners was doing something bad to periodic boundaries in Riemann with CT
+            !    call all_fluid_boundaries(nocorners = .true.)
             ! else
-               call all_fluid_boundaries
+               call all_fluid_boundaries !(nocorners = .true., dir = cdim)
             ! endif
          endif
       endif


### PR DESCRIPTION
* Moved an extra copy of whole u to uh array from whole-array copy to line by line copy on use. Gained some speedup in sweeps (especially for CRESP).
* Changed order of internal boundaries update (can give a bit better communication/computation overlap in specific cases).
* Changed the order of cg processed in sweeps (can reduce MPI waits in specific cases).
* Some cosmetics and comments.

Some of the above optimisations have only marginal, barely measurable impact in CRESP. They act here more as a reminder of important points for future MPI-2 communication design.