### PR TITLE
CFL_warn fix

### DIFF
--- a/jenkins/gold_configs/mcrwind.config
+++ b/jenkins/gold_configs/mcrwind.config
@@ -1,6 +1,7 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=13ad465916cacb7876d0995c948dea9b7f0688d0
+GOLD_COMMIT=104e426f0f85c3957c98fcbd01e9ec98a24e090d
+# 104e426f0f85c3957c98fcbd01e9ec98a24e090d - [timestep] shrinked dt after redoing step taken into account for used cfl
 # 13ad465916cacb7876d0995c948dea9b7f0688d0 - autodetection of mpi_f08
 # 1044504830059279ddf543fe03178e283e9255d0 - [IO/hdf5,units] extend range for CR dataset to cr01:cr99
 # d32318380141a6be987a8155a4c80c7b5eb9b323 - [mcrwind] set default initial single SN amplitude to 10^51 erg

--- a/problems/mcrwind/problem.par.build
+++ b/problems/mcrwind/problem.par.build
@@ -56,7 +56,7 @@
     smallei      = 1.e-4
     limiter      = "vanleer"
     divB_0       = "CT"
-    repeat_step = .true.
+    cflcontrol   = 'redo'
   /
 
  $GRAVITY

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -405,10 +405,6 @@ contains
 
       endif
 
-#ifdef NBODY
-      if (master .and. any(cflcontrol == ['redo', 'repeat', 'flex', 'flexible'])) call warn("[global:init_global] step repeating (clfcontrol == 'redo' or 'flex') unsupported by NBODY (particles aren't implemented yet).")
-#endif /* NBODY */
-
       select case (solver_str)
          case ("")  ! leave the default
          case ("rtvd", "RTVD")

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -40,17 +40,17 @@ module global
 
    private
    public :: cleanup_global, init_global, &
-        &    cfl, cfl_max, cflcontrol, cfl_violated, disallow_negatives, disallow_CRnegatives, unwanted_negatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
+        &    cfl, cfl_max, cflcontrol, disallow_negatives, disallow_CRnegatives, unwanted_negatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, max_redostep_attempts, repetitive_steps, &
-        &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
+        &    repeat_step, integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, skip_sweep, geometry25D, &
         &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, do_external_corners, prefer_merged_MPI, &
         &    divB_0_method, cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fluid_prolong, which_solver
 
-   logical         :: cfl_violated             !< True when cfl condition is violated
    logical         :: dn_negative = .false.
    logical         :: ei_negative = .false.
    logical         :: cr_negative = .false.
+   logical         :: repeat_step = .false.     !< order to repeat fluid step
    logical         :: disallow_negatives, disallow_CRnegatives, unwanted_negatives = .false.
    logical         :: repetitive_steps         !< epetitve fluid step if cfl condition is violated (significantly increases mem usage)
    logical         :: dirty_debug              !< Allow initializing arrays with some insane values and checking if these values can propagate

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -41,7 +41,7 @@ module global
    private
    public :: cleanup_global, init_global, &
         &    cfl, cfl_max, cflcontrol, cfl_violated, disallow_negatives, disallow_CRnegatives, unwanted_negatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
-        &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, &
+        &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, max_redostep_attempts, &
         &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, repeat_step, skip_sweep, geometry25D, &
         &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, do_external_corners, prefer_merged_MPI, &
@@ -73,6 +73,7 @@ module global
    real    :: dt_max                   !< maximum allowed timestep
    real    :: cfl                      !< desired Courant–Friedrichs–Lewy number
    real    :: cfl_max                  !< warning threshold for the effective CFL number achieved
+   integer :: max_redostep_attempts    !< limitation for a number of redoing step attempts (Note: Something might be terribly wrong if a single step requires too many reductions)
    logical :: use_smalld               !< correct density when it gets lower than smalld
    logical :: use_smallei              !< correct internal energy density when it gets lower then smallei
    logical :: geometry25D              !< include source terms in reduced dimension for 2D simulations
@@ -109,7 +110,7 @@ module global
    character(len=cbuff_len)      :: solver_str        !< allow to switch between RIEMANN and RTVD without recompilation
 
    namelist /NUMERICAL_SETUP/ cfl, cflcontrol, disallow_negatives, disallow_CRnegatives, cfl_max, use_smalld, use_smallei, smalld, smallei, smallc, smallp, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, &
