### PR TITLE
Switchable MPI

### DIFF
--- a/bin/qa.py
+++ b/bin/qa.py
@@ -356,9 +356,13 @@ def qa_false_refs(lines, name, store, fname):
     uses = list(filter(has_use.search, temp))
 
     for item in uses:
-        to_check = [f.strip() for f in item.split("only:")[1].split(',')]
-        to_check = [re.sub('&', '', f).lstrip(
-        ) for f in to_check]     # additional sanitization
+        try:
+            to_check = [f.strip() for f in item.split("only:")[1].split(',')]
+        except IndexError:
+            to_check = []
+            store.append(give_warn("QA:  ") + "'" + item + "' without ONLY clause in [%s:%s]" %
+                         (fname, name))
+        to_check = [re.sub('&', '', f).lstrip() for f in to_check]  # additional sanitization
         # remove operator keyword from import
         for ino, item in enumerate(to_check):
             try:

--- a/compilers/lothlorien.in
+++ b/compilers/lothlorien.in
@@ -22,15 +22,17 @@ F90FLAGS += -fcheck=all
 # ToDo: Find out why.
 F90FLAGS += -frecursive
 
-# for gfortran >= 10.0 the use mpi_f08 interface is strongly encouraged
+# For gfortran >= 10.0 the use mpi_f08 interface is strongly encouraged
 F90FLAGS += -pedantic
+
+# Hack for old MPI interface when gfortran >= 10.
+ifneq (filter("-DNO_MPIF08_AVAILABLE",$(CPPFLAGS)),)
+F90FLAGS := $(filter-out -pedantic -pedantic-errors, $(F90FLAGS)) -fallow-argument-mismatch
+endif
 
 # For gfortran 10.x some optimisations implied by -O2 are known to lead to
 # wrong evaluation of the code
 F90FLAGS += -fno-inline-small-functions -fno-tree-pre
-
-# Ugly hack for old MPI interface
-# F90FLAGS += -fallow-argument-mismatch
 
 ifdef I64
   F90FLAGS += -fdefault-integer-8

--- a/compilers/tests/mpi.F90
+++ b/compilers/tests/mpi.F90
@@ -1,5 +1,16 @@
 ! Test whether the older MPI Fortran interface is sufficiently modern.
-! Older implementations are no longer supported since gfortran 10.x
+! Older implementations may require some special care, especially since gfortran 10.x
+
 program mpi_new
+
+#ifndef MPIF08
+
+#  ifndef NO_ALL_MPI_FUNCTIONS_AVAILABLE
    use mpi, only: MPI_Send
+#  else
+#    warning Current MPI library does not provide modern Fortran interface
+#  endif
+
+#endif
+
 end program mpi_new

--- a/compilers/tests/mpi_allgatherv_bug.F90
+++ b/compilers/tests/mpi_allgatherv_bug.F90
@@ -1,0 +1,38 @@
+! This program was found to fail on Fedora 32 with MPICH 3.3.2 when the modern mpi_f08 interface is in use.
+! The old approach with "use mpi" (after necessary changes such as adding ierror argument and
+! removing MPI_Allgatherv from the import statement) works correctly.
+
+program Allgatherv_bug
+
+   use mpi_f08, only: MPI_Init, MPI_Finalize, MPI_Comm_size, MPI_Allgatherv, &
+        &             MPI_COMM_WORLD, MPI_IN_PLACE, MPI_DATATYPE_NULL, MPI_INTEGER, MPI_INTEGER_KIND
+
+   implicit none
+
+   integer(kind=MPI_INTEGER_KIND) :: nproc, i, o
+   integer(kind=MPI_INTEGER_KIND), allocatable, dimension(:) :: se, cnt, off
+   integer :: l, u
+   integer(kind=MPI_INTEGER_KIND), parameter :: lu_bug = 7
+
+   call MPI_Init()
+   call MPI_Comm_size(MPI_COMM_WORLD, nproc)
+
+   allocate(cnt(0:nproc-1), off(0:nproc-1))
+   cnt(:) = 1
+   o = 0
+   do i = lbound(cnt, 1), ubound(cnt, 1)
+      off(i) = o
+      o = o + cnt(i)
+   end do
+   allocate(se(o))
+   se(:) = -1
+
+   l = lbound(se, 1)
+   u = ubound(se, 1)
+   call MPI_Allgatherv(MPI_IN_PLACE, 0_MPI_INTEGER_KIND, MPI_DATATYPE_NULL, se, cnt, off, MPI_INTEGER, MPI_COMM_WORLD)
+
+   if (l /= lbound(se, 1) .or. u /= ubound(se, 1)) call MPI_Abort(MPI_COMM_WORLD, lu_bug)
+
+   call MPI_Finalize()
+
+end program Allgatherv_bug

