### PR TITLE
Preventing MPI data races

### DIFF
--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -34,6 +34,7 @@
 module global
 
    use constants, only: cbuff_len, xdim, zdim
+   use mpisetup,  only: extra_barriers
 
    implicit none
 
@@ -106,11 +107,14 @@ module global
    integer(kind=4)               :: ord_fluid_prolong !< prolongation order for u
    logical                       :: do_external_corners  !< when .true. then perform boundary exchanges inside external guardcells
    character(len=cbuff_len)      :: solver_str        !< allow to switch between RIEMANN and RTVD without recompilation
-   logical                       :: prefer_merged_MPI !< prefer internal_boundaries_MPI_merged over internal_boundaries_MPI_1by1
 
    namelist /NUMERICAL_SETUP/ cfl, cflcontrol, disallow_negatives, disallow_CRnegatives, cfl_max, use_smalld, use_smallei, smalld, smallei, smallc, smallp, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, &
-        &                     repeat_step, limiter, limiter_b, relax_time, integration_order, cfr_smooth, skip_sweep, geometry25D, sweeps_mgu, print_divB, prefer_merged_MPI, &
+        &                     repeat_step, limiter, limiter_b, relax_time, integration_order, cfr_smooth, skip_sweep, geometry25D, sweeps_mgu, print_divB, &
         &                     use_fargo, divB_0, glm_alpha, use_eglm, cfl_glm, ch_grid, interpol_str, w_epsilon, psi_bnd_str, ord_mag_prolong, ord_fluid_prolong, do_external_corners, solver_str
+
+   logical                       :: prefer_merged_MPI !< prefer internal_boundaries_MPI_merged over internal_boundaries_MPI_1by1
+
+   namelist /PARALLEL_SETUP/ extra_barriers, prefer_merged_MPI
 
 contains
 
@@ -155,9 +159,18 @@ contains
 !!   <tr><td>ord_mag_prolong  </td><td>2      </td><td>integer                              </td><td>\copydoc global::ord_mag_prolong  </td></tr>
 !!   <tr><td>ord_fluid_prolong </td><td>0     </td><td>integer                              </td><td>\copydoc global::ord_fluid_prolong </td></tr>
 !!   <tr><td>do_external_corners </td><td>.false.</td><td>logical                           </td><td>\copydoc global::do_external_corners </td></tr>
-!!   <tr><td>prefer_merged_MPI </td><td>.true.</td><td>logical                              </td><td>\copydoc global::prefer_merged_MPI </td></tr>
 !! </table>
 !! \n \n
+!! \n \n
+!! @b NUMERICAL_SETUP
+!! \n \n
+!! <table border="+1">
+!!   <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
+!!   <tr><td>prefer_merged_MPI </td><td>.true.  </td><td>logical </td><td>\copydoc global::prefer_merged_MPI </td></tr>
+!!   <tr><td>extra_barriers    </td><td>.false. </td><td>logical </td><td>\copydoc mpisetup::xtra_barriers   </td></tr>
+!! </table>
+!! \n \n
+
 !<
    subroutine init_global
 
@@ -236,10 +249,13 @@ contains
       ord_fluid_prolong = O_INJ        !< O_INJ and O_LIN ensure monotoniciy and nonnegative density and energy
       do_external_corners =.false.
       solver_str = ""
-      prefer_merged_MPI = .false.  ! non-merged MPI in internal_boundaries are implemented without buffers, which is faster
+
+      prefer_merged_MPI = .false.  ! non-merged MPI in internal_boundaries are implemented without buffers, which often is faster
 
       if (master) then
+
          if (.not.nh%initialized) call nh%init()
+
          open(newunit=nh%lun, file=nh%tmp1, status="unknown")
          write(nh%lun,nml=NUMERICAL_SETUP)
          close(nh%lun)
@@ -252,6 +268,21 @@ contains
          call nh%namelist_errh(nh%ierrh, "NUMERICAL_SETUP", .true.)
          open(newunit=nh%lun, file=nh%tmp2, status="unknown")
          write(nh%lun,nml=NUMERICAL_SETUP)