-        &                     repeat_step, limiter, limiter_b, relax_time, integration_order, cfr_smooth, skip_sweep, geometry25D, sweeps_mgu, print_divB, &
+        &                     repeat_step, max_redostep_attempts, limiter, limiter_b, relax_time, integration_order, cfr_smooth, skip_sweep, geometry25D, sweeps_mgu, print_divB, &
         &                     use_fargo, divB_0, glm_alpha, use_eglm, cfl_glm, ch_grid, interpol_str, w_epsilon, psi_bnd_str, ord_mag_prolong, ord_fluid_prolong, do_external_corners, solver_str
 
    logical                       :: prefer_merged_MPI !< prefer internal_boundaries_MPI_merged over internal_boundaries_MPI_1by1
@@ -127,38 +128,39 @@ contains
 !! \n \n
 !! <table border="+1">
 !!   <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
-!!   <tr><td>cfl              </td><td>0.7    </td><td>real value between 0.0 and 1.0       </td><td>\copydoc global::cfl              </td></tr>
-!!   <tr><td>cfl_max          </td><td>0.9    </td><td>real value between cfl and 1.0       </td><td>\copydoc global::cfl_max          </td></tr>
-!!   <tr><td>cflcontrol       </td><td>warn   </td><td>string                               </td><td>\copydoc global::cflcontrol       </td></tr>
-!!   <tr><td>repeat_step      </td><td>.true. </td><td>logical value                        </td><td>\copydoc global::use_smalld       </td></tr>
-!!   <tr><td>smallp           </td><td>1.e-10 </td><td>real value                           </td><td>\copydoc global::smallp           </td></tr>
-!!   <tr><td>smalld           </td><td>1.e-10 </td><td>real value                           </td><td>\copydoc global::smalld           </td></tr>
-!!   <tr><td>use_smalld       </td><td>.true. </td><td>logical value                        </td><td>\copydoc global::use_smalld       </td></tr>
-!!   <tr><td>smallei          </td><td>1.e-10 </td><td>real value                           </td><td>\copydoc global::smallei          </td></tr>
-!!   <tr><td>smallc           </td><td>1.e-10 </td><td>real value                           </td><td>\copydoc global::smallc           </td></tr>
-!!   <tr><td>integration_order</td><td>2      </td><td>1 or 2                               </td><td>\copydoc global::integration_order</td></tr>
-!!   <tr><td>cfr_smooth       </td><td>0.0    </td><td>real value                           </td><td>\copydoc global::cfr_smooth       </td></tr>
-!!   <tr><td>dt_initial       </td><td>-1.    </td><td>positive real value or -1. .. 0.     </td><td>\copydoc global::dt_initial       </td></tr>
-!!   <tr><td>dt_max_grow      </td><td>2.     </td><td>real value, should be > 1.           </td><td>\copydoc global::dt_max_grow      </td></tr>
-!!   <tr><td>dt_shrink        </td><td>0.5    </td><td>real value, should be < 1.           </td><td>\copydoc global::dt_shrink        </td></tr>
-!!   <tr><td>dt_min           </td><td>0.     </td><td>positive real value                  </td><td>\copydoc global::dt_min           </td></tr>
-!!   <tr><td>dt_max           </td><td>0.     </td><td>positive real value                  </td><td>\copydoc global::dt_max           </td></tr>
-!!   <tr><td>limiter          </td><td>vanleer</td><td>string                               </td><td>\copydoc global::limiter          </td></tr>
-!!   <tr><td>limiter_b        </td><td>moncen </td><td>string                               </td><td>\copydoc global::limiter_b        </td></tr>
-!!   <tr><td>relax_time       </td><td>0.0    </td><td>real value                           </td><td>\copydoc global::relax_time       </td></tr>
-!!   <tr><td>skip_sweep       </td><td>F, F, F</td><td>logical array                        </td><td>\copydoc global::skip_sweep       </td></tr>
-!!   <tr><td>geometry25D      </td><td>F      </td><td>logical value                        </td><td>\copydoc global::geometry25d      </td></tr>
-!!   <tr><td>sweeps_mgu       </td><td>F      </td><td>logical value                        </td><td>\copydoc global::sweeps_mgu       </td></tr>
-!!   <tr><td>divB_0           </td><td>CT     </td><td>string                               </td><td>\copydoc global::divB_0           </td></tr>
-!!   <tr><td>glm_alpha        </td><td>0.1    </td><td>real value                           </td><td>\copydoc global::glm_alpha        </td></tr>
-!!   <tr><td>use_eglm         </td><td>false  </td><td>logical value                        </td><td>\copydoc global::use_eglm         </td></tr>
-!!   <tr><td>print_divB       </td><td>100    </td><td>integer value                        </td><td>\copydoc global::print_divB       </td></tr>
-!!   <tr><td>ch_grid          </td><td>false  </td><td>logical value                        </td><td>\copydoc global::ch_grid          </td></tr>
-!!   <tr><td>w_epsilon        </td><td>1e-10  </td><td>real                                 </td><td>\copydoc global::w_epsilon        </td></tr>
-!!   <tr><td>psi_bnd_str      </td><td>"default" </td><td>string                            </td><td>\copydoc global::psi_bnd_str      </td></tr>
-!!   <tr><td>ord_mag_prolong  </td><td>2      </td><td>integer                              </td><td>\copydoc global::ord_mag_prolong  </td></tr>
-!!   <tr><td>ord_fluid_prolong </td><td>0     </td><td>integer                              </td><td>\copydoc global::ord_fluid_prolong </td></tr>
-!!   <tr><td>do_external_corners </td><td>.false.</td><td>logical                           </td><td>\copydoc global::do_external_corners </td></tr>
+!!   <tr><td>cfl                  </td><td>0.7      </td><td>real value between 0.0 and 1.0       </td><td>\copydoc global::cfl                  </td></tr>
+!!   <tr><td>cfl_max              </td><td>0.9      </td><td>real value between cfl and 1.0       </td><td>\copydoc global::cfl_max              </td></tr>
+!!   <tr><td>cflcontrol           </td><td>warn     </td><td>string                               </td><td>\copydoc global::cflcontrol           </td></tr>
+!!   <tr><td>repeat_step          </td><td>.true.   </td><td>logical value                        </td><td>\copydoc global::use_smalld           </td></tr>
+!!   <tr><td>max_redostep_attempts</td><td>10       </td><td>integer                              </td><td>\copydoc global::max_redostep_attempts</td></tr>
+!!   <tr><td>smallp               </td><td>1.e-10   </td><td>real value                           </td><td>\copydoc global::smallp               </td></tr>
+!!   <tr><td>smalld               </td><td>1.e-10   </td><td>real value                           </td><td>\copydoc global::smalld               </td></tr>
+!!   <tr><td>use_smalld           </td><td>.true.   </td><td>logical value                        </td><td>\copydoc global::use_smalld           </td></tr>
+!!   <tr><td>smallei              </td><td>1.e-10   </td><td>real value                           </td><td>\copydoc global::smallei              </td></tr>
+!!   <tr><td>smallc               </td><td>1.e-10   </td><td>real value                           </td><td>\copydoc global::smallc               </td></tr>
+!!   <tr><td>integration_order    </td><td>2        </td><td>1 or 2                               </td><td>\copydoc global::integration_order    </td></tr>
+!!   <tr><td>cfr_smooth           </td><td>0.0      </td><td>real value                           </td><td>\copydoc global::cfr_smooth           </td></tr>
+!!   <tr><td>dt_initial           </td><td>-1.      </td><td>positive real value or -1. .. 0.     </td><td>\copydoc global::dt_initial           </td></tr>
+!!   <tr><td>dt_max_grow          </td><td>2.       </td><td>real value, should be > 1.           </td><td>\copydoc global::dt_max_grow          </td></tr>
+!!   <tr><td>dt_shrink            </td><td>0.5      </td><td>real value, should be < 1.           </td><td>\copydoc global::dt_shrink            </td></tr>
+!!   <tr><td>dt_min               </td><td>0.       </td><td>positive real value                  </td><td>\copydoc global::dt_min               </td></tr>
+!!   <tr><td>dt_max               </td><td>0.       </td><td>positive real value                  </td><td>\copydoc global::dt_max               </td></tr>
+!!   <tr><td>limiter              </td><td>vanleer  </td><td>string                               </td><td>\copydoc global::limiter              </td></tr>
+!!   <tr><td>limiter_b            </td><td>moncen   </td><td>string                               </td><td>\copydoc global::limiter_b            </td></tr>
+!!   <tr><td>relax_time           </td><td>0.0      </td><td>real value                           </td><td>\copydoc global::relax_time           </td></tr>
+!!   <tr><td>skip_sweep           </td><td>F, F, F  </td><td>logical array                        </td><td>\copydoc global::skip_sweep           </td></tr>
+!!   <tr><td>geometry25D          </td><td>F        </td><td>logical value                        </td><td>\copydoc global::geometry25d          </td></tr>
+!!   <tr><td>sweeps_mgu           </td><td>F        </td><td>logical value                        </td><td>\copydoc global::sweeps_mgu           </td></tr>
+!!   <tr><td>divB_0               </td><td>CT       </td><td>string                               </td><td>\copydoc global::divB_0               </td></tr>
+!!   <tr><td>glm_alpha            </td><td>0.1      </td><td>real value                           </td><td>\copydoc global::glm_alpha            </td></tr>
+!!   <tr><td>use_eglm             </td><td>false    </td><td>logical value                        </td><td>\copydoc global::use_eglm             </td></tr>
+!!   <tr><td>print_divB           </td><td>100      </td><td>integer value                        </td><td>\copydoc global::print_divB           </td></tr>
+!!   <tr><td>ch_grid              </td><td>false    </td><td>logical value                        </td><td>\copydoc global::ch_grid              </td></tr>
+!!   <tr><td>w_epsilon            </td><td>1e-10    </td><td>real                                 </td><td>\copydoc global::w_epsilon            </td></tr>
+!!   <tr><td>psi_bnd_str          </td><td>"default"</td><td>string                               </td><td>\copydoc global::psi_bnd_str          </td></tr>
+!!   <tr><td>ord_mag_prolong      </td><td>2        </td><td>integer                              </td><td>\copydoc global::ord_mag_prolong      </td></tr>
+!!   <tr><td>ord_fluid_prolong    </td><td>0        </td><td>integer                              </td><td>\copydoc global::ord_fluid_prolong    </td></tr>
+!!   <tr><td>do_external_corners  </td><td>.false.  </td><td>logical                              </td><td>\copydoc global::do_external_corners  </td></tr>
 !! </table>
 !! \n \n
 !! \n \n
