### PR TITLE
CFL violation handling for CRESP

### DIFF
--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -237,7 +237,6 @@ contains
 #endif /* COSM_RAYS */
 #ifdef COSM_RAY_ELECTRONS
       use cresp_grid,     only: cfl_cresp_violation
-      use initcrspectrum, only: cresp_substep
 #endif /* COSM_RAY_ELECTRONS */
 
       implicit none
@@ -301,10 +300,6 @@ contains
       use global,       only: cfl, cfl_max, cfl_violated, unwanted_negatives
       use mpisetup,     only: piernik_MPI_Bcast, master
       use timestep_pub, only: c_all, c_all_old, stepcfl
-#ifdef COSM_RAY_ELECTRONS
-      use cresp_grid,   only: cfl_cresp_violation
-      use initcrspectrum, only: cfl_cre
-#endif /* COSM_RAY_ELECTRONS */
 
       implicit none
 

--- a/src/fluids/cosmicrays/timestep_cresp.F90
+++ b/src/fluids/cosmicrays/timestep_cresp.F90
@@ -36,9 +36,9 @@ module timestep_cresp
    implicit none
 
    private
-   public :: dt_cre, cresp_timestep, dt_cre_synch, dt_cre_adiab, dt_cre_K, dt_spectrum, cresp_reaction_to_redo_step, dt_cresp_bck, cresp_timestep_cell
+   public :: dt_cre, cresp_timestep, dt_cre_synch, dt_cre_adiab, dt_cre_K, cresp_timestep_cell
 
-   real :: dt_cre, dt_cre_synch, dt_cre_adiab, dt_cre_K, dt_spectrum, dt_cresp_bck
+   real :: dt_cre, dt_cre_synch, dt_cre_adiab, dt_cre_K
 
 contains
 
@@ -71,7 +71,6 @@ contains
       dt_cre_K     = big
       dt_cre_synch = big
       dt_cre_adiab = big
-      dt_spectrum  = big
 
       if (.not. use_cresp_evol) return
 
@@ -125,14 +124,14 @@ contains
       call piernik_MPI_Allreduce(dt_cre_synch, pMIN)
       call piernik_MPI_Allreduce(dt_cre_K,     pMIN)
 
-      dt_spectrum = min(dt_cre_adiab, dt_cre_synch)
+      dt_cre = min(dt_cre_adiab, dt_cre_synch)
 
       if (cresp_substep) then
       ! with cresp_substep enabled, dt_cre_adiab and dt_cre_synch are used only within CRESP module for substepping
       ! half * dt_spectrum * n_substeps_max tries to prevent number of substeps from exceeding n_substeps_max limit
-         dt_cre = min(dt_spectrum * max(n_substeps_max-I_ONE, I_ONE), dt_cre_K)  ! number of substeps with dt_spectrum limited by n_substeps_max
+         dt_cre = min(dt_cre * max(n_substeps_max-I_ONE, I_ONE), dt_cre_K)  ! number of substeps with dt_spectrum limited by n_substeps_max
       else
-         dt_cre = min(dt_spectrum, dt_cre_K)                   ! dt comes in to cresp_crspectrum with factor * 2
+         dt_cre = min(dt_cre, dt_cre_K)                   ! dt comes in to cresp_crspectrum with factor * 2
       endif
 
    end subroutine cresp_timestep
@@ -173,40 +172,9 @@ contains
    end subroutine cresp_timestep_synchrotron
 
 !----------------------------------------------------------------------------------------------------
-
-   subroutine cresp_reaction_to_redo_step
-
-      use dataio_pub,      only: msg, warn
-      use global,          only: cfl_violated, dt_shrink, repeat_step, tstep_attempt
-      use initcrspectrum,  only: cresp_substep
-      use mpisetup,        only: master
-
-      implicit none
-
-      if (.not. repeat_step) return
-
-      if (cfl_violated) then
-         if (cresp_substep) then
-            dt_spectrum = dt_spectrum * (dt_shrink ** tstep_attempt) ! If dt is repeated, dt_spectrum should follow, this way seems legit
-
-            if (master) then
-               write (msg, "(A72,E14.7)") "[timestep_cresp:cresp_reaction_to_redo_step] (repeat step) shrinking dt_spectrum = ", dt_spectrum
-               call warn(msg)
-            endif
-
-         else
-            return   !< if .not. cresp_substep, no other than default reactions necessary
-         endif
-      else
-         return      !< no action necessary if CFL not violated
-      endif
-
-   end subroutine cresp_reaction_to_redo_step
-
-!----------------------------------------------------------------------------------------------------
 !! \brief This subroutine returns timestep for cell at (i,j,k) position, with already prepared u_b and u_d values.
 
-   subroutine cresp_timestep_cell(b, dt_cell, empty_cell)
+   subroutine cresp_timestep_cell(p_loss_terms, dt_cell, empty_cell)
 
       use initcrspectrum,     only: adiab_active, cresp, synch_active, spec_mod_trms
       use cresp_crspectrum,   only: cresp_find_prepare_spectrum
@@ -214,7 +182,7 @@ contains
 
       implicit none
 
-      type(spec_mod_trms), intent(in) :: b
+      type(spec_mod_trms), intent(in) :: p_loss_terms
       real,               intent(out) :: dt_cell
       logical,            intent(out) :: empty_cell
       integer(kind=4)                 :: i_up_cell
@@ -228,8 +196,8 @@ contains
       call cresp_find_prepare_spectrum(cresp%n, cresp%e, empty_cell, i_up_cell) ! needed for synchrotron timestep
 
       if (.not. empty_cell) then
-         if (synch_active) call cresp_timestep_synchrotron(b%ub, i_up_cell)
-         if (adiab_active) call cresp_timestep_adiabatic(b%ud)
+         if (synch_active) call cresp_timestep_synchrotron(p_loss_terms%ub, i_up_cell)
+         if (adiab_active) call cresp_timestep_adiabatic(p_loss_terms%ud)
       else
          return
       endif


### PR DESCRIPTION
Reduce cfl_cresp_violation across all grids, remove redundant timestep-related instructions.