+         close(nh%lun)
+         call nh%compare_namelist()
+
+         open(newunit=nh%lun, file=nh%tmp1, status="unknown")
+         write(nh%lun,nml=PARALLEL_SETUP)
+         close(nh%lun)
+         open(newunit=nh%lun, file=nh%par_file)
+         nh%errstr=""
+         read(unit=nh%lun, nml=PARALLEL_SETUP, iostat=nh%ierrh, iomsg=nh%errstr)
+         close(nh%lun)
+         call nh%namelist_errh(nh%ierrh, "PARALLEL_SETUP")
+         read(nh%cmdl_nml,nml=PARALLEL_SETUP, iostat=nh%ierrh)
+         call nh%namelist_errh(nh%ierrh, "PARALLEL_SETUP", .true.)
+         open(newunit=nh%lun, file=nh%tmp2, status="unknown")
+         write(nh%lun,nml=PARALLEL_SETUP)
          close(nh%lun)
          call nh%compare_namelist()
 
@@ -313,6 +344,7 @@ contains
          lbuff(14)  = disallow_negatives
          lbuff(15)  = disallow_CRnegatives
          lbuff(16)  = prefer_merged_MPI
+         lbuff(17)  = extra_barriers
 
       endif
 
@@ -336,6 +368,7 @@ contains
          disallow_negatives   = lbuff(14)
          disallow_CRnegatives = lbuff(15)
          prefer_merged_MPI    = lbuff(16)
+         extra_barriers       = lbuff(17)
 
          smalld               = rbuff( 1)
          smallc               = rbuff( 2)

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -162,12 +162,12 @@ contains
 !! </table>
 !! \n \n
 !! \n \n
-!! @b NUMERICAL_SETUP
+!! @b PARALLEL_SETUP
 !! \n \n
 !! <table border="+1">
 !!   <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
 !!   <tr><td>prefer_merged_MPI </td><td>.true.  </td><td>logical </td><td>\copydoc global::prefer_merged_MPI </td></tr>
-!!   <tr><td>extra_barriers    </td><td>.false. </td><td>logical </td><td>\copydoc mpisetup::xtra_barriers   </td></tr>
+!!   <tr><td>extra_barriers    </td><td>.false. </td><td>logical </td><td>\copydoc mpisetup::extra_barriers  </td></tr>
 !! </table>
 !! \n \n
 

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -46,7 +46,7 @@ module mpisetup
         &    buffer_dim, cbuff, ibuff, lbuff, rbuff, req, req2, err_mpi, tag_ub, &
         &    master, slave, nproc, proc, FIRST, LAST, have_mpi, is_spawned, &
         &    piernik_MPI_Allreduce, piernik_MPI_Barrier, piernik_MPI_Bcast, report_to_master, &
-        &    report_string_to_master
+        &    report_string_to_master, extra_barriers
 
    integer(kind=4), protected :: nproc          !< number of processes
    integer(kind=4), protected :: proc           !< rank of my process
@@ -62,6 +62,8 @@ module mpisetup
    logical, protected :: slave       !< .True. if proc != FIRST
    logical, protected :: have_mpi    !< .True. when run on more than one processor
    logical, protected :: is_spawned  !< .True. if Piernik was run via MPI_Spawn
+
+   logical, save :: extra_barriers = .false.  !< when changed to .true. additional MPI_Barriers will be called.
 
 #ifdef MPIF08
    type(MPI_Request), allocatable, dimension(:), target :: req        !< request array for MPI_Waitall

--- a/src/base/ppp_eventlist.F90
+++ b/src/base/ppp_eventlist.F90
@@ -252,7 +252,7 @@ contains
       use dataio_pub,   only: printinfo, msg
       use MPIF,         only: MPI_STATUS_IGNORE, MPI_STATUSES_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
       use MPIFUN,       only: MPI_Isend, MPI_Recv, MPI_Waitall
-      use mpisetup,     only: proc, master, slave, err_mpi, FIRST, LAST, req, inflate_req
+      use mpisetup,     only: proc, master, slave, err_mpi, FIRST, LAST, req, inflate_req, piernik_MPI_Barrier, extra_barriers
 
       implicit none
 
@@ -330,6 +330,8 @@ contains
          call MPI_Waitall(t, req(:t), MPI_STATUSES_IGNORE, err_mpi)
          deallocate(buflabel, buftime)
       endif
+
+      if (extra_barriers) call piernik_MPI_Barrier
 
       call this%cleanup
 