@@ -245,6 +247,7 @@ contains
       w_epsilon   = 1e-10
       psi_bnd_str = "default"
       integration_order  = 2
+      max_redostep_attempts = 10
       ord_mag_prolong = O_I2           !< it looks like most f/c artifacts are gone just with cubic prolongation of magnetic guardcells
       ord_fluid_prolong = O_INJ        !< O_INJ and O_LIN ensure monotoniciy and nonnegative density and energy
       do_external_corners =.false.
@@ -313,6 +316,7 @@ contains
          ibuff(2) = print_divB
          ibuff(3) = ord_mag_prolong
          ibuff(4) = ord_fluid_prolong
+         ibuff(5) = max_redostep_attempts
 
          rbuff( 1) = smalld
          rbuff( 2) = smallc
@@ -355,50 +359,51 @@ contains
 
       if (slave) then
 
-         use_smalld           = lbuff(1)
-         use_smallei          = lbuff(2)
-         repeat_step          = lbuff(3)
-         skip_sweep           = lbuff(4:6)
-         geometry25D          = lbuff(7)
-         sweeps_mgu           = lbuff(8)
-         use_fargo            = lbuff(9)
-         use_eglm             = lbuff(10)
-         ch_grid              = lbuff(11)
-         do_external_corners  = lbuff(13)
-         disallow_negatives   = lbuff(14)
-         disallow_CRnegatives = lbuff(15)
-         prefer_merged_MPI    = lbuff(16)
-         extra_barriers       = lbuff(17)
+         use_smalld            = lbuff(1)
+         use_smallei           = lbuff(2)
+         repeat_step           = lbuff(3)
+         skip_sweep            = lbuff(4:6)
+         geometry25D           = lbuff(7)
+         sweeps_mgu            = lbuff(8)
+         use_fargo             = lbuff(9)
+         use_eglm              = lbuff(10)
+         ch_grid               = lbuff(11)
+         do_external_corners   = lbuff(13)
+         disallow_negatives    = lbuff(14)
+         disallow_CRnegatives  = lbuff(15)
+         prefer_merged_MPI     = lbuff(16)
+         extra_barriers        = lbuff(17)
 
