### PR TITLE
Organize CRESP flags and solution map reading from restart.

### DIFF
--- a/src/IO/hdf5/restart_hdf5_v1.F90
+++ b/src/IO/hdf5/restart_hdf5_v1.F90
@@ -490,6 +490,7 @@ contains
       use snsources,        only: nsn
 #endif /* SN_SRC */
 #ifdef COSM_RAY_ELECTRONS
+      use initcrspectrum,  only: use_cresp
       use cresp_NR_method, only: cresp_read_smaps_from_hdf
 #endif /* COSM_RAY_ELECTRONS */
 
@@ -587,7 +588,7 @@ contains
       call h5pclose_f(plist_id, error)
 
 #ifdef COSM_RAY_ELECTRONS
-      call cresp_read_smaps_from_hdf(file_id)
+      if (use_cresp) call cresp_read_smaps_from_hdf(file_id)
 #endif /* COSM_RAY_ELECTRONS */
 
       ! set up things such as register user rank-3 and rank-4 arrays to be read by read_arr_from_restart. Read also anything that is not read by all read_arr_from_restart calls

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -611,6 +611,7 @@ contains
       use multigrid_gravity,  only: read_oldsoln_from_restart
 #endif /* MULTIGRID && SELF_GRAV */
 #ifdef COSM_RAY_ELECTRONS
+      use initcrspectrum,  only: use_cresp
       use cresp_NR_method, only: cresp_read_smaps_from_hdf
 #endif /* COSM_RAY_ELECTRONS */
 
@@ -877,7 +878,7 @@ contains
       call set_refinement(cg_res)
 
 #ifdef COSM_RAY_ELECTRONS
-      call cresp_read_smaps_from_hdf(file_id)
+      if (use_cresp) call cresp_read_smaps_from_hdf(file_id)
 #endif /* COSM_RAY_ELECTRONS */
 
       ! set up things such as register user rank-3 and rank-4 arrays to be read by read_arr_from_restart. Read also anything that is not read by all read_cg_from_restart calls

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -425,7 +425,10 @@ contains
          ncre           = 0
       endif
 
-      if (.not. use_cresp) return
+      if (.not. use_cresp) then
+         use_cresp_evol = .false.
+         return
+      endif
 
       if (ncre < 3) call die("[initcrspectrum:init_cresp] CRESP algorithm currently requires at least 3 bins (ncre) in order to work properly, check your parameters.")
 

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -426,6 +426,7 @@ contains
       endif
 
       if (.not. use_cresp) then
+         if (master) call warn("[initcrspectrum:init_cresp] Switching 'use_cresp_evol' off: superior 'use_cresp' is switched off.") ! TODO die instead?
          use_cresp_evol = .false.
          return
       endif

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -426,7 +426,7 @@ contains
       endif
 
       if (.not. use_cresp) then
-         if (master) call warn("[initcrspectrum:init_cresp] Switching 'use_cresp_evol' off: superior 'use_cresp' is switched off.") ! TODO die instead?
+         if (master) call warn("[initcrspectrum:init_cresp] Switching 'use_cresp_evol' off: superior 'use_cresp' is switched off.")
          use_cresp_evol = .false.
          return
       endif


### PR DESCRIPTION
If compiled, CRESP is by default switched on. Switching it off is possible via setting ncre to 0 or declaring use_cresp = .false.; it can additionally be partially switched off via use_cresp_evol = .false. (e.g. module and spectrum initialized and spatially propagated, but not spectrally evolved). If use_cresp = .false. the module should not be initialized and no related action should be taken.
This PR disallows use_cresp_evol and reading solution maps (used in the module) from restart file in such case.