### PR TITLE
Fix SIGSEGV in initproblem for mcrtest_cresp

### DIFF
--- a/problems/mcrtest/mcrtest_cresp/initproblem.F90
+++ b/problems/mcrtest/mcrtest_cresp/initproblem.F90
@@ -178,7 +178,7 @@ contains
 #ifdef COSM_RAY_ELECTRONS
       use cresp_crspectrum, only: cresp_get_scaled_init_spectrum
       use initcosmicrays,   only: iarr_cre_e, iarr_cre_n
-      use initcrspectrum,   only: expan_order, smallcree, cresp, cre_eff
+      use initcrspectrum,   only: expan_order, smallcree, cresp, cre_eff, use_cresp
 #endif /* COSM_RAY_ELECTRONS */
 
       implicit none
@@ -288,7 +288,7 @@ contains
 #ifdef COSM_RAY_ELECTRONS
 ! Explosions @CRESP independent of cr nucleons
                   e_tot = amp_cr1 * cre_eff * decr
-                  if (e_tot > smallcree) then
+                  if (e_tot > smallcree .and. use_cresp) then
                      cresp%n = 0.0 ;  cresp%e = 0.0
                      call cresp_get_scaled_init_spectrum(cresp%n, cresp%e, e_tot)
                      cg%u(iarr_cre_n,i,j,k) = cg%u(iarr_cre_n,i,j,k) + cresp%n

--- a/problems/mcrtest/mcrtest_cresp/initproblem.F90
+++ b/problems/mcrtest/mcrtest_cresp/initproblem.F90
@@ -335,7 +335,7 @@ contains
       enddo
 #ifdef COSM_RAY_ELECTRONS
       write(msg,*) '[initproblem:problem_initial_conditions]: Taylor_exp._ord. (cresp)    = ', expan_order
-      call printinfo(msg)
+      if (master) call printinfo(msg)
 #endif /* COSM_RAY_ELECTRONS */
 
    end subroutine problem_initial_conditions

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -470,7 +470,7 @@ contains
       use mpisetup,      only: master, slave
       use version,       only: env, nenv
 #ifdef COSM_RAY_ELECTRONS
-      use initcrspectrum,  only: write_cresp_to_restart
+      use initcrspectrum,  only: write_cresp_to_restart, use_cresp
       use cresp_io,        only: create_cresp_smap_fields
       use cresp_NR_method, only: cresp_write_smaps_to_hdf
 #endif /* COSM_RAY_ELECTRONS */
@@ -558,8 +558,10 @@ contains
       call write_snsources_to_restart(file_id)
 #endif /* SN_SRC */
 #ifdef COSM_RAY_ELECTRONS
-      call create_cresp_smap_fields(file_id) ! create "/cresp/smaps_{LO,UP}/..."
-      call cresp_write_smaps_to_hdf(file_id) ! create "/cresp/smaps_{LO,UP}/{p_f}_ratio"
+      if (use_cresp) then
+         call create_cresp_smap_fields(file_id) ! create "/cresp/smaps_{LO,UP}/..."
+         call cresp_write_smaps_to_hdf(file_id) ! create "/cresp/smaps_{LO,UP}/{p_f}_ratio"
+      endif
 #endif /* COSM_RAY_ELECTRONS */
       if (associated(user_attrs_wr)) call user_attrs_wr(file_id)
 

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -419,7 +419,7 @@ contains
 ! Input parameters check
       if (use_cresp .and. ncre <= I_ZERO)  then
          write (msg,"(A,I4,A)") '[initcrspectrum:init_cresp] ncre   = ', ncre, '; cr-electrons NOT initnialized. Switching CRESP module off.'
-         call warn(msg)
+         if (master) call warn(msg)
          use_cresp      = .false.
          use_cresp_evol = .false.
          ncre           = 0


### PR DESCRIPTION
In mcrtest_cresp test problem, when setting ncre = 0, the module is switched off and is not being initialized. In mcrtest_cresp problem file, initproblem.F90, a check for 'use_cresp' was overlooked which resulted in segmentation fault. This is fixed by importing 'use_cresp' and checking it during initialization.