-         smalld               = rbuff( 1)
-         smallc               = rbuff( 2)
-         smallp               = rbuff( 3)
-         smallei              = rbuff( 4)
-         cfl                  = rbuff( 5)
-         cfr_smooth           = rbuff( 6)
-         dt_initial           = rbuff( 7)
-         dt_max_grow          = rbuff( 8)
-         dt_min               = rbuff( 9)
-         dt_max               = rbuff(10)
-         cfl_max              = rbuff(11)
-         relax_time           = rbuff(12)
-         glm_alpha            = rbuff(13)
-         cfl_glm              = rbuff(14)
-         w_epsilon            = rbuff(15)
-         dt_shrink            = rbuff(16)
+         smalld                = rbuff( 1)
+         smallc                = rbuff( 2)
+         smallp                = rbuff( 3)
+         smallei               = rbuff( 4)
+         cfl                   = rbuff( 5)
+         cfr_smooth            = rbuff( 6)
+         dt_initial            = rbuff( 7)
+         dt_max_grow           = rbuff( 8)
+         dt_min                = rbuff( 9)
+         dt_max                = rbuff(10)
+         cfl_max               = rbuff(11)
+         relax_time            = rbuff(12)
+         glm_alpha             = rbuff(13)
+         cfl_glm               = rbuff(14)
+         w_epsilon             = rbuff(15)
+         dt_shrink             = rbuff(16)
 