--- a/compilers/tests/mpi_f08.F90
+++ b/compilers/tests/mpi_f08.F90
@@ -1,4 +1,25 @@
 ! Test for avalability of modern MPI interface (Fortran 2008 with type checking)
+
 program F08
+
+#ifndef NO_MPIF08_AVAILABLE
+
    use mpi_f08
+
+#  ifdef FORBID_F08
+#    error The use of mpi_f08 was excluded by FORBID_F08
+#  endif
+
+#else
+
+#  ifdef FORBID_F08
+#    warning The use of mpi_f08 was excluded by FORBID_F08
+#  endif
+
+#  ifdef MPIF08
+#    error Both NO_MPIF08_AVAILABLE and MPIF08 are not allowed
+#  endif
+
+#endif
+
 end program F08

--- a/problems/wt4/initproblem.F90
+++ b/problems/wt4/initproblem.F90
@@ -230,7 +230,8 @@ contains
       use dataio_pub,  only: msg, die
       use func,        only: operator(.notequals.)
       use grid_cont,   only: grid_container
-      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Send, MPI_Recv
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,      only: MPI_Send, MPI_Recv
       use mpisetup,    only: proc, master, FIRST, LAST, err_mpi
 
       implicit none

--- a/python/piernik_setup.py
+++ b/python/piernik_setup.py
@@ -68,6 +68,7 @@ define ECHO_CC
 endef
 endif
 