--- a/src/base/ppp_mpi.F90
+++ b/src/base/ppp_mpi.F90
@@ -50,7 +50,7 @@ contains
    subroutine piernik_Waitall(nr, ppp_label, x_mask, use_req2)
 
       use constants, only: PPP_MPI
-      use mpisetup,  only: err_mpi, req, req2
+      use mpisetup,  only: err_mpi, req, req2, piernik_MPI_Barrier, extra_barriers
       use MPIF,      only: MPI_STATUSES_IGNORE
       use MPIFUN,    only: MPI_Waitall
       use ppp,       only: ppp_main
@@ -82,6 +82,8 @@ contains
 
          call ppp_main%stop(mpiw // ppp_label, mask)
       endif
+
+      if (extra_barriers) call piernik_MPI_Barrier
 
    end subroutine piernik_Waitall
 

--- a/src/grid/cg_level_connected.F90
+++ b/src/grid/cg_level_connected.F90
@@ -903,10 +903,13 @@ contains
       use grid_helpers,     only: f2c, c2f
       use mpisetup,         only: err_mpi, req, inflate_req, master
       use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
-      use MPIFUN,           only: MPI_Irecv, MPI_Isend
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend, MPI_Comm_dup, MPI_Comm_free
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main
       use ppp_mpi,          only: piernik_Waitall
+#ifdef MPIF08
+      use MPIF,             only: MPI_Comm
+#endif /* MPIF08 */
 
       implicit none
 
@@ -929,6 +932,11 @@ contains
       integer(kind=8), dimension(ndims, LO:HI)           :: box_8            !< temporary storage
       character(len=*), parameter                        :: pq1_label = "prolong_1v"
       logical                                            :: d4
+#ifdef MPIF08
+      type(MPI_Comm)  :: p1v_comm
+#else /* !MPIF08 */
+      integer(kind=4) :: p1v_comm
+#endif /* !MPIF08 */
 
       d4 = .false.
       if (present(dim4)) d4 = dim4
@@ -970,6 +978,7 @@ contains
          call this%check_dirty(iv, "prolong-")
       endif
 
+      call MPI_Comm_dup(MPI_COMM_WORLD, p1v_comm, err_mpi)
       nr = 0
       ! be ready to receive everything into right buffers
       cgl => fine%first
@@ -982,9 +991,9 @@ contains
                if (nr > size(req, dim=1)) call inflate_req
                if (d4) then
                   allocate(seg(g)%buf4(wna%lst(iv)%dim4, size(seg(g)%buf, dim=1), size(seg(g)%buf, dim=2), size(seg(g)%buf, dim=3)))
-                  call MPI_Irecv(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Irecv(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, p1v_comm, req(nr), err_mpi)
                else
-                  call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, p1v_comm, req(nr), err_mpi)
                endif
             enddo
          endif
@@ -1006,11 +1015,11 @@ contains
                allocate(seg(g)%buf4(wna%lst(iv)%dim4, size(seg(g)%buf, dim=1), size(seg(g)%buf, dim=2), size(seg(g)%buf, dim=3)))
                p4d => cg%w(iv)%span(cse)
                seg(g)%buf4(:, :, :, :) = p4d
-               call MPI_Isend(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+               call MPI_Isend(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, p1v_comm, req(nr), err_mpi)
             else
                p3d => cg%q(iv)%span(cse)
                seg(g)%buf(:, :, :) = p3d
-               call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+               call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, p1v_comm, req(nr), err_mpi)
             endif
          enddo
          end associate
@@ -1018,6 +1027,7 @@ contains
       enddo
 
       call piernik_Waitall(nr, "prolong_1v")
+      call MPI_Comm_free(p1v_comm, err_mpi)
 
       ! merge received coarse data into one array and interpolate it into the right place
       cgl => fine%first
@@ -1122,11 +1132,14 @@ contains
       use grid_cont,        only: grid_container
       use grid_helpers,     only: c2f
       use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
-      use MPIFUN,           only: MPI_Irecv, MPI_Isend
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend, MPI_Comm_dup, MPI_Comm_free
       use mpisetup,         only: err_mpi, req, inflate_req, master
       use named_array_list, only: qna, wna
       use ppp,              only: ppp_main
       use ppp_mpi,          only: piernik_Waitall
+#ifdef MPIF08
+      use MPIF,             only: MPI_Comm
+#endif /* MPIF08 */
 
       implicit none
 
@@ -1145,6 +1158,12 @@ contains
       integer :: g
       logical, save :: firstcall = .true.
       character(len=*), parameter :: pbc_label = "prolong_bnd_from_coarser" , pbcv_label = "prolong_bnd_from_coarser:vbp"
+#ifdef MPIF08
+      type(MPI_Comm)  :: pbfc_comm
+#else /* !MPIF08 */
+      integer(kind=4) :: pbfc_comm
+#endif /* !MPIF08 */
+
       if (present(dir)) then
          if (firstcall .and. master) call warn("[cg_level_connected:prolong_bnd_from_coarser] dir present but not implemented yet")
       endif
@@ -1172,6 +1191,7 @@ contains
       ext_buf = dom%D_ * all_cg%ord_prolong_nb ! extension of the buffers due to stencil range
       ! OPT: actual stencil range should be used instead
 
+      call MPI_Comm_dup(MPI_COMM_WORLD, pbfc_comm, err_mpi)
       nr = 0
       ! be ready to receive everything into right buffers
       cgl => this%first
@@ -1184,9 +1204,9 @@ contains
                if (present(arr4d)) then
                   if (allocated(seg(g)%buf4)) call die("[cg_level_connected:prolong_bnd_from_coarser] allocated pib buf4")
                   allocate(seg(g)%buf4(wna%lst(ind)%dim4, size(seg(g)%buf, dim=1), size(seg(g)%buf, dim=2), size(seg(g)%buf, dim=3)))
-                  call MPI_Irecv(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Irecv(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, pbfc_comm, req(nr), err_mpi)
                else
-                  call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Irecv(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, pbfc_comm, req(nr), err_mpi)
                endif
             enddo
          endif
@@ -1211,10 +1231,10 @@ contains
                   if (allocated(seg(g)%buf4)) call die("[cg_level_connected:prolong_bnd_from_coarser] allocated pob buf4")
                   allocate(seg(g)%buf4(wna%lst(ind)%dim4, size(seg(g)%buf, dim=1), size(seg(g)%buf, dim=2), size(seg(g)%buf, dim=3)))
                   seg(g)%buf4(:, :, :, :) = cgl%cg%w(ind)%arr(:, cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI))
-                  call MPI_Isend(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Isend(seg(g)%buf4(1, 1, 1, 1), size(seg(g)%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, pbfc_comm, req(nr), err_mpi)
                else
                   seg(g)%buf(:, :, :)     = cgl%cg%q(ind)%arr(   cse(xdim, LO):cse(xdim, HI), cse(ydim, LO):cse(ydim, HI), cse(zdim, LO):cse(zdim, HI))
-                  call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Isend(seg(g)%buf(1, 1, 1), size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, pbfc_comm, req(nr), err_mpi)
                endif
             enddo
          endif
@@ -1223,6 +1243,7 @@ contains
       enddo
 
       call piernik_Waitall(nr, "prolong_bnd_from_coarser", PPP_AMR)
+      call MPI_Comm_free(pbfc_comm, err_mpi)
 
       ! merge received coarse data into one array and interpolate it into the right place
       per(:) = 0
@@ -1435,10 +1456,13 @@ contains
       use grid_cont,        only: grid_container
       use mpisetup,         only: err_mpi, req, inflate_req, master
       use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
-      use MPIFUN,           only: MPI_Irecv, MPI_Isend
+      use MPIFUN,           only: MPI_Irecv, MPI_Isend, MPI_Comm_dup, MPI_Comm_free
       use named_array,      only: p3, p4
       use named_array_list, only: qna, wna
       use ppp_mpi,          only: piernik_Waitall
+#ifdef MPIF08
+      use MPIF,             only: MPI_Comm
+#endif /* MPIF08 */
 
       implicit none
 
@@ -1459,6 +1483,11 @@ contains
       logical, save                                      :: warned = .false.
       integer                                            :: position
       logical                                            :: d4
+#ifdef MPIF08
+      type(MPI_Comm)  :: r1v_comm
+#else /* !MPIF08 */
+      integer(kind=4) :: r1v_comm
+#endif /* !MPIF08 */
 
       d4 = .false.
       if (present(dim4)) d4 = dim4
@@ -1483,6 +1512,7 @@ contains
       call coarse%vertical_prep
 
       ! be ready to receive everything into right buffers
+      call MPI_Comm_dup(MPI_COMM_WORLD, r1v_comm, err_mpi)
       nr = 0
       cgl => coarse%first
       do while (associated(cgl))
@@ -1494,9 +1524,9 @@ contains
                associate (seg => cg%ri_tgt%seg(g))
                   if (d4) then
                      allocate(seg%buf4(wna%lst(iv)%dim4, size(seg%buf, dim=1), size(seg%buf, dim=2), size(seg%buf, dim=3)))
-                     call MPI_Irecv(seg%buf4(1, 1, 1, 1), size(seg%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                     call MPI_Irecv(seg%buf4(1, 1, 1, 1), size(seg%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, r1v_comm, req(nr), err_mpi)
                   else
-                     call MPI_Irecv(seg%buf(1, 1, 1), size(seg%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                     call MPI_Irecv(seg%buf(1, 1, 1), size(seg%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, r1v_comm, req(nr), err_mpi)
                   endif
                end associate
             enddo
@@ -1596,9 +1626,9 @@ contains
                nr = nr + I_ONE
                if (nr > size(req, dim=1)) call inflate_req
                if (d4) then
-                  call MPI_Isend(seg%buf4(1, 1, 1, 1), size(seg%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Isend(seg%buf4(1, 1, 1, 1), size(seg%buf4(:, :, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, r1v_comm, req(nr), err_mpi)
                else
-                  call MPI_Isend(seg%buf(1, 1, 1), size(seg%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                  call MPI_Isend(seg%buf(1, 1, 1), size(seg%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg%proc, seg%tag, r1v_comm, req(nr), err_mpi)
                endif
             end associate
          enddo
@@ -1606,6 +1636,7 @@ contains
       enddo
 
       call piernik_Waitall(nr, "restrict_1v")
+      call MPI_Comm_free(r1v_comm, err_mpi)
 
       ! copy the received buffers to the right places
       cgl => coarse%first

--- a/src/grid/cg_list_rebalance.F90
+++ b/src/grid/cg_list_rebalance.F90
@@ -196,12 +196,15 @@ contains
       use grid_container_ext, only: cg_extptrs
       use list_of_cg_lists,   only: all_lists
       use MPIF,               only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
-      use MPIFUN,             only: MPI_Isend, MPI_Irecv
+      use MPIFUN,             only: MPI_Isend, MPI_Irecv, MPI_Comm_dup, MPI_Comm_free
       use mpisetup,           only: master, piernik_MPI_Bcast, piernik_MPI_Allreduce, proc, err_mpi, req, inflate_req, tag_ub
       use named_array_list,   only: qna, wna
       use ppp,                only: ppp_main
       use ppp_mpi,            only: piernik_Waitall
       use sort_piece_list,    only: grid_piece_list
+#ifdef MPIF08
+      use MPIF,               only: MPI_Comm
+#endif /* MPIF08 */
 
       implicit none
 
@@ -230,6 +233,11 @@ contains
          enumerator :: I_D_P = I_C_P + I_ONE
       end enum
       character(len=*), parameter :: ISR_label = "reshuffle_Isend+Irecv"
+#ifdef MPIF08
+      type(MPI_Comm)  :: shuff_comm
+#else /* !MPIF08 */
+      integer(kind=4) :: shuff_comm
+#endif /* !MPIF08 */
 
       totfld = 0
       cgl => this%first
@@ -263,6 +271,7 @@ contains
       call piernik_MPI_Bcast(gptemp)
 
       ! Irecv & Isend
+      call MPI_Comm_dup(MPI_COMM_WORLD, shuff_comm, err_mpi)
       call ppp_main%start(ISR_label, PPP_AMR)
       nr = I_ZERO
       allocate(cglepa(size(gptemp)))
@@ -300,7 +309,7 @@ contains
             if (.not. found) call die("[cg_list_rebalance:balance_old] Grid id not found")
             nr = nr + I_ONE
             if (nr > size(req, dim=1)) call inflate_req
-            call MPI_Isend(cglepa(i)%tbuf, size(cglepa(i)%tbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_D_P, i), kind=4), i, MPI_COMM_WORLD, req(nr), err_mpi)
+            call MPI_Isend(cglepa(i)%tbuf, size(cglepa(i)%tbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_D_P, i), kind=4), i, shuff_comm, req(nr), err_mpi)
          endif
          if (gptemp(I_D_P, i) == proc) then ! receive
             n_gid = 1
@@ -319,12 +328,13 @@ contains
             call all_cg%add(this%last%cg)
             nr = nr + I_ONE
             if (nr > size(req, dim=1)) call inflate_req
-            call MPI_Irecv(cglepa(i)%tbuf, size(cglepa(i)%tbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_C_P, i), kind=4), i, MPI_COMM_WORLD, req(nr), err_mpi)
+            call MPI_Irecv(cglepa(i)%tbuf, size(cglepa(i)%tbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_C_P, i), kind=4), i, shuff_comm, req(nr), err_mpi)
          endif
       enddo
       call ppp_main%stop(ISR_label, PPP_AMR)
 
       call piernik_Waitall(nr, "reshuffle", PPP_AMR)
+      call MPI_Comm_free(shuff_comm, err_mpi)
 
       do i = lbound(gptemp, dim=2, kind=4), ubound(gptemp, dim=2, kind=4)
          cgl => cglepa(i)%p

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -245,9 +245,12 @@ contains
       use dataio_pub,         only: die, warn
       use domain,             only: dom
       use MPIF,               only: MPI_INTEGER, MPI_STATUS_IGNORE, MPI_COMM_WORLD
-      use MPIFUN,             only: MPI_Alltoall, MPI_Isend, MPI_Recv
+      use MPIFUN,             only: MPI_Alltoall, MPI_Isend, MPI_Recv, MPI_Comm_dup, MPI_Comm_free
       use mpisetup,           only: FIRST, LAST, err_mpi, proc, req, inflate_req
       use ppp_mpi,            only: piernik_Waitall
+#ifdef MPIF08
+      use MPIF,       only: MPI_Comm
+#endif /* MPIF08 */
 
       implicit none
 
@@ -266,6 +269,11 @@ contains
       type(pt), dimension(:), allocatable :: pt_list
       integer(kind=4) :: pt_cnt
       integer(kind=4) :: rtag
+#ifdef MPIF08
+      type(MPI_Comm)  :: ref_comm
+#else /* !MPIF08 */
+      integer(kind=4) :: ref_comm
+#endif /* !MPIF08 */
 
       if (perimeter > dom%nb) call die("[refinement_update:parents_prevent_derefinement_lev] perimeter > dom%nb")
       if (.not. associated(lev%finer)) then
@@ -315,12 +323,13 @@ contains
       call MPI_Alltoall(gscnt, I_ONE, MPI_INTEGER, grcnt, I_ONE, MPI_INTEGER, MPI_COMM_WORLD, err_mpi)
 
       ! Apparently gscnt/grcnt represent quite sparse matrix, so we better do nonblocking point-to-point than MPI_AlltoAllv
+      call MPI_Comm_dup(MPI_COMM_WORLD, ref_comm, err_mpi)
       nr = 0
       if (pt_cnt > 0) then
          do g = lbound(pt_list, dim=1, kind=4), pt_cnt
             nr = nr + I_ONE
             if (nr > size(req, dim=1)) call inflate_req
-            call MPI_Isend(pt_list(g)%tag, I_ONE, MPI_INTEGER, pt_list(g)%proc, I_ZERO, MPI_COMM_WORLD, req(nr), err_mpi)
+            call MPI_Isend(pt_list(g)%tag, I_ONE, MPI_INTEGER, pt_list(g)%proc, I_ZERO, ref_comm, req(nr), err_mpi)
             ! OPT: Perhaps it will be more efficient to allocate arrays according to gscnt and send tags in bunches
          enddo
       endif
@@ -329,13 +338,14 @@ contains
          if (grcnt(g) /= 0) then
             if (g == proc) call die("[refinement_update:parents_prevent_derefinement] MPI_Recv from self")  ! this is not an error but it should've been handled as local thing
             do i = 1, grcnt(g)
-               call MPI_Recv(rtag, I_ONE, MPI_INTEGER, g, I_ZERO, MPI_COMM_WORLD, MPI_STATUS_IGNORE, err_mpi)
+               call MPI_Recv(rtag, I_ONE, MPI_INTEGER, g, I_ZERO, ref_comm, MPI_STATUS_IGNORE, err_mpi)
                call disable_derefine_by_tag(lev%finer, rtag)  ! beware: O(leaves%cnt^2)
             enddo
          endif
       enddo
 
       call piernik_Waitall(nr, "prevent_derefinement")
+      call MPI_Comm_free(ref_comm, err_mpi)
 
       deallocate(pt_list)
 

--- a/src/scheme/sweeps.F90
+++ b/src/scheme/sweeps.F90
@@ -49,11 +49,20 @@
 module sweeps
 
 ! pulled by ANY
+#ifdef MPIF08
+   use MPIF, only: MPI_Comm
+#endif /* MPIF08 */
 
    implicit none
 
    private
    public  :: sweep
+
+#ifdef MPIF08
+   type(MPI_Comm)  :: sweeps_comm
+#else /* !MPIF08 */
+   integer(kind=4) :: sweeps_comm
+#endif /* !MPIF08 */
 
 contains
 
@@ -66,7 +75,7 @@ contains
       use constants, only: LO, HI, I_ONE
       use cg_leaves, only: leaves
       use cg_list,   only: cg_list_element
-      use MPIF,      only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIF,      only: MPI_DOUBLE_PRECISION
       use MPIFUN,    only: MPI_Irecv
       use mpisetup,  only: err_mpi, req, inflate_req
 
@@ -93,7 +102,7 @@ contains
                   if (jc(LO) == jc(HI)) then
                      nr = nr + I_ONE
                      if (nr > size(req, dim=1)) call inflate_req
-                     call MPI_Irecv(seg(g)%buf, size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+                     call MPI_Irecv(seg(g)%buf, size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, sweeps_comm, req(nr), err_mpi)
                      seg(g)%req => req(nr)
                   endif
                enddo
@@ -177,7 +186,7 @@ contains
       use domain,       only: dom
       use grid_cont,    only: grid_container
       use grid_helpers, only: f2c_o
-      use MPIF,         only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
+      use MPIF,         only: MPI_DOUBLE_PRECISION
       use MPIFUN,       only: MPI_Isend
       use mpisetup,     only: err_mpi, req, inflate_req
       use ppp,          only: ppp_main
@@ -225,7 +234,7 @@ contains
 
                nr = nr + I_ONE
                if (nr > size(req, dim=1)) call inflate_req
-               call MPI_Isend(seg(g)%buf, size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, MPI_COMM_WORLD, req(nr), err_mpi)
+               call MPI_Isend(seg(g)%buf, size(seg(g)%buf(:, :, :), kind=4), MPI_DOUBLE_PRECISION, seg(g)%proc, seg(g)%tag, sweeps_comm, req(nr), err_mpi)
                seg(g)%req => req(nr)
             endif
          enddo
@@ -303,7 +312,7 @@ contains
       use dataio_pub,       only: die
       use global,           only: integration_order, use_fargo, which_solver
       use grid_cont,        only: grid_container
-      use MPIF,             only: MPI_STATUS_IGNORE
+      use MPIF,             only: MPI_STATUS_IGNORE, MPI_COMM_WORLD
       use MPIFUN,           only: MPI_Waitany
       use mpisetup,         only: err_mpi, req
       use named_array_list, only: qna, wna
@@ -394,6 +403,8 @@ contains
 
       ! This is the loop over Runge-Kutta stages
       do istep = first_stage(integration_order), last_stage(integration_order)
+
+         call MPI_Comm_dup(MPI_COMM_WORLD, sweeps_comm, err_mpi)
          nr_recv = compute_nr_recv(cdim)
          nr = nr_recv
          all_processed = .false.
@@ -433,6 +444,7 @@ contains
          enddo
 
          call piernik_Waitall(nr, "sweeps")
+         call MPI_Comm_free(sweeps_comm, err_mpi)
 
          call update_boundaries(cdim, istep)
       enddo


### PR DESCRIPTION
Fighting deadlocks on Tryton:
* Optional MPI_Barriers to enforce "epoch" separation.
* Separate MPI communicator for sepate communication contexts.