-         limiter              = cbuff(1)
-         limiter_b            = cbuff(2)
-         cflcontrol           = cbuff(3)
-         divB_0               = cbuff(5)
-         interpol_str         = cbuff(6)
-         psi_bnd_str          = cbuff(7)
-         solver_str           = cbuff(8)
+         limiter               = cbuff(1)
+         limiter_b             = cbuff(2)
+         cflcontrol            = cbuff(3)
+         divB_0                = cbuff(5)
+         interpol_str          = cbuff(6)
+         psi_bnd_str           = cbuff(7)
+         solver_str            = cbuff(8)
 
-         integration_order    = ibuff(1)
-         print_divB           = ibuff(2)
-         ord_mag_prolong      = ibuff(3)
-         ord_fluid_prolong    = ibuff(4)
+         integration_order     = ibuff(1)
+         print_divB            = ibuff(2)
+         ord_mag_prolong       = ibuff(3)
+         ord_fluid_prolong     = ibuff(4)
+         max_redostep_attempts = ibuff(5)
 
       endif
 

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -93,7 +93,7 @@ module global
    integer(kind=4), protected    :: integration_order !< Runge-Kutta time integration order (1 - 1st order (Euler), 2 - 2nd order (RK2))
    character(len=cbuff_len)      :: limiter           !< type of flux limiter
    character(len=cbuff_len)      :: limiter_b         !< type of flux limiter for magnetic field in the Riemann solver
-   character(len=cbuff_len)      :: cflcontrol        !< type of cfl control just before/after each sweep (possibilities: 'none', 'warn', 'redo', 'auto')
+   character(len=cbuff_len)      :: cflcontrol        !< type of cfl control just before/after each sweep (possibilities: 'none', 'warn', 'redo', 'flex', 'auto')
    character(len=cbuff_len)      :: interpol_str      !< type of interpolation
    character(len=cbuff_len)      :: divB_0            !< human-readable method of making div(B) = 0 (currently CT or HDC)
    character(len=cbuff_len)      :: psi_bnd_str       !< "default" for general boundaries or override ith something special
@@ -406,7 +406,7 @@ contains
       endif
 
 #ifdef NBODY
-      if (master .and. cflcontrol == 'redo') call warn("[global:init_global] step repeating (clfcontrol == 'redo') unsupported by NBODY (particles aren't implemented yet).")
+      if (master .and. any(cflcontrol == ['redo', 'repeat', 'flex', 'flexible'])) call warn("[global:init_global] step repeating (clfcontrol == 'redo' or 'flex') unsupported by NBODY (particles aren't implemented yet).")
 #endif /* NBODY */
 
       select case (solver_str)

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -41,9 +41,9 @@ module global
    private
    public :: cleanup_global, init_global, &
         &    cfl, cfl_max, cflcontrol, cfl_violated, disallow_negatives, disallow_CRnegatives, unwanted_negatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