+CPPFLAGS := $(CPPFLAGS) $(shell $(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi_allgatherv_bug.F90 && $(F90) $(LDFLAGS) -o mpi_allgatherv_bug mpi_allgatherv_bug.o $(LIBS) && ./mpi_allgatherv_bug 2> /dev/null || echo -DFORBID_F08)
 CPPFLAGS := $(CPPFLAGS) $(shell $(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi_f08.F90 2> /dev/null && echo -DMPIF08 || echo -DNO_MPIF08_AVAILABLE)
 CPPFLAGS := $(CPPFLAGS) $(shell $(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi.F90 2> /dev/null || echo -DNO_ALL_MPI_FUNCTIONS_AVAILABLE)
 
@@ -84,8 +85,8 @@ ifeq ("$(SILENT)","1")
 endif
 \t@$(ECHO) $(F90) $(LDFLAGS) -o $@ '*.o' $(LIBS)
 \t@$(F90) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
-\t@touch mpi_f08.o mpi.o a.out
-\t@$(RM) mpi_f08.o mpi.o a.out
+\t@touch mpi_f08.o mpi.o a.out mpi_allgatherv_bug mpi_allgatherv_bug.o
+\t@$(RM) mpi_f08.o mpi.o a.out mpi_allgatherv_bug mpi_allgatherv_bug.o
 \t@AO1=`mktemp _ao_XXXXXX`;\\
 \tAO2=`mktemp _ao_XXXXXX`;\\
 \t$(ECHO) $(OBJS) | tr ' ' '\\n' | sort > $$AO1;\\

--- a/python/piernik_setup.py
+++ b/python/piernik_setup.py
@@ -68,13 +68,14 @@ define ECHO_CC
 endef
 endif
 
-CPPFLAGS := $(CPPFLAGS) $(shell $(F90) $(F90FLAGS) ../compilers/tests/mpi_f08.F90 2> /dev/null && echo -DMPIF08 || echo -DNO_MPIF08_AVAILABLE)
+CPPFLAGS := $(CPPFLAGS) $(shell $(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi_f08.F90 2> /dev/null && echo -DMPIF08 || echo -DNO_MPIF08_AVAILABLE)
+CPPFLAGS := $(CPPFLAGS) $(shell $(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi.F90 2> /dev/null || echo -DNO_ALL_MPI_FUNCTIONS_AVAILABLE)
 
 all: env.dat print_setup $(PROG)
 
 check_mpi:
-\t@$(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi_f08.F90 2> /dev/null  || (\
-$(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi.F90 2> /dev/null || echo -e "\033[91mWarning: current MPI fortran compiler may not be capable of 'mpi_f90' or sufficiently modern 'mpi' interface\033[0m" )
+\t@$(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi_f08.F90
+\t@$(F90) $(CPPFLAGS) $(F90FLAGS) ../compilers/tests/mpi.F90
 
 $(PROG): $(OBJS) check_mpi
 ifeq ("$(SILENT)","1")

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -1872,7 +1872,8 @@ contains
          use constants,    only: I_ONE, INVALID
          use dataio_pub,   only: msg, printinfo
          use memory_usage, only: system_mem_usage
-         use MPIF,         only: MPI_INTEGER, MPI_COMM_WORLD, MPI_Gather
+         use MPIF,         only: MPI_INTEGER, MPI_COMM_WORLD
+         use MPIFUN,       only: MPI_Gather
          use mpisetup,     only: master, FIRST, LAST, err_mpi
 
          implicit none

--- a/src/IO/hdf5/cg_particles_io.F90
+++ b/src/IO/hdf5/cg_particles_io.F90
@@ -144,7 +144,8 @@ contains
       use dataio_pub,     only: nproc_io, can_i_write, die
       use domain,         only: is_multicg
       use hdf5,           only: HID_T
-      use MPIF,           only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Recv, MPI_Send
+      use MPIF,           only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,         only: MPI_Recv, MPI_Send
       use mpisetup,       only: master, FIRST, LAST, proc, err_mpi
       use particle_types, only: particle
 
@@ -229,7 +230,8 @@ contains
       use dataio_pub,     only: nproc_io, can_i_write, die
       use domain,         only: is_multicg
       use hdf5,           only: HID_T
-      use MPIF,           only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Recv, MPI_Send
+      use MPIF,           only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,         only: MPI_Recv, MPI_Send
       use mpisetup,       only: master, FIRST, LAST, proc, err_mpi
       use particle_types, only: particle
 

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -845,8 +845,8 @@ contains
          &                    h5open_f, h5close_f, h5fopen_f, h5fclose_f, h5gcreate_f, h5gopen_f, h5gclose_f, h5pclose_f, &
          &                    h5zfilter_avail_f
       use helpers_hdf5, only: create_attribute!, create_corefile
-      use MPIF,         only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_REAL8, MPI_COMM_WORLD, &
-           &                  MPI_Allgather, MPI_Recv, MPI_Send
+      use MPIF,         only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_REAL8, MPI_COMM_WORLD
+      use MPIFUN,       only: MPI_Allgather, MPI_Recv, MPI_Send
       use mpisetup,     only: FIRST, LAST, master, err_mpi, piernik_MPI_Bcast
 #ifdef NBODY_1FILE
       use constants,      only: I_FIVE

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -628,7 +628,8 @@ contains
       use global,      only: nstep
       use grid_cont,   only: grid_container
       use hdf5,        only: HID_T, HSIZE_T, H5T_NATIVE_REAL, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
-      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Recv, MPI_Send
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,      only: MPI_Recv, MPI_Send
       use mpisetup,    only: master, FIRST, proc, err_mpi, tag_ub
       use ppp,         only: ppp_main
 #ifdef NBODY_1FILE

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -208,7 +208,8 @@ contains
       use dataio_pub,       only: die, nproc_io, can_i_write
       use grid_cont,        only: grid_container
       use hdf5,             only: HID_T, HSIZE_T, H5T_NATIVE_DOUBLE, h5sclose_f, h5dwrite_f, h5sselect_none_f, h5screate_simple_f
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Recv, MPI_Send
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,           only: MPI_Recv, MPI_Send
       use mpisetup,         only: master, FIRST, proc, err_mpi, tag_ub
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main

--- a/src/base/cmp_1D_mpi.F90
+++ b/src/base/cmp_1D_mpi.F90
@@ -62,7 +62,8 @@ contains
       use constants,  only: I_ONE
       use dataio_pub, only: die
       use func,       only: operator(.notequals.)
-      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Send, MPI_Recv
+      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,     only: MPI_Send, MPI_Recv
       use mpisetup,   only: slave, LAST, proc, err_mpi
 
       implicit none
@@ -86,7 +87,8 @@ contains
 
       use constants,  only: I_ONE
       use dataio_pub, only: die
-      use MPIF,       only: MPI_INTEGER, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Send, MPI_Recv
+      use MPIF,       only: MPI_INTEGER, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,     only: MPI_Send, MPI_Recv
       use mpisetup,   only: slave, LAST, proc, err_mpi
 
       implicit none
@@ -110,7 +112,8 @@ contains
 
       use constants,  only: I_ONE
       use dataio_pub, only: die
-      use MPIF,       only: MPI_CHARACTER, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Send, MPI_Recv
+      use MPIF,       only: MPI_CHARACTER, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,     only: MPI_Send, MPI_Recv
       use mpisetup,   only: slave, LAST, proc, err_mpi
 
       implicit none

--- a/src/base/defines.c
+++ b/src/base/defines.c
@@ -94,3 +94,23 @@
 #ifdef USER_RULES
 #  include "user_rules.h"
 #endif /* USER_RULES */
+
+/*
+  MPI + Fortran sanity
+*/
+
+#ifdef MPIF08
+
+#  ifdef NO_MPIF08_AVAILABLE
+#    error Both NO_MPIF08_AVAILABLE and MPIF08 are not allowed
+#  endif
+
+#  ifdef NO_ALL_MPI_FUNCTIONS_AVAILABLE
+#    error NO_ALL_MPI_FUNCTIONS_AVAILABLE contradicts the use of mpi_f08 interface
+#  endif
+
+#  ifdef FORBID_F08
+#    error FORBID_F08 got ignored somehow
+#  endif
+
+#endif

--- a/src/base/defines.c
+++ b/src/base/defines.c
@@ -103,14 +103,14 @@
 
 #  ifdef NO_MPIF08_AVAILABLE
 #    error Both NO_MPIF08_AVAILABLE and MPIF08 are not allowed
-#  endif
+#  endif /* NO_MPIF08_AVAILABLE */
 
 #  ifdef NO_ALL_MPI_FUNCTIONS_AVAILABLE
 #    error NO_ALL_MPI_FUNCTIONS_AVAILABLE contradicts the use of mpi_f08 interface
-#  endif
+#  endif /* NO_ALL_MPI_FUNCTIONS_AVAILABLE */
 
 #  ifdef FORBID_F08
 #    error FORBID_F08 got ignored somehow
-#  endif
+#  endif /* FORBID_F08 */
 
-#endif
+#endif /* MPIF08 */

--- a/src/base/mass_defect.F90
+++ b/src/base/mass_defect.F90
@@ -62,7 +62,8 @@ contains
    subroutine update_magic_mass
 
       use fluidindex,  only: flind
-      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, MPI_Reduce
+      use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD
+      use MPIFUN,      only: MPI_Reduce
       use mpisetup,    only: err_mpi, FIRST, master
 
       implicit none

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -143,8 +143,9 @@ contains
       use constants,     only: cwdlen, I_ONE
       use MPIF,          only: MPI_COMM_WORLD, MPI_CHARACTER, MPI_INTEGER, MPI_COMM_NULL, &
            &                   MPI_SUM, MPI_MIN, MPI_MAX, MPI_LOR, MPI_LAND, MPI_TAG_UB, &
-           &                   MPI_Wtime, MPI_Gather, MPI_Init, &
-           &                   MPI_Comm_get_parent, MPI_Comm_rank, MPI_Comm_size, MPI_Comm_get_attr
+           &                   MPI_Wtime, MPI_Init, MPI_Comm_get_parent, &
+           &                   MPI_Comm_rank, MPI_Comm_size
+      use MPIFUN,        only: MPI_Gather, MPI_Comm_get_attr
       use dataio_pub,    only: die, printinfo, msg, ansi_white, ansi_black, tmp_log_file
       use dataio_pub,    only: par_file, lun
       use signalhandler, only: SIGINT, register_sighandler
@@ -387,7 +388,8 @@ contains
    subroutine MPI_Bcast_single_logical(lvar)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_LOGICAL, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,      only: MPI_LOGICAL, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Bcast
 
       implicit none
 
@@ -404,7 +406,8 @@ contains
 !<
    subroutine MPI_Bcast_vec_logical(lvar)
 
-      use MPIF, only: MPI_LOGICAL, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_LOGICAL, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -421,7 +424,8 @@ contains
 !<
    subroutine MPI_Bcast_single_string(cvar, clen)
 
-      use MPIF, only: MPI_CHARACTER, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_CHARACTER, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -439,7 +443,8 @@ contains
 !<
    subroutine MPI_Bcast_vec_string(cvar, clen)
 
-      use MPIF, only: MPI_CHARACTER, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_CHARACTER, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -458,7 +463,8 @@ contains
    subroutine MPI_Bcast_single_int4(ivar4)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_INTEGER, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,      only: MPI_INTEGER, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Bcast
 
       implicit none
 
@@ -476,7 +482,8 @@ contains
    subroutine MPI_Bcast_single_int8(ivar8)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_INTEGER8, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,      only: MPI_INTEGER8, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Bcast
 
       implicit none
 
@@ -494,7 +501,8 @@ contains
    subroutine MPI_Bcast_single_real4(rvar4)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_REAL, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,      only: MPI_REAL, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Bcast
 
       implicit none
 
@@ -512,7 +520,8 @@ contains
    subroutine MPI_Bcast_single_real8(rvar8)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Bcast
 
       implicit none
 
@@ -529,7 +538,8 @@ contains
 !<
    subroutine MPI_Bcast_vec_real4(rvar4)
 
-      use MPIF, only: MPI_REAL, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_REAL, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -546,7 +556,8 @@ contains
 !<
    subroutine MPI_Bcast_vec_real8(rvar8)
 
-      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -563,7 +574,8 @@ contains
 !<
    subroutine MPI_Bcast_vec_int4(ivar4)
 
-      use MPIF, only: MPI_INTEGER, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_INTEGER, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -580,7 +592,8 @@ contains
 !<
    subroutine MPI_Bcast_vec_int8(ivar8)
 
-      use MPIF, only: MPI_INTEGER8, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_INTEGER8, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -597,7 +610,8 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_real4(rvar4)
 
-      use MPIF, only: MPI_REAL, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_REAL, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -614,7 +628,8 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_real8(rvar8)
 
-      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -631,7 +646,8 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_int4(ivar4)
 
-      use MPIF, only: MPI_INTEGER, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_INTEGER, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -648,7 +664,8 @@ contains
 !<
    subroutine MPI_Bcast_arr2d_int8(ivar8)
 
-      use MPIF, only: MPI_INTEGER8, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_INTEGER8, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -665,7 +682,8 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_real4(rvar4)
 
-      use MPIF, only: MPI_REAL, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_REAL, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -682,7 +700,8 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_real8(rvar8)
 
-      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -699,7 +718,8 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_int4(ivar4)
 
-      use MPIF, only: MPI_INTEGER, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_INTEGER, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -716,7 +736,8 @@ contains
 !<
    subroutine MPI_Bcast_arr3d_int8(ivar8)
 
-      use MPIF, only: MPI_INTEGER8, MPI_COMM_WORLD, MPI_Bcast
+      use MPIF,   only: MPI_INTEGER8, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Bcast
 
       implicit none
 
@@ -733,7 +754,8 @@ contains
    subroutine MPI_Allreduce_single_logical(lvar, reduction)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_LOGICAL, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,      only: MPI_LOGICAL, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Allreduce
 
       implicit none
 
@@ -751,7 +773,8 @@ contains
    subroutine MPI_Allreduce_single_int4(ivar4, reduction)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_INTEGER, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,      only: MPI_INTEGER, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Allreduce
 
       implicit none
 
@@ -769,7 +792,8 @@ contains
    subroutine MPI_Allreduce_single_int8(ivar8, reduction)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_INTEGER8, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,      only: MPI_INTEGER8, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Allreduce
 
       implicit none
 
@@ -786,7 +810,8 @@ contains
 !<
    subroutine MPI_Allreduce_vec_int4(ivar4, reduction)
 
-      use MPIF, only: MPI_INTEGER, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,   only: MPI_INTEGER, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Allreduce
 
       implicit none
 
@@ -803,7 +828,8 @@ contains
 !<
    subroutine MPI_Allreduce_vec_int8(ivar8, reduction)
 
-      use MPIF, only: MPI_INTEGER8, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,   only: MPI_INTEGER8, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Allreduce
 
       implicit none
 
@@ -821,7 +847,8 @@ contains
    subroutine MPI_Allreduce_single_real4(rvar4, reduction)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_REAL, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,      only: MPI_REAL, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Allreduce
 
       implicit none
 
@@ -839,7 +866,8 @@ contains
    subroutine MPI_Allreduce_single_real8(rvar8, reduction)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Allreduce
 
       implicit none
 
@@ -856,7 +884,8 @@ contains
 !<
    subroutine MPI_Allreduce_vec_real4(rvar4, reduction)
 
-      use MPIF,      only: MPI_REAL, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,   only: MPI_REAL, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Allreduce
 
       implicit none
 
@@ -873,7 +902,8 @@ contains
 !<
    subroutine MPI_Allreduce_vec_real8(rvar8, reduction)
 
-      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,   only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Allreduce
 
       implicit none
 
@@ -890,7 +920,8 @@ contains
 !<
    subroutine MPI_Allreduce_arr3d_real8(rvar8, reduction)
 
-      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,   only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Allreduce
 
       implicit none
 
@@ -907,7 +938,8 @@ contains
 !<
    subroutine MPI_Allreduce_arr2d_real8(rvar8, reduction)
 
-      use MPIF, only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,   only: MPI_DOUBLE_PRECISION, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Allreduce
 
       implicit none
 
@@ -924,7 +956,8 @@ contains
 !<
    subroutine MPI_Allreduce_arr2d_real4(rvar4, reduction)
 
-      use MPIF, only: MPI_REAL, MPI_IN_PLACE, MPI_COMM_WORLD, MPI_Allreduce
+      use MPIF,   only: MPI_REAL, MPI_IN_PLACE, MPI_COMM_WORLD
+      use MPIFUN, only: MPI_Allreduce
 
       implicit none
 
@@ -941,7 +974,8 @@ contains
    subroutine report_to_master(ivar4, only_master)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_INTEGER, MPI_Send
+      use MPIF,      only: MPI_INTEGER
+      use MPIFUN,    only: MPI_Send
 
       implicit none
 
@@ -967,7 +1001,8 @@ contains
    subroutine report_string_to_master(str, only_master)
 
       use constants, only: I_ONE
-      use MPIF,      only: MPI_INTEGER, MPI_CHARACTER, MPI_Send
+      use MPIF,      only: MPI_INTEGER, MPI_CHARACTER
+      use MPIFUN,    only: MPI_Send
 
       implicit none
       character(len=*),  intent(in) :: str

--- a/src/base/piernik.h
+++ b/src/base/piernik.h
@@ -51,6 +51,14 @@
 
 #ifdef MPIF08
 #  define MPIF mpi_f08
-#else
+#  define MPIFUN mpi_f08
+#else /* !MPIF08 */
 #  define MPIF mpi
-#endif
+#  ifdef NO_ALL_MPI_FUNCTIONS_AVAILABLE
+/* Ignore the rest of list to avoid import errors for MPICH and the old Fortran interface.
+   One may also import something harmless like MPI_OP_NULL at a cost of some more warnings. */
+#    define MPIFUN mpi !
+#  else /* !NO_ALL_MPI_FUNCTIONS_AVAILABLE */
+#    define MPIFUN mpi
+#  endif /* !NO_ALL_MPI_FUNCTIONS_AVAILABLE */
+#endif /* !MPIF08 */

--- a/src/base/ppp_eventlist.F90
+++ b/src/base/ppp_eventlist.F90
@@ -250,8 +250,8 @@ contains
 
       use constants,    only: I_ZERO, I_ONE
       use dataio_pub,   only: printinfo, msg
-      use MPIF,         only: MPI_STATUS_IGNORE, MPI_STATUSES_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, &
-           &                  MPI_Isend, MPI_Recv, MPI_Waitall
+      use MPIF,         only: MPI_STATUS_IGNORE, MPI_STATUSES_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,       only: MPI_Isend, MPI_Recv, MPI_Waitall
       use mpisetup,     only: proc, master, slave, err_mpi, FIRST, LAST, req, inflate_req
 
       implicit none

--- a/src/base/ppp_mpi.F90
+++ b/src/base/ppp_mpi.F90
@@ -51,7 +51,8 @@ contains
 
       use constants, only: PPP_MPI
       use mpisetup,  only: err_mpi, req, req2
-      use MPIF,      only: MPI_STATUSES_IGNORE, MPI_Waitall
+      use MPIF,      only: MPI_STATUSES_IGNORE
+      use MPIFUN,    only: MPI_Waitall
       use ppp,       only: ppp_main
 
       implicit none

--- a/src/base/timer.F90
+++ b/src/base/timer.F90
@@ -296,7 +296,8 @@ contains
 
       use constants,  only: I_ONE, half
       use dataio_pub, only: msg, printinfo
-      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, MPI_Reduce
+      use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD
+      use MPIFUN,     only: MPI_Reduce
       use mpisetup,   only: err_mpi, master, FIRST
 
       implicit none

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -404,7 +404,8 @@ contains
       use grid_cont,      only: grid_container
       use grid_helpers,   only: f2c
       use mergebox,       only: wmap  ! this is the last place that uses this module
-      use MPIF,           only: MPI_INTEGER, MPI_INTEGER8, MPI_COMM_WORLD, MPI_Alltoall, MPI_Alltoallv
+      use MPIF,           only: MPI_INTEGER, MPI_INTEGER8, MPI_COMM_WORLD
+      use MPIFUN,         only: MPI_Alltoall, MPI_Alltoallv
       use mpisetup,       only: FIRST, LAST, err_mpi, proc
       use overlap,        only: is_overlap
       use tag_pool,       only: t_pool
@@ -901,7 +902,8 @@ contains
       use grid_cont,        only: grid_container
       use grid_helpers,     only: f2c, c2f
       use mpisetup,         only: err_mpi, req, inflate_req, master
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main
       use ppp_mpi,          only: piernik_Waitall
@@ -1119,7 +1121,8 @@ contains
       use domain,           only: dom
       use grid_cont,        only: grid_container
       use grid_helpers,     only: c2f
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend
       use mpisetup,         only: err_mpi, req, inflate_req, master
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main
@@ -1431,7 +1434,8 @@ contains
       use cg_list,          only: cg_list_element
       use grid_cont,        only: grid_container
       use mpisetup,         only: err_mpi, req, inflate_req, master
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend
       use named_array,      only: p3, p4
       use named_array_list, only: qna, wna
       use ppp_mpi,          only: piernik_Waitall

--- a/src/grid/cg_list_balance.F90
+++ b/src/grid/cg_list_balance.F90
@@ -221,7 +221,8 @@ contains
 
       use constants,       only: pSUM, I_ONE
       use dataio_pub,      only: die
-      use MPIF,            only: MPI_INTEGER, MPI_COMM_WORLD, MPI_Gather
+      use MPIF,            only: MPI_INTEGER, MPI_COMM_WORLD
+      use MPIFUN,          only:  MPI_Gather
       use mpisetup,        only: piernik_MPI_Allreduce, master, FIRST, LAST, err_mpi, nproc
       use sort_piece_list, only: grid_piece_list
 
@@ -304,8 +305,8 @@ contains
    subroutine patches_to_list(this, gp, ls)
 
       use constants,       only: ndims, INVALID, I_ONE
-      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD, &
-           &                     MPI_Isend, MPI_Send, MPI_Recv, MPI_Wait
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_Wait
+      use MPIFUN,          only: MPI_Isend, MPI_Send, MPI_Recv
       use mpisetup,        only: master, slave, FIRST, LAST, req, err_mpi, inflate_req
       use sort_piece_list, only: grid_piece_list
 
@@ -369,8 +370,8 @@ contains
    subroutine distribute_patches(this, gp, from)
 
       use constants,       only: ndims, I_ONE
-      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD, &
-           &                     MPI_Send, MPI_Recv
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,          only: MPI_Send, MPI_Recv
       use mpisetup,        only: master, FIRST, LAST, err_mpi
       use sort_piece_list, only: grid_piece_list
 

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -298,7 +298,8 @@ contains
       use constants,        only: xdim, ydim, zdim, cor_dim, I_ONE, LO, HI
       use dataio_pub,       only: die
       use merge_segments,   only: IN, OUT
-      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend
+      use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend
       use mpisetup,         only: FIRST, LAST, proc, err_mpi, req, req2, inflate_req, nproc
       use named_array_list, only: wna
       use ppp_mpi,          only: piernik_Waitall
@@ -458,7 +459,8 @@ contains
       use grid_cont,        only: grid_container
       use grid_cont_bnd,    only: segment
       use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_ORDER_FORTRAN, &
-           &                      MPI_Irecv, MPI_Isend, MPI_Type_create_subarray, MPI_Type_commit, MPI_Type_free
+           &                      MPI_Type_create_subarray, MPI_Type_commit, MPI_Type_free
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend
       use mpisetup,         only: err_mpi, req, inflate_req
       use named_array_list, only: wna
       use ppp_mpi,          only: piernik_Waitall

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -104,7 +104,7 @@ contains
       use types,       only: value
 #ifdef MPIF08
       use MPIF,      only: MPI_Op
-#endif
+#endif /* MPIF08 */
 
       implicit none
 

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -97,8 +97,8 @@ contains
       use domain,      only: dom
       use grid_cont,   only: grid_container
       use MPIF,        only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_2DOUBLE_PRECISION, &
-           &                 MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_MINLOC, MPI_MAXLOC, MPI_IN_PLACE, &
-           &                 MPI_Allreduce, MPI_Send, MPI_Recv
+           &                 MPI_STATUS_IGNORE, MPI_COMM_WORLD, MPI_MINLOC, MPI_MAXLOC, MPI_IN_PLACE
+      use MPIFUN,      only: MPI_Allreduce, MPI_Send, MPI_Recv
       use mpisetup,    only: err_mpi, master, proc, FIRST
 !      use named_array_list, only: qna
       use types,       only: value

--- a/src/grid/cg_list_rebalance.F90
+++ b/src/grid/cg_list_rebalance.F90
@@ -62,8 +62,8 @@ contains
       use refinement,      only: oop_thr
       use sort_piece_list, only: grid_piece_list
 #ifdef DEBUG
-      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD, &
-           &                     MPI_Gather, MPI_Recv, MPI_Send
+      use MPIF,            only: MPI_INTEGER, MPI_INTEGER8, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,          only: MPI_Gather, MPI_Recv, MPI_Send
       use mpisetup,        only: err_mpi
 #endif /* DEBUG */
 
@@ -195,7 +195,8 @@ contains
       use grid_cont,          only: grid_container
       use grid_container_ext, only: cg_extptrs
       use list_of_cg_lists,   only: all_lists
-      use MPIF,               only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Isend, MPI_Irecv
+      use MPIF,               only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,             only: MPI_Isend, MPI_Irecv
       use mpisetup,           only: master, piernik_MPI_Bcast, piernik_MPI_Allreduce, proc, err_mpi, req, inflate_req, tag_ub
       use named_array_list,   only: qna, wna
       use ppp,                only: ppp_main

--- a/src/grid/dot.F90
+++ b/src/grid/dot.F90
@@ -107,7 +107,8 @@ contains
       use cg_list,    only: cg_list_element
       use constants,  only: I_ZERO, I_ONE, ndims, LO, HI
       use dataio_pub, only: die
-      use MPIF,       only: MPI_IN_PLACE, MPI_DATATYPE_NULL, MPI_INTEGER, MPI_COMM_WORLD, MPI_Allgather, MPI_Allgatherv
+      use MPIF,       only: MPI_IN_PLACE, MPI_DATATYPE_NULL, MPI_INTEGER, MPI_COMM_WORLD
+      use MPIFUN,     only: MPI_Allgather, MPI_Allgatherv
       use mpisetup,   only: FIRST, LAST, proc, err_mpi
       use ordering,   only: SFC_order
 
@@ -270,7 +271,8 @@ contains
    subroutine check_blocky(this)
 
       use constants,  only: ndims, LO, HI, pLAND, I_ONE
-      use MPIF,       only: MPI_INTEGER, MPI_REQUEST_NULL, MPI_COMM_WORLD, MPI_Irecv, MPI_Isend
+      use MPIF,       only: MPI_INTEGER, MPI_REQUEST_NULL, MPI_COMM_WORLD
+      use MPIFUN,     only: MPI_Irecv, MPI_Isend
       use mpisetup,   only: proc, req, err_mpi, LAST, inflate_req, slave, piernik_MPI_Allreduce
       use ppp_mpi,    only: piernik_Waitall
 
@@ -323,7 +325,8 @@ contains
 
       use constants,  only: LO, HI, ndims, I_ONE
       use dataio_pub, only: die
-      use MPIF,       only: MPI_INTEGER8, MPI_COMM_WORLD, MPI_Allgather
+      use MPIF,       only: MPI_INTEGER8, MPI_COMM_WORLD
+      use MPIFUN,     only: MPI_Allgather
       use mpisetup,   only: FIRST, LAST, proc, err_mpi
       use ordering,   only: SFC_order
 

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -244,8 +244,8 @@ contains
       use constants,          only: xdim, zdim, LO, HI, I_ONE, I_ZERO
       use dataio_pub,         only: die, warn
       use domain,             only: dom
-      use MPIF,               only: MPI_INTEGER, MPI_STATUS_IGNORE, MPI_COMM_WORLD, &
-           &                        MPI_Alltoall, MPI_Isend, MPI_Recv
+      use MPIF,               only: MPI_INTEGER, MPI_STATUS_IGNORE, MPI_COMM_WORLD
+      use MPIFUN,             only: MPI_Alltoall, MPI_Isend, MPI_Recv
       use mpisetup,           only: FIRST, LAST, err_mpi, proc, req, inflate_req
       use ppp_mpi,            only: piernik_Waitall
 

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -357,7 +357,8 @@ contains
 
       use constants,           only: I_ONE
       use dataio_pub,          only: msg, printinfo
-      use MPIF,                only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Gather
+      use MPIF,                only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,              only: MPI_Gather
       use mpisetup,            only: master, nproc, FIRST, LAST, err_mpi
       use multigridvars,       only: tot_ts
 #ifdef SELF_GRAV

--- a/src/particles/particle_utils.F90
+++ b/src/particles/particle_utils.F90
@@ -390,7 +390,8 @@ contains
       use dataio_pub,    only: die
       use domain,        only: dom, is_refined
       use grid_cont,     only: grid_container
-      use MPIF,          only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_COMM_WORLD, MPI_Alltoall, MPI_Alltoallv
+      use MPIF,          only: MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_COMM_WORLD
+      use MPIFUN,        only: MPI_Alltoall, MPI_Alltoallv
       use mpisetup,      only: proc, err_mpi, FIRST, LAST
       use ppp,           only: ppp_main
       use particle_func, only: particle_in_area

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -66,7 +66,8 @@ contains
       use constants, only: LO, HI, I_ONE
       use cg_leaves, only: leaves
       use cg_list,   only: cg_list_element
-      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Irecv
+      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,    only: MPI_Irecv
       use mpisetup,  only: err_mpi, req, inflate_req
 
       implicit none
@@ -176,7 +177,8 @@ contains
       use domain,       only: dom
       use grid_cont,    only: grid_container
       use grid_helpers, only: f2c_o
-      use MPIF,         only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_Isend
+      use MPIF,         only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIFUN,       only: MPI_Isend
       use mpisetup,     only: err_mpi, req, inflate_req
       use ppp,          only: ppp_main
 
@@ -301,7 +303,8 @@ contains
       use dataio_pub,       only: die
       use global,           only: integration_order, use_fargo, which_solver
       use grid_cont,        only: grid_container
-      use MPIF,             only: MPI_STATUS_IGNORE, MPI_Waitany
+      use MPIF,             only: MPI_STATUS_IGNORE
+      use MPIFUN,           only: MPI_Waitany
       use mpisetup,         only: err_mpi, req
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main


### PR DESCRIPTION
* Implemented `FORBID_F08` symbol to enforce older Fortran interface. Can be used dureing setup call (also via `.setuprc`) or in compiler configuration.
* Implemented compatibility with MPI implementations that does bot provide functions such as `MPI_Send` for import in the old fortran interface.