-        &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, max_redostep_attempts, &
+        &    dt, dt_initial, dt_max_grow, dt_shrink, dt_min, dt_max, dt_old, dtm, t, t_saved, nstep, nstep_saved, max_redostep_attempts, repetitive_steps, &
         &    integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
-        &    relax_time, grace_period_passed, cfr_smooth, repeat_step, skip_sweep, geometry25D, &
+        &    relax_time, grace_period_passed, cfr_smooth, skip_sweep, geometry25D, &
         &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, do_external_corners, prefer_merged_MPI, &
         &    divB_0_method, cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fluid_prolong, which_solver
 
@@ -52,7 +52,7 @@ module global
    logical         :: ei_negative = .false.
    logical         :: cr_negative = .false.
    logical         :: disallow_negatives, disallow_CRnegatives, unwanted_negatives = .false.
-   logical         :: repeat_step              !< repeat fluid step if cfl condition is violated
+   logical         :: repetitive_steps         !< epetitve fluid step if cfl condition is violated (significantly increases mem usage)
    logical         :: dirty_debug              !< Allow initializing arrays with some insane values and checking if these values can propagate
    integer(kind=4) :: show_n_dirtys            !< use to limit the amount of printed messages on dirty values found
    logical         :: do_ascii_dump            !< to dump, or not to dump: that is a question (ascii)
@@ -186,10 +186,9 @@ contains
 
       if (code_progress < PIERNIK_INIT_DOMAIN) call die("[global:init_global] MPI not initialized.")
 
-      repeat_step = .false.
       dirty_debug = .false.
-      dt_old = -1.
-      t = 0.
+      dt_old      = -1.
+      t           = 0.
 
       ! Begin processing of namelist parameters
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -42,7 +42,7 @@ program piernik
    use fluidindex,        only: flind
    use fluidupdate,       only: fluid_update
    use func,              only: operator(.equals.)
-   use global,            only: t, nstep, dt, dtm, cfl_violated, print_divB, repeat_step, tstep_attempt
+   use global,            only: t, nstep, dt, dtm, cfl_violated, print_divB, repetitive_steps, tstep_attempt
    use initpiernik,       only: init_piernik
    use lb_helpers,        only: costs_maintenance
    use list_of_cg_lists,  only: all_lists
@@ -114,7 +114,7 @@ program piernik
    call print_progress(nstep)
    if (print_divB > 0) call print_divB_norm
 
-   do while (t < tend .and. nstep < nend .and. .not.(end_sim) .or. (cfl_violated .and. repeat_step)) ! main loop
+   do while (t < tend .and. nstep < nend .and. .not.(end_sim) .or. (cfl_violated .and. repetitive_steps)) ! main loop
 
       write(buf, '(i10)') nstep
       label = "step " // adjustl(trim(buf))

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -135,7 +135,7 @@ program piernik
       call all_cg%check_na
       !call all_cg%check_for_dirt
 
-      call time_step(dt, flind, .true.)
+      if (.not. repeat_step) call time_step(dt, flind, .true.)
       call grace_period
 
       if (.not. repeat_step) then

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -135,7 +135,7 @@ program piernik
       call all_cg%check_na
       !call all_cg%check_for_dirt
 
-      call time_step(dt, flind)
+      call time_step(dt, flind, .true.)
       call grace_period
 
       if (.not.cfl_violated) then
@@ -150,7 +150,7 @@ program piernik
       call fluid_update
       nstep = nstep + I_ONE
       call print_progress(nstep)
-      call check_cfl_violation(dt, flind)
+      call check_cfl_violation(flind)
 
       if ((t .equals. tlast) .and. .not. first_step .and. .not. cfl_violated) call die("[piernik] timestep is too small: t == t + 2 * dt")
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -135,10 +135,10 @@ program piernik
       call all_cg%check_na
       !call all_cg%check_for_dirt
 
-      if (.not. repeat_step) call time_step(dt, flind, .true.)
-      call grace_period
-
       if (.not. repeat_step) then
+         call time_step(dt, flind, .true.)
+         call grace_period
+
          dtm = dt
 
          call check_log

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -62,7 +62,7 @@ contains
 
       use constants,  only: PIERNIK_INIT_GLOBAL
       use dataio_pub, only: msg, die, warn, code_progress
-      use global,     only: cflcontrol
+      use global,     only: cflcontrol, repeat_step
 
       implicit none
 
@@ -71,6 +71,9 @@ contains
       select case (cflcontrol)
          case ('warn')
             cfl_manager => cfl_warn
+         case ('redo', 'repeat')
+            cfl_manager => cfl_warn
+            repeat_step = .true.
          case ('auto', 'adaptive')
             cfl_manager => cfl_auto
          case ('none', '')
@@ -247,7 +250,7 @@ contains
       real                          :: checkdt   !< checked dt after fluid_update
       real                          :: c_all_bck !< backup for timestep sensitive variables
 
-      if (cflcontrol /= 'warn') return
+      if (cflcontrol /= 'warn' .and. cflcontrol /= 'redo' .and. cflcontrol /= 'repeat') return
 
 
 #ifdef COSM_RAY_ELECTRONS

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -94,6 +94,9 @@ contains
          call warn("[timestep:init_time_step] cfl_manager was not associated.")
          return
       endif
+#ifdef NBODY
+      if (repetitive_steps) call die("[timestep:init_time_step] step repeating (clfcontrol == 'redo' or 'flex') unsupported by NBODY (not implemented yet).")
+#endif /* NBODY */
 #if !(defined(__INTEL_COMPILER) || defined(_CRAYFTN))
       !! \deprecated remove this clause as soon as Intel Compiler gets required features and/or bug fixes
       call cfl_manager

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -113,7 +113,7 @@ contains
       use dataio_pub,         only: tend, msg, warn
       use fargo,              only: timestep_fargo
       use fluidtypes,         only: var_numbers
-      use global,             only: t, dt_old, dt_full, dt_max_grow, dt_initial, dt_min, dt_max, nstep, repeat_step, repetitive_steps
+      use global,             only: t, dt_old, dt_full, dt_max_grow, dt_initial, dt_min, dt_max, nstep, repetitive_steps
       use grid_cont,          only: grid_container
       use mpisetup,           only: master, piernik_MPI_Allreduce
       use ppp,                only: ppp_main
@@ -144,8 +144,6 @@ contains
       real                             :: c_, dt_
       integer                          :: ifl
       character(len=*), parameter :: ts_label = "timestep"
-
-      if (main_call .and. repeat_step) return
 
       call ppp_main%start(ts_label)
 
@@ -200,7 +198,7 @@ contains
       endif
 
       if (associated(cfl_manager) .and. (main_call .neqv. repetitive_steps)) call cfl_manager
-      if (main_call .and. .not. repeat_step) c_all_old = c_all
+      if (main_call) c_all_old = c_all
 
       if (dt < dt_min) then ! something nasty had happened
          if (master) then
@@ -220,7 +218,7 @@ contains
       endif
 #endif /* DEBUG */
       call compare_array1D([dt])  ! just in case
-      if (main_call .and. .not. repeat_step) dt_full = dt
+      if (main_call) dt_full = dt
 
       call ppp_main%stop(ts_label)
 

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -62,18 +62,19 @@ contains
 
       use constants,  only: PIERNIK_INIT_GLOBAL
       use dataio_pub, only: msg, die, warn, code_progress
-      use global,     only: cflcontrol, repeat_step
+      use global,     only: cflcontrol, repetitive_steps
 
       implicit none
 
       if (code_progress < PIERNIK_INIT_GLOBAL) call die("[timestep:init_time_step] globals not initialized.")
 
+      repetitive_steps = .false.
       select case (cflcontrol)
          case ('warn')
             cfl_manager => cfl_warn
          case ('redo', 'repeat')
             cfl_manager => cfl_warn
-            repeat_step = .true.
+            repetitive_steps = .true.
          case ('auto', 'adaptive')
             cfl_manager => cfl_auto
          case ('none', '')

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -88,7 +88,7 @@ contains
       use cg_list,          only: cg_list_element
       use constants,        only: pSUM, I_ZERO, I_ONE, dsetnamelen, AT_IGNORE, INVALID
       use dataio_pub,       only: warn, msg, die
-      use global,           only: dt, dtm, t, t_saved, cfl_violated, nstep, nstep_saved, dt_shrink, repeat_step, tstep_attempt
+      use global,           only: dt, dtm, t, t_saved, cfl_violated, max_redostep_attempts, nstep, nstep_saved, dt_shrink, repeat_step, tstep_attempt
       use mass_defect,      only: downgrade_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
@@ -104,7 +104,6 @@ contains
       integer(kind=4)                :: no_hist_count
       integer                        :: i, j
       character(len=dsetnamelen)     :: rname
-      integer, parameter             :: max_attempts = 10  !< Something is terribly wrong if a single step requires too many reductions
       character(len=*), parameter :: rs_label = "repeat_step_"
 
       if (.not.repeat_step) return
@@ -113,8 +112,8 @@ contains
 
       if (cfl_violated) then
          tstep_attempt = tstep_attempt + I_ONE
-         if (tstep_attempt > max_attempts) then
-            write(msg, '(a,i2,a)')"[timestep_retry:repeat_fluidstep] tstep_attempt > ", max_attempts, " (hardcoded limit)"
+         if (tstep_attempt > max_redostep_attempts) then
+            write(msg, '(a,i2,a)')"[timestep_retry:repeat_fluidstep] tstep_attempt > ", max_redostep_attempts, " (max_redostep_attempts)"
             call die(msg)
          endif
          write(msg, '(a,i2,a)') "[timestep_retry:repeat_fluidstep] Redoing previous step (", tstep_attempt, ")"

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -88,7 +88,7 @@ contains
       use cg_list,          only: cg_list_element
       use constants,        only: pSUM, I_ZERO, I_ONE, dsetnamelen, AT_IGNORE, INVALID
       use dataio_pub,       only: warn, msg, die
-      use global,           only: dt, dtm, t, t_saved, cfl_violated, max_redostep_attempts, nstep, nstep_saved, dt_shrink, repeat_step, tstep_attempt
+      use global,           only: dt, dtm, t, t_saved, cfl_violated, max_redostep_attempts, nstep, nstep_saved, dt_shrink, repetitive_steps, tstep_attempt
       use mass_defect,      only: downgrade_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
@@ -106,7 +106,7 @@ contains
       character(len=dsetnamelen)     :: rname
       character(len=*), parameter :: rs_label = "repeat_step_"
 
-      if (.not.repeat_step) return
+      if (.not. repetitive_steps) return
 
       call restart_arrays
 

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -88,7 +88,7 @@ contains
       use cg_list,          only: cg_list_element
       use constants,        only: pSUM, I_ZERO, I_ONE, dsetnamelen, AT_IGNORE, INVALID
       use dataio_pub,       only: warn, msg, die
-      use global,           only: dt, dtm, t, t_saved, max_redostep_attempts, nstep, nstep_saved, dt_shrink, repeat_step, repetitive_steps, tstep_attempt
+      use global,           only: dt, dt_full, t, t_saved, max_redostep_attempts, nstep, nstep_saved, dt_cur_shrink, repeat_step, repetitive_steps, tstep_attempt
       use mass_defect,      only: downgrade_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
@@ -120,7 +120,7 @@ contains
          if (master) call warn(msg)
          t = t_saved
          nstep = nstep_saved
-         dt = dtm * dt_shrink
+         dt = dt_full * dt_cur_shrink
          call reset_freezing_speed
          call downgrade_magic_mass
          if (associated(user_reaction_to_redo_step)) call user_reaction_to_redo_step

--- a/src/supernovae/snsources.F90
+++ b/src/supernovae/snsources.F90
@@ -159,14 +159,14 @@ contains
 !<
    subroutine random_sn
 
-      use global,    only: t, cfl_violated
+      use global, only: t, repeat_step
 
       implicit none
 
       real, dimension(ndims) :: snpos
       integer                :: isn, nsn_per_timestep
 
-      if (.not.cfl_violated) nsn_last = nsn
+      if (.not.repeat_step) nsn_last = nsn
 
       nsn = int(t * f_sn, kind=4)
       nsn_per_timestep = nsn - nsn_last


### PR DESCRIPTION
cfl_violation fix for static conditions with unexpected source added by user
and further development for repeating steps scenarios:
* suspend calling time_step while step is repeated
* control dt shrinking by dt_cur_shrink variable
* new experimental scenario flex that takes precise dt shrinking in just one step repetition attempt
* rename variables to have code better readable