### PR TITLE
Fixups and cosmetics

### DIFF
--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -633,9 +633,9 @@ contains
          select case (trim(umsg))
 #ifdef HDF5
             case ('res', 'dump')
-               call write_restart_hdf5
+               call write_restart_hdf5(.false.)
             case ('hdf')
-               call write_hdf5
+               call write_hdf5(.false.)
 #endif /* HDF5 */
             case ('log')
                call write_log
@@ -775,20 +775,20 @@ contains
 #ifdef HDF5
       call determine_dump(dump(RES), last_res_time, dt_res, output, RES)
       call manage_hdf_dump(RES, dump(RES), output)
-      if (dump(RES)) call write_restart_hdf5
+      if (dump(RES)) call write_restart_hdf5(.true.)
 
       if (wdt_res > 0.0) then
          if (master) tleft = walltime_nextres%time_left()
          call piernik_MPI_Bcast(tleft)
          if (.not.tleft) then
-            call write_restart_hdf5
+            call write_restart_hdf5(.false.)
             if (master) tleft = walltime_nextres%time_left(wdt_res)
          endif
       endif
 
       call determine_dump(dump(HDF), last_hdf_time, dt_hdf, output, HDF)
       call manage_hdf_dump(HDF, dump(HDF), output)
-      if (dump(HDF)) call write_hdf5
+      if (dump(HDF)) call write_hdf5(.true.)
 #endif /* HDF5 */
       if (associated(user_post_write_data)) call user_post_write_data(output, dump)
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -175,7 +175,7 @@ contains
       use constants,  only: cwdlen, PIERNIK_INIT_MPI, INVALID
       use dataio_pub, only: nrestart, last_hdf_time, last_res_time, last_tsl_time, last_log_time, log_file_initialized, &
            &                tmp_log_file, printinfo, printio, warn, msg, die, code_progress, log_wr, restarted_sim, &
-           &                move_file, parfile, parfilelines, log_file, maxparfilelines, can_i_write, ierrh, par_file
+           &                move_file, parfile, parfilelines, log_file, maxparlen, maxparfilelines, can_i_write, ierrh, par_file
       use mpisetup,   only: master, nproc, proc, piernik_MPI_Bcast, piernik_MPI_Barrier, FIRST, LAST
 
       implicit none
@@ -208,6 +208,7 @@ contains
          enddo
          close(par_lun)
          if (parfilelines == maxparfilelines) call warn("[dataio:init_dataio_parameters] problem.par has too many lines. The copy in the logfile and HDF dumps can be truncated.")
+         maxparlen = int(maxval(len_trim(parfile(:parfilelines))), kind=4)
       endif
 
       ! For 1 /= nproc_io /= nproc there should be choice between two strategies : nproc < nproc_io and the current one
@@ -502,12 +503,12 @@ contains
    subroutine init_dataio
 
       use constants,    only: PIERNIK_INIT_IO_IC
-      use dataio_pub,   only: code_progress, die, nres, nrestart, printinfo, restarted_sim, warn
+      use dataio_pub,   only: code_progress, die, maxenvlen, nres, nrestart, printinfo, restarted_sim, warn
       use domain,       only: dom
       use mpisetup,     only: master
       use timer,        only: walltime_end
       use user_hooks,   only: user_vars_arr_in_restart
-      use version,      only: nenv,env, init_version
+      use version,      only: nenv, env, init_version
 #ifdef HDF5
       use common_hdf5,  only: init_hdf5
       use data_hdf5,    only: init_data
@@ -555,6 +556,7 @@ contains
             call printinfo(env(i), .false.)
          enddo
       endif
+      maxenvlen = int(maxval(len_trim(env(:nenv))), kind=4)
 
       if (associated(user_vars_arr_in_restart)) call user_vars_arr_in_restart
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -1815,9 +1815,9 @@ contains
          call cgl%cg%costs%start
 
 #ifdef COSM_RAY_ELECTRONS
-         cgl%cg%wa        = sum(cgl%cg%u(iarr_all_crn,:,:,:),1)
+         cgl%cg%wa = sum(cgl%cg%u(iarr_all_crn,:,:,:),1)
 #else /* !COSM_RAY_ELECTRONS */
-         cgl%cg%wa        = sum(cgl%cg%u(iarr_all_crs,:,:,:),1)
+         cgl%cg%wa = sum(cgl%cg%u(iarr_all_crs,:,:,:),1)
 #endif /* !COSM_RAY_ELECTRONS */
 
          call cgl%cg%costs%stop(I_OTHER)

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -102,6 +102,8 @@ module dataio_pub
    character(len=maxparfilelen), allocatable, dimension(:) :: parfile !< contents of the parameter file
    character(len=msglen), allocatable, dimension(:) :: logbuffer !< buffer for log I/O
    integer, save               :: parfilelines = 0               !< number of lines in the parameter file
+   integer(kind=4)             :: maxparlen                      !< max length of parfile lines
+   integer(kind=4)             :: maxenvlen                      !< max length of env array
 
    logical, save               :: halfstep = .false.             !< true when X-Y-Z sweeps are done and Z-Y-X are not
    logical, save               :: log_file_initialized = .false. !< logical to mark initialization of logfile

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -44,7 +44,8 @@ module common_hdf5
    public :: hdf_vars, hdf_vars_avail, cancel_hdf_var, d_gname, base_d_gname, d_fc_aname, d_size_aname, &
         d_edge_apname, d_bnd_apname, cg_gname, cg_cnt_aname, cg_lev_aname, cg_size_aname, cg_offset_aname, &
         n_cg_name, dir_pref, cg_ledge_aname, cg_redge_aname, cg_dl_aname, O_OUT, O_RES, STAT_OK, STAT_INV, &
-        create_empty_cg_dataset, get_nth_cg, data_gname, output_fname, cg_output, enable_all_hdf_var, dump_announcement
+        create_empty_cg_dataset, get_nth_cg, data_gname, output_fname, cg_output, enable_all_hdf_var, &
+        dump_announcement, dump_announce_time
 #ifdef NBODY_1FILE
    public ::  part_types_gname, part_gname, st_gname
 #endif /* NBODY_1FILE */
@@ -1310,10 +1311,11 @@ contains
 
    subroutine dump_announcement(dumptype, fname, last_dump_time, phv, sequential)
 
-      use constants,  only: fnamelen
-      use dataio_pub, only: msg, printio
+      use constants,  only: fnamelen, tmr_hdf
+      use dataio_pub, only: msg, printio, thdf
       use global,     only: t
       use mpisetup,   only: master
+      use timer,      only: set_timer
 
       implicit none
 
@@ -1322,6 +1324,8 @@ contains
       real,                    intent(in) :: last_dump_time
       real,                    intent(in) :: phv
       logical,                 intent(in) :: sequential
+
+      thdf = set_timer(tmr_hdf,.true.)
 
       if (.not. master) return
 
@@ -1333,6 +1337,23 @@ contains
       call printio(msg, .true.)
 
    end subroutine dump_announcement
+
+   subroutine dump_announce_time
+
+      use constants,  only: tmr_hdf
+      use dataio_pub, only: msg, printinfo, thdf
+      use mpisetup,   only: master
+      use timer,      only: set_timer
+
+      implicit none
+
+      thdf = set_timer(tmr_hdf)
+      if (master) then
+         write(msg,'(a6,f10.2,a2)') ' done ', thdf, ' s'
+         call printinfo(msg, .true.)
+      endif
+
+   end subroutine dump_announce_time
 
 #ifdef NBODY_1FILE
    subroutine initialize_write_cg(this, cgl_g_id, cg_n, nproc_io, dsets, pdsets)

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -44,7 +44,7 @@ module common_hdf5
    public :: hdf_vars, hdf_vars_avail, cancel_hdf_var, d_gname, base_d_gname, d_fc_aname, d_size_aname, &
         d_edge_apname, d_bnd_apname, cg_gname, cg_cnt_aname, cg_lev_aname, cg_size_aname, cg_offset_aname, &
         n_cg_name, dir_pref, cg_ledge_aname, cg_redge_aname, cg_dl_aname, O_OUT, O_RES, STAT_OK, STAT_INV, &
-        create_empty_cg_dataset, get_nth_cg, data_gname, output_fname, cg_output, enable_all_hdf_var
+        create_empty_cg_dataset, get_nth_cg, data_gname, output_fname, cg_output, enable_all_hdf_var, dump_announcement
 #ifdef NBODY_1FILE
    public ::  part_types_gname, part_gname, st_gname
 #endif /* NBODY_1FILE */
@@ -1307,6 +1307,32 @@ contains
       endif
 
    end function output_fname
+
+   subroutine dump_announcement(dumptype, fname, last_dump_time, phv, sequential)
+
+      use constants,  only: fnamelen
+      use dataio_pub, only: msg, printio
+      use global,     only: t
+      use mpisetup,   only: master
+
+      implicit none
+
+      character(len=*),        intent(in) :: dumptype
+      character(len=fnamelen), intent(in) :: fname
+      real,                    intent(in) :: last_dump_time
+      real,                    intent(in) :: phv
+      logical,                 intent(in) :: sequential
+
+      if (.not. master) return
+
+      if (sequential) then
+         write(msg,'(a,es23.16,a,a,a,f5.2,1x,2a)') 'ordered t ', last_dump_time, ': Writing ', dumptype, ' v', phv, trim(fname), " ... "
+      else
+         write(msg,'(a,es23.16,a,a,a,f5.2,1x,2a)') 'requested at t ', t, ': Writing ', dumptype, ' v', phv, trim(fname), " ... "
+      endif
+      call printio(msg, .true.)
+
+   end subroutine dump_announcement
 
 #ifdef NBODY_1FILE
    subroutine initialize_write_cg(this, cgl_g_id, cg_n, nproc_io, dsets, pdsets)

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -126,7 +126,7 @@ contains
       integer                                              :: i
       character(len=singlechar)                            :: fc, ord
       character(len=dsetnamelen)                           :: aux
-#if defined COSM_RAYS
+#ifdef COSM_RAYS
       integer                                              :: k
 #endif /* COSM_RAYS */
 

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -1311,7 +1311,7 @@ contains
 
    subroutine dump_announcement(dumptype, fname, last_dump_time, sequential)
 
-      use constants,  only: fnamelen, tmr_hdf, RES
+      use constants,  only: fnamelen, tmr_hdf, I_SEVEN, RES
       use dataio_pub, only: msg, printio, thdf, multiple_h5files, piernik_hdf5_version, piernik_hdf5_version2, use_v2_io
       use global,     only: t
       use mpisetup,   only: master
@@ -1319,12 +1319,12 @@ contains
 
       implicit none
 
-      integer(kind=4),               intent(in) :: dumptype
-      character(len=fnamelen),       intent(in) :: fname
-      real,                          intent(in) :: last_dump_time
-      logical,                       intent(in) :: sequential
-      character(len=7), dimension(2), parameter :: dumpname = ['restart', 'dataset']
-      real                                      :: phv
+      integer(kind=4),                     intent(in) :: dumptype
+      character(len=fnamelen),             intent(in) :: fname
+      real,                                intent(in) :: last_dump_time
+      logical,                             intent(in) :: sequential
+      character(len=I_SEVEN), dimension(2), parameter :: dumpname = ['restart', 'dataset']
+      real                                            :: phv
 
       thdf = set_timer(tmr_hdf,.true.)
 

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -1332,7 +1332,7 @@ contains
       implicit none
 
       integer(kind=4),                     intent(in)    :: dumptype
-      integer,                             intent(inout) :: nio
+      integer(kind=4),                     intent(inout) :: nio
       character(len=cwdlen),               intent(out)   :: fname
       real,                                intent(in)    :: last_dump_time
       logical,                             intent(in)    :: sequential

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -1309,30 +1309,34 @@ contains
 
    end function output_fname
 
-   subroutine dump_announcement(dumptype, fname, last_dump_time, phv, sequential)
+   subroutine dump_announcement(dumptype, fname, last_dump_time, sequential)
 
-      use constants,  only: fnamelen, tmr_hdf
-      use dataio_pub, only: msg, printio, thdf
+      use constants,  only: fnamelen, tmr_hdf, RES
+      use dataio_pub, only: msg, printio, thdf, multiple_h5files, piernik_hdf5_version, piernik_hdf5_version2, use_v2_io
       use global,     only: t
       use mpisetup,   only: master
       use timer,      only: set_timer
 
       implicit none
 
-      character(len=*),        intent(in) :: dumptype
-      character(len=fnamelen), intent(in) :: fname
-      real,                    intent(in) :: last_dump_time
-      real,                    intent(in) :: phv
-      logical,                 intent(in) :: sequential
+      integer(kind=4),               intent(in) :: dumptype
+      character(len=fnamelen),       intent(in) :: fname
+      real,                          intent(in) :: last_dump_time
+      logical,                       intent(in) :: sequential
+      character(len=7), dimension(2), parameter :: dumpname = ['restart', 'dataset']
+      real                                      :: phv
 
       thdf = set_timer(tmr_hdf,.true.)
 
       if (.not. master) return
 
+      phv = piernik_hdf5_version
+      if (use_v2_io .and. (dumptype == RES .or. .not. multiple_h5files)) phv = piernik_hdf5_version2
+
       if (sequential) then
-         write(msg,'(a,es23.16,a,a,a,f5.2,1x,2a)') 'ordered t ', last_dump_time, ': Writing ', dumptype, ' v', phv, trim(fname), " ... "
+         write(msg,'(a,es23.16,a,a,a,f5.2,1x,2a)') 'ordered t ', last_dump_time, ': Writing ', dumpname(dumptype), ' v', phv, trim(fname), " ... "
       else
-         write(msg,'(a,es23.16,a,a,a,f5.2,1x,2a)') 'requested at t ', t, ': Writing ', dumptype, ' v', phv, trim(fname), " ... "
+         write(msg,'(a,es23.16,a,a,a,f5.2,1x,2a)') 'requested at t ', t, ': Writing ', dumpname(dumptype), ' v', phv, trim(fname), " ... "
       endif
       call printio(msg, .true.)
 

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -39,8 +39,9 @@ module data_hdf5
    public :: init_data, write_hdf5, gdf_translate
 
    interface
-      subroutine h5_write
+      subroutine h5_write(sequential)
          implicit none
+         logical, intent(in) :: sequential
       end subroutine h5_write
    end interface
 
@@ -544,12 +545,13 @@ contains
 !
 ! ------------------------------------------------------------------------------------
 !
-   subroutine h5_write_to_single_file
+   subroutine h5_write_to_single_file(sequential)
 
       use common_hdf5,     only: set_common_attributes
       use constants,       only: cwdlen, I_ONE, tmr_hdf, PPP_IO
       use dataio_pub,      only: printio, printinfo, nhdf, thdf, wd_wr, piernik_hdf5_version, piernik_hdf5_version2, &
          &                       msg, run_id, problem_name, use_v2_io, last_hdf_time
+      use global,          only: t
       use mpisetup,        only: master, piernik_MPI_Bcast, report_to_master, report_string_to_master
       use piernik_mpi_sig, only: sig
       use ppp,             only: ppp_main
@@ -563,6 +565,7 @@ contains
 
       implicit none
 
+      logical,         intent(in) :: sequential
       character(len=cwdlen)       :: fname
       real                        :: phv
       character(len=*), parameter :: wrd_label = "IO_write_datafile_v1"
@@ -575,7 +578,11 @@ contains
       phv = piernik_hdf5_version ; if (use_v2_io) phv = piernik_hdf5_version2
       if (master) then
          write(fname, '(2a,a1,a3,a1,i4.4,a3)') trim(wd_wr), trim(problem_name),"_", trim(run_id),"_", nhdf,".h5" !> \todo: merge with function restart_fname()
-         write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'ordered t ',last_hdf_time,': Writing datafile v', phv, trim(fname), " ... "
+         if (sequential) then
+            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'ordered t ', last_hdf_time,': Writing datafile v', phv, trim(fname), " ... "
+         else
+            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'requested at t ', t,': Writing datafile v', phv, trim(fname), " ... "
+         endif
          call printio(msg, .true.)
       endif
       call piernik_MPI_Bcast(fname, cwdlen)
@@ -1110,13 +1117,14 @@ contains
       write(f, '(2a,"_",a3,i4.4,".cpu",i5.5,".h5")') trim(wd_wr), trim(problem_name), trim(run_id), nhdf, proc
    end function h5_filename
 
-   subroutine h5_write_to_multiple_files
+   subroutine h5_write_to_multiple_files(sequential)
 
       use cg_leaves,   only: leaves
       use cg_list,     only: cg_list_element
       use common_hdf5, only: hdf_vars, hdf_vars_avail
       use constants,   only: dsetnamelen, fnamelen, xdim, ydim, zdim, I_ONE, tmr_hdf
       use dataio_pub,  only: msg, printio, printinfo, thdf, last_hdf_time, piernik_hdf5_version
+      use global,      only: t
       use grid_cont,   only: grid_container
       use h5lt,        only: h5ltmake_dataset_double_f
       use hdf5,        only: H5F_ACC_TRUNC_F, h5fcreate_f, h5open_f, h5fclose_f, h5close_f, HID_T, h5gcreate_f, h5gclose_f, HSIZE_T
@@ -1125,6 +1133,7 @@ contains
 
       implicit none
 
+      logical,               intent(in) :: sequential
       type(cg_list_element), pointer    :: cgl
       type(grid_container),  pointer    :: cg
       integer(kind=4), parameter        :: rank = 3
@@ -1139,7 +1148,11 @@ contains
       thdf = set_timer(tmr_hdf,.true.)
       fname = h5_filename()
       if (master) then
-         write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'ordered t ',last_hdf_time,': Writing datafile v', piernik_hdf5_version, trim(fname), " ... "
+         if (sequential) then
+            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'ordered t ', last_hdf_time,': Writing datafile v', piernik_hdf5_version, trim(fname), " ... "
+         else
+            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'requested at t ', t,': Writing datafile v', piernik_hdf5_version, trim(fname), " ... "
+         endif
          call printio(msg, .true.)
       endif
 

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -55,7 +55,6 @@ contains
 
       implicit none
 
-      write(*,*) 'INIT_DATA: ', multiple_h5files, use_v2_io
       if (multiple_h5files) then
          write_hdf5 => h5_write_to_multiple_files
          if (use_v2_io) call warn('[data_hdf5:init_data] v2 I/O format for multiple h5 files not available')

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -338,18 +338,18 @@ contains
 
       implicit none
 
-      character(len=dsetnamelen),     intent(in)  :: var
-      real, dimension(:,:,:),         intent(out) :: tab
-      integer,                        intent(out) :: ierrh
-      type(grid_container),  pointer, intent(in)  :: cg
+      character(len=dsetnamelen),      intent(in)    :: var
+      real, dimension(:,:,:), pointer, intent(inout) :: tab
+      integer,                         intent(out)   :: ierrh
+      type(grid_container),   pointer, intent(in)    :: cg
 
-      class(component_fluid), pointer             :: fl_dni, fl_mach
-      integer(kind=4)                             :: i_xyz
-      integer                                     :: ii, jj, kk
+      class(component_fluid), pointer                :: fl_dni, fl_mach
+      integer(kind=4)                                :: i_xyz
+      integer                                        :: ii, jj, kk
 #ifdef COSM_RAYS
-      integer                                     :: i
-      integer, parameter                          :: auxlen = dsetnamelen - 1
-      character(len=auxlen)                       :: aux
+      integer                                        :: i
+      integer, parameter                             :: auxlen = dsetnamelen - 1
+      character(len=auxlen)                          :: aux
 #endif /* COSM_RAYS */
 
       call common_shortcuts(var, fl_dni, i_xyz)
@@ -992,7 +992,7 @@ contains
       integer(kind=4)                   :: error                   !< error perhaps should be of type integer(HID_T)
       type(cg_list_element), pointer    :: cgl
       type(grid_container),  pointer    :: cg
-      real, pointer                     :: data (:,:,:)            !< Data to write
+      real, dimension(:,:,:), pointer   :: data                    !< Data to write
       integer(kind=4), parameter        :: rank = ndims            !< Dataset rank = 3
       integer(HID_T)                    :: dset_id                 !< Dataset identifier
       integer(HID_T)                    :: filespace               !< Dataspace identifier in file
@@ -1099,7 +1099,8 @@ contains
       use mpisetup,   only: proc
       implicit none
       character(len=fnamelen) :: f
-      write(f, '(2a,"_",a3,i4.4,".cpu",i5.5,".h5")') trim(wd_wr), trim(problem_name), trim(run_id), nhdf, proc
+      nhdf = nhdf + 1
+      write(f, '(2a,"_",a3,"_",i4.4,".cpu",i5.5,".h5")') trim(wd_wr), trim(problem_name), trim(run_id), nhdf, proc
    end function h5_filename
 
    subroutine h5_write_to_multiple_files(sequential)
@@ -1125,7 +1126,7 @@ contains
       integer(HSIZE_T), dimension(rank) :: dims
       character(len=dsetnamelen)        :: gname
       character(len=fnamelen)           :: fname
-      real, pointer                     :: data (:,:,:)     !< Data to write
+      real, dimension(:,:,:), pointer   :: data             !< Data to write
 
       fname = h5_filename()
       call dump_announcement(HDF, fname, last_hdf_time, sequential)
@@ -1134,6 +1135,7 @@ contains
       call h5fcreate_f(fname, H5F_ACC_TRUNC_F, file_id, error)
       cgl => leaves%first
       ngc = 0
+      nullify(data)
       do while (associated(cgl))
          cg => cgl%cg
 

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -52,12 +52,13 @@ contains
    subroutine init_data
 
       use dataio_pub, only: multiple_h5files, use_v2_io, warn
+      use mpisetup,   only: master
 
       implicit none
 
       if (multiple_h5files) then
          write_hdf5 => h5_write_to_multiple_files
-         if (use_v2_io) call warn('[data_hdf5:init_data] v2 I/O format for multiple h5 files not available')
+         if (use_v2_io .and. master) call warn('[data_hdf5:init_data] v2 I/O format for multiple h5 files not available')
       else
          write_hdf5 => h5_write_to_single_file
       endif

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -547,14 +547,13 @@ contains
 !
    subroutine h5_write_to_single_file(sequential)
 
-      use common_hdf5,     only: dump_announcement, set_common_attributes
-      use constants,       only: cwdlen, I_ONE, tmr_hdf, PPP_IO
-      use dataio_pub,      only: printinfo, nhdf, thdf, wd_wr, piernik_hdf5_version, piernik_hdf5_version2, &
-         &                       msg, run_id, problem_name, use_v2_io, last_hdf_time
+      use common_hdf5,     only: dump_announcement, dump_announce_time, set_common_attributes
+      use constants,       only: cwdlen, I_ONE, PPP_IO
+      use dataio_pub,      only: nhdf, wd_wr, piernik_hdf5_version, piernik_hdf5_version2, &
+         &                       run_id, problem_name, use_v2_io, last_hdf_time
       use mpisetup,        only: master, piernik_MPI_Bcast, report_to_master, report_string_to_master
       use piernik_mpi_sig, only: sig
       use ppp,             only: ppp_main
-      use timer,           only: set_timer
 #if defined(MULTIGRID) && defined(SELF_GRAV)
       use multigrid_gravity, only: unmark_oldsoln
 #endif /* MULTIGRID && SELF_GRAV */
@@ -570,7 +569,6 @@ contains
       character(len=*), parameter :: wrd_label = "IO_write_datafile_v1"
 
       call ppp_main%start(wrd_label, PPP_IO)
-      thdf = set_timer(tmr_hdf,.true.)
       nhdf = nhdf + I_ONE
       ! Initialize HDF5 library and Fortran interfaces.
       !
@@ -589,11 +587,7 @@ contains
       call unmark_oldsoln
 #endif /* MULTIGRID && SELF_GRAV */
 
-      thdf = set_timer(tmr_hdf)
-      if (master) then
-         write(msg,'(a6,f10.2,a2)') ' done ', thdf, ' s'
-         call printinfo(msg, .true.)
-      endif
+      call dump_announce_time
       call report_to_master(sig%hdf_written, only_master=.True.)
       call report_string_to_master(fname, only_master=.True.)
 #ifdef NBODY_1FILE
@@ -1113,14 +1107,12 @@ contains
 
       use cg_leaves,   only: leaves
       use cg_list,     only: cg_list_element
-      use common_hdf5, only: dump_announcement, hdf_vars, hdf_vars_avail
-      use constants,   only: dsetnamelen, fnamelen, xdim, ydim, zdim, I_ONE, tmr_hdf
-      use dataio_pub,  only: msg, printinfo, thdf, last_hdf_time, piernik_hdf5_version
+      use common_hdf5, only: dump_announcement, dump_announce_time, hdf_vars, hdf_vars_avail
+      use constants,   only: dsetnamelen, fnamelen, xdim, ydim, zdim, I_ONE
+      use dataio_pub,  only: last_hdf_time, piernik_hdf5_version
       use grid_cont,   only: grid_container
       use h5lt,        only: h5ltmake_dataset_double_f
       use hdf5,        only: H5F_ACC_TRUNC_F, h5fcreate_f, h5open_f, h5fclose_f, h5close_f, HID_T, h5gcreate_f, h5gclose_f, HSIZE_T
-      use mpisetup,    only: master
-      use timer,       only: set_timer
 
       implicit none
 
@@ -1136,7 +1128,6 @@ contains
       character(len=fnamelen)           :: fname
       real, pointer                     :: data (:,:,:)     !< Data to write
 
-      thdf = set_timer(tmr_hdf,.true.)
       fname = h5_filename()
       call dump_announcement('datafile', fname, last_hdf_time, piernik_hdf5_version, sequential)
 
@@ -1168,11 +1159,7 @@ contains
       call h5fclose_f(file_id, error)
       call h5close_f(error)
 
-      thdf = set_timer(tmr_hdf)
-      if (master) then
-         write(msg,'(a6,f10.2,a2)') ' done ', thdf, ' s'
-         call printinfo(msg, .true.)
-      endif
+      call dump_announce_time
 
    end subroutine h5_write_to_multiple_files
 

--- a/src/IO/hdf5/io_debug.F90
+++ b/src/IO/hdf5/io_debug.F90
@@ -121,13 +121,13 @@ contains
 
       if (force_hdf5_dump) &
 #ifdef HDF5
-           call write_hdf5
+           call write_hdf5(.false.)
 #else /* !HDF5 */
            call warn("[io_debug:force_dumps] no HDF5 available (w)")
 #endif /* !HDF5 */
       if (force_res_dump) &
 #ifdef HDF5
-           call write_restart_hdf5
+           call write_restart_hdf5(.false.)
 #else /* !HDF5 */
            call warn("[io_debug:force_dumps] no HDF5 available (r)")
 #endif /* !HDF5 */

--- a/src/IO/hdf5/restart_hdf5.F90
+++ b/src/IO/hdf5/restart_hdf5.F90
@@ -43,11 +43,12 @@ contains
 !! \brief Wrapper routine that writes a version 2.x or version 1.x restart file, depending on use_v2_io switch
 !<
 
-   subroutine write_restart_hdf5
+   subroutine write_restart_hdf5(sequential)
 
       use common_hdf5,     only: set_common_attributes, output_fname
       use constants,       only: I_ONE, cwdlen, WR, tmr_hdf, PPP_IO
       use dataio_pub,      only: msg, printio, printinfo, thdf, use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
+      use global,          only: t
       use mpisetup,        only: master, piernik_MPI_Barrier
       use ppp,             only: ppp_main
       use restart_hdf5_v1, only: write_restart_hdf5_v1
@@ -59,6 +60,7 @@ contains
 
       implicit none
 
+      logical,   intent(in) :: sequential
       character(len=cwdlen) :: filename  ! File name
       real                  :: phv
       character(len=*), parameter :: wrr_label = "IO_write_restart"
@@ -73,7 +75,11 @@ contains
 
       filename = output_fname(WR,'.res', nres, bcast=.true.)
       if (master) then
-         write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'ordered t ',last_res_time,': Writing restart v', phv, trim(filename), " ... "
+         if (sequential) then
+            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'ordered t ', last_res_time,': Writing restart v', phv, trim(filename), " ... "
+         else
+            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'requested at t ', t,': Writing restart v', phv, trim(filename), " ... "
+         endif
          call printio(msg, .true.)
       endif
       call set_common_attributes(filename)

--- a/src/IO/hdf5/restart_hdf5.F90
+++ b/src/IO/hdf5/restart_hdf5.F90
@@ -45,14 +45,13 @@ contains
 
    subroutine write_restart_hdf5(sequential)
 
-      use common_hdf5,     only: dump_announcement, set_common_attributes, output_fname
-      use constants,       only: I_ONE, cwdlen, WR, tmr_hdf, PPP_IO
-      use dataio_pub,      only: msg, printinfo, thdf, use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
-      use mpisetup,        only: master, piernik_MPI_Barrier
+      use common_hdf5,     only: dump_announcement, dump_announce_time, set_common_attributes, output_fname
+      use constants,       only: I_ONE, cwdlen, WR, PPP_IO
+      use dataio_pub,      only: use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
+      use mpisetup,        only: piernik_MPI_Barrier
       use ppp,             only: ppp_main
       use restart_hdf5_v1, only: write_restart_hdf5_v1
       use restart_hdf5_v2, only: write_restart_hdf5_v2
-      use timer,           only: set_timer
 #if defined(MULTIGRID) && defined(SELF_GRAV)
       use multigrid_gravity, only: unmark_oldsoln
 #endif /* MULTIGRID && SELF_GRAV */
@@ -67,8 +66,6 @@ contains
       call ppp_main%start(wrr_label, PPP_IO)
 
       nres = nres + I_ONE
-
-      thdf = set_timer(tmr_hdf,.true.)
 
       phv = piernik_hdf5_version ; if (use_v2_io) phv = piernik_hdf5_version2
 
@@ -88,11 +85,7 @@ contains
 
       call piernik_MPI_Barrier
 
-      thdf = set_timer(tmr_hdf)
-      if (master) then
-         write(msg,'(a6,f10.2,a2)') ' done ', thdf, ' s'
-         call printinfo(msg, .true.)
-      endif
+      call dump_announce_time
 
       call ppp_main%stop(wrr_label, PPP_IO)
 

--- a/src/IO/hdf5/restart_hdf5.F90
+++ b/src/IO/hdf5/restart_hdf5.F90
@@ -46,8 +46,8 @@ contains
    subroutine write_restart_hdf5(sequential)
 
       use common_hdf5,     only: dump_announcement, dump_announce_time, set_common_attributes, output_fname
-      use constants,       only: I_ONE, cwdlen, WR, PPP_IO
-      use dataio_pub,      only: use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
+      use constants,       only: I_ONE, cwdlen, WR, PPP_IO, RES
+      use dataio_pub,      only: use_v2_io, nres, last_res_time
       use mpisetup,        only: piernik_MPI_Barrier
       use ppp,             only: ppp_main
       use restart_hdf5_v1, only: write_restart_hdf5_v1
@@ -60,17 +60,14 @@ contains
 
       logical,         intent(in) :: sequential
       character(len=cwdlen)       :: filename  ! File name
-      real                        :: phv
       character(len=*), parameter :: wrr_label = "IO_write_restart"
 
       call ppp_main%start(wrr_label, PPP_IO)
 
       nres = nres + I_ONE
 
-      phv = piernik_hdf5_version ; if (use_v2_io) phv = piernik_hdf5_version2
-
       filename = output_fname(WR,'.res', nres, bcast=.true.)
-      call dump_announcement('restart', filename, last_res_time, phv, sequential)
+      call dump_announcement(RES, filename, last_res_time, sequential)
       call set_common_attributes(filename)
 
       if (use_v2_io) then

--- a/src/IO/hdf5/restart_hdf5.F90
+++ b/src/IO/hdf5/restart_hdf5.F90
@@ -45,10 +45,9 @@ contains
 
    subroutine write_restart_hdf5(sequential)
 
-      use common_hdf5,     only: set_common_attributes, output_fname
+      use common_hdf5,     only: dump_announcement, set_common_attributes, output_fname
       use constants,       only: I_ONE, cwdlen, WR, tmr_hdf, PPP_IO
-      use dataio_pub,      only: msg, printio, printinfo, thdf, use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
-      use global,          only: t
+      use dataio_pub,      only: msg, printinfo, thdf, use_v2_io, nres, piernik_hdf5_version, piernik_hdf5_version2, last_res_time
       use mpisetup,        only: master, piernik_MPI_Barrier
       use ppp,             only: ppp_main
       use restart_hdf5_v1, only: write_restart_hdf5_v1
@@ -60,9 +59,9 @@ contains
 
       implicit none
 
-      logical,   intent(in) :: sequential
-      character(len=cwdlen) :: filename  ! File name
-      real                  :: phv
+      logical,         intent(in) :: sequential
+      character(len=cwdlen)       :: filename  ! File name
+      real                        :: phv
       character(len=*), parameter :: wrr_label = "IO_write_restart"
 
       call ppp_main%start(wrr_label, PPP_IO)
@@ -74,14 +73,7 @@ contains
       phv = piernik_hdf5_version ; if (use_v2_io) phv = piernik_hdf5_version2
 
       filename = output_fname(WR,'.res', nres, bcast=.true.)
-      if (master) then
-         if (sequential) then
-            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'ordered t ', last_res_time,': Writing restart v', phv, trim(filename), " ... "
-         else
-            write(msg,'(a,es23.16,a,f5.2,1x,2a)') 'requested at t ', t,': Writing restart v', phv, trim(filename), " ... "
-         endif
-         call printio(msg, .true.)
-      endif
+      call dump_announcement('restart', filename, last_res_time, phv, sequential)
       call set_common_attributes(filename)
 
       if (use_v2_io) then

--- a/src/IO/hdf5/restart_hdf5.F90
+++ b/src/IO/hdf5/restart_hdf5.F90
@@ -45,8 +45,8 @@ contains
 
    subroutine write_restart_hdf5(sequential)
 
-      use common_hdf5,     only: dump_announcement, dump_announce_time, set_common_attributes, output_fname
-      use constants,       only: I_ONE, cwdlen, WR, PPP_IO, RES
+      use common_hdf5,     only: dump_announcement, dump_announce_time, set_common_attributes
+      use constants,       only: cwdlen, PPP_IO, RES
       use dataio_pub,      only: use_v2_io, nres, last_res_time
       use mpisetup,        only: piernik_MPI_Barrier
       use ppp,             only: ppp_main
@@ -64,10 +64,8 @@ contains
 
       call ppp_main%start(wrr_label, PPP_IO)
 
-      nres = nres + I_ONE
+      call dump_announcement(RES, nres, filename, last_res_time, sequential)
 
-      filename = output_fname(WR,'.res', nres, bcast=.true.)
-      call dump_announcement(RES, filename, last_res_time, sequential)
       call set_common_attributes(filename)
 
       if (use_v2_io) then

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -438,7 +438,7 @@ contains
 
       use constants,  only: stdout, cwdlen
       use dataio_pub, only: cmdl_nml, wd_rd, wd_wr, piernik_hdf5_version, piernik_hdf5_version2, log_wr
-      use version,    only: nenv,env, init_version
+      use version,    only: nenv, env, init_version
 
       implicit none
 

--- a/src/fluids/cosmicrays/multigrid_diffusion.F90
+++ b/src/fluids/cosmicrays/multigrid_diffusion.F90
@@ -265,7 +265,6 @@ contains
 !>
 !! \brief Cleanup
 !<
-
    subroutine cleanup_multigrid_diff
 
       implicit none

--- a/src/particles/particle_pub.F90
+++ b/src/particles/particle_pub.F90
@@ -42,8 +42,8 @@ module particle_pub
    public :: init_particles, cleanup_particles
    public :: lf_c, ignore_dt_fluid
 
-   real            :: lf_c               !< timestep should depends of grid and velocities of particles (used to extrapolation of the gravitational potential)
-   logical         :: ignore_dt_fluid    !< option to test only nbody part of the code, never true by default
+   real    :: lf_c               !< timestep should depends of grid and velocities of particles (used to extrapolation of the gravitational potential)
+   logical :: ignore_dt_fluid    !< option to test only nbody part of the code, never true by default
 
 contains
 

--- a/src/scheme/fluidupdate.F90
+++ b/src/scheme/fluidupdate.F90
@@ -227,9 +227,9 @@ contains
       endif
       call ppp_main%stop(sw3_label)
 
-#if defined(GRAV)
+#ifdef GRAV
       need_update = .true.
-#if defined(NBODY)
+#ifdef NBODY
       if (associated(psolver)) call psolver(forward)  ! this will clear need_update it it would call source_terms_grav
 #endif /* NBODY */
       if (need_update) call source_terms_grav
@@ -268,7 +268,7 @@ contains
       integer(kind=4), intent(in) :: dir      !< direction, one of xdim, ydim, zdim
       logical,         intent(in) :: forward  !< if .false. then reverse operation order in the sweep
 
-#if defined(MAGNETIC)
+#ifdef MAGNETIC
       if ((which_solver == RTVD_SPLIT) .and. (divB_0_method /= DIVB_CT)) call die("[fluidupdate:make_sweep] only CT is implemented in RTVD")
 #endif /* MAGNETIC */
 

--- a/src/scheme/fluidupdate.F90
+++ b/src/scheme/fluidupdate.F90
@@ -99,17 +99,10 @@ contains
       use mass_defect,    only: update_magic_mass
       use timestep_retry, only: repeat_fluidstep
 #ifdef COSM_RAY_ELECTRONS
-      use all_boundaries, only: all_fluid_boundaries
       use cresp_grid,     only: cresp_update_grid, cresp_clean_grid
-      use initcrspectrum, only: use_cresp_evol
-      use ppp,            only: ppp_main
 #endif /* COSM_RAY_ELECTRONS */
 
       implicit none
-
-#ifdef COSM_RAY_ELECTRONS
-      character(len=*), parameter :: crug_label = "CRESP_upd_grid", crcg_label = "CRESP_clean_grid"
-#endif /* COSM_RAY_ELECTRONS */
 
       call repeat_fluidstep
       call update_chspeed
@@ -122,12 +115,7 @@ contains
 ! Sources should be hooked to problem_customize_solution with forward argument
 
 #ifdef COSM_RAY_ELECTRONS
-      if (use_cresp_evol) then
-         call ppp_main%start(crug_label)
-         call cresp_update_grid     ! updating number density and energy density of cosmic ray electrons via CRESP module
-         call all_fluid_boundaries
-         call ppp_main%stop(crug_label)
-      endif
+      call cresp_update_grid     ! updating number density and energy density of cosmic ray electrons via CRESP module
 #endif /* COSM_RAY_ELECTRONS */
 
       halfstep = .true.
@@ -137,9 +125,7 @@ contains
       call make_3sweeps(.false.) ! Z -> Y -> X
       call update_magic_mass
 #ifdef COSM_RAY_ELECTRONS
-      call ppp_main%start(crcg_label)
       call cresp_clean_grid ! BEWARE: due to diffusion some junk remains in the grid - this nullifies all inactive bins.
-      call ppp_main%stop(crcg_label)
 #endif /* COSM_RAY_ELECTRONS */
 
    end subroutine fluid_update_full

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -210,15 +210,8 @@ def plotcompose(pthfilen, var, output, options):
             drawd = False
         else:
             if drawd:
-                d1min, d1max, d2min, d2max, d3min, d3max = min(extr[0]), max(extr[1]), min(extr[2]), max(extr[3]), min(extr[4]), max(extr[5])
-                vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, any(draw2D), [d1min, d1max, d2min, d2max])
+                vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, any(draw1D), any(draw2D), extr)
 
-                print('3D data value range: ', d3min, d3max)
-                if any(draw2D):
-                    print('Slices  value range: ', d2min, d2max)
-                if any(draw1D):
-                    print('1D data value range: ', d1min, d1max)
-                print('Plotted value range: ', vmin, vmax)
                 vlab = var + " [%s]" % pu.labelx()(uvar)
                 field = drawd, vmin, vmax, sctype, symmin, cmap, autsc, vlab
 

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -212,7 +212,7 @@ def plotcompose(pthfilen, var, output, options):
             if drawd:
                 vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, any(draw1D), any(draw2D), extr)
 
-                vlab = var + " [%s]" % pu.labelx()(uvar)
+                vlab = pu.labellog(sctype, symmin) + var + " [%s]" % pu.labelx()(uvar)
                 field = drawd, vmin, vmax, sctype, symmin, cmap, autsc, vlab
 
     h5f.close()

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -7,6 +7,7 @@ figrwcls = [(2, 2), (1, 1), (1, 2), (2, 1), (1, 2), (1, 3)]
 figplace = [(3, 2, 0), (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 0), (1, 0, 0)]
 cbsplace = [(1, 1), (-1, -1), (2, 2), (0, 1), (1, 1), (2, 2)]
 
+fineqv = 1.0
 
 def plane_in_outputname(figmode, draw2D):
     to_insert = ''
@@ -23,9 +24,6 @@ def plane_in_outputname(figmode, draw2D):
 def fsym(vmin, vmax):
     vmx = np.max([np.abs(vmin), np.abs(vmax)])
     vmn = -1.0 * vmx
-    if vmn == vmx:
-        vmn = vmn - 0.00001
-        vmx = vmx + 0.00001
     return vmn, vmx
 
 
@@ -69,6 +67,10 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
             vmax = np.log10(max(np.abs(smin), np.abs(smax)) / symmin)
         vmin = -vmax
         print('SYMMIN value for SYMLOG scaletype: %s' % symmin)
+
+    if vmin == vmax:
+        vmin = vmin - fineqv
+        vmax = vmax + fineqv
 
     print('3D data value range: ', d3min, d3max)
     if d2:

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -83,7 +83,7 @@ def check_minimum_data(refis, extended):
     cmdmin, cmdmax = np.inf, -np.inf
     for blks in refis:
         for bl in blks:
-            binb, bxyz = bl[0:2]
+            bxyz, binb = bl[0:2]
             for ncut in range(3):
                 if binb[ncut]:
                     cmdmin = min(cmdmin, np.min(bxyz[ncut], initial=np.inf, where=(bxyz[ncut] > 0.0)))

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -29,13 +29,14 @@ def fsym(vmin, vmax):
     return vmn, vmx
 
 
-def scale_manage(sctype, refis, umin, umax, d2, minmax):
+def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
     symmin = 1.0
     autoscale = False
+    d1min, d1max, d2min, d2max, d3min, d3max = min(extr[0]), max(extr[1]), min(extr[2]), max(extr[3]), min(extr[4]), max(extr[5])
     if d2:
-        dmin, dmax = minmax[2], minmax[3]
+        dmin, dmax = d2min, d2max
     else:
-        dmin, dmax = minmax[0], minmax[1]
+        dmin, dmax = d1min, d1max
     if (umin == 0.0 and umax == 0.0):
         vmin, vmax = dmin, dmax
         autoscale = True
@@ -69,6 +70,12 @@ def scale_manage(sctype, refis, umin, umax, d2, minmax):
         vmin = -vmax
         print('SYMMIN value for SYMLOG scaletype: %s' % symmin)
 
+    print('3D data value range: ', d3min, d3max)
+    if d2:
+        print('Slices  value range: ', d2min, d2max)
+    if d1:
+        print('1D data value range: ', d1min, d1max)
+    print('Plotted value range: ', vmin, vmax)
     return vmin, vmax, symmin, autoscale
 
 

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -52,7 +52,9 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
         if (vmax > 0.0):
             vmax = np.log10(vmax)
         else:
-            vmax = -1.
+            vmax = fineqv
+        if (vmin == np.inf):
+            vmin = vmax - fineqv
     elif (sctype == '3' or sctype == 'symlog'):
         if (umin > 0.0 and umax > 0.0):
             symmin = umin

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -7,7 +7,6 @@ figrwcls = [(2, 2), (1, 1), (1, 2), (2, 1), (1, 2), (1, 3)]
 figplace = [(3, 2, 0), (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 0), (1, 0, 0)]
 cbsplace = [(1, 1), (-1, -1), (2, 2), (0, 1), (1, 1), (2, 2)]
 
-fineqv = 1.0
 
 def plane_in_outputname(figmode, draw2D):
     to_insert = ''
@@ -52,9 +51,9 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
         if (vmax > 0.0):
             vmax = np.log10(vmax)
         else:
-            vmax = fineqv
+            vmax = ps.fineqv
         if (vmin == np.inf):
-            vmin = vmax - fineqv
+            vmin = vmax - ps.fineqv
     elif (sctype == '3' or sctype == 'symlog'):
         if (umin > 0.0 and umax > 0.0):
             symmin = umin
@@ -72,8 +71,8 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
         print('SYMMIN value for SYMLOG scaletype: %s' % symmin)
 
     if vmin == vmax:
-        vmin = vmin - fineqv
-        vmax = vmax + fineqv
+        vmin = vmin - ps.fineqv
+        vmax = vmax + ps.fineqv
 
     print('3D data value range: ', d3min, d3max)
     if d2:

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -122,6 +122,15 @@ def labelx():
     return lambda var: '$' + str(var)[2:-1].replace('**', '^') + '$'
 
 
+def labellog(sctype, symmin):
+    logname = ''
+    if (sctype == '2' or sctype == 'log'):
+        logname = 'log '
+    elif (sctype == '3' or sctype == 'symlog'):
+        logname = '{symmetry level = %8.3e} log ' % symmin
+    return logname
+
+
 def take_nonempty(lst):
     for it in lst:
         if it != []:

--- a/visual/pvf_settings.py
+++ b/visual/pvf_settings.py
@@ -22,6 +22,9 @@ centertick_color = 'silver'
 centertick_width = 2.
 centertick_length = 6.
 
+#scaletypes
+fineqv = 1.0
+
 # colorbars
 cbar_hist2d_shift = 0.7
 cbar_plot2d_shift = 0.1

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -79,7 +79,7 @@ def read_block(h5f, dset_name, ig, olev, oc, usc, getmap, draw1D, draw2D):
     if not any(inb):
         return False, [], []
     if not getmap:
-        return levok, [inb, [], [], ledge / usc, redge / usc, olev], []
+        return levok, [[], inb, ledge / usc, redge / usc, olev, []], []
     clen = h5g.attrs['dl']
     off = h5g.attrs['off']
     n_b = [int(ngb[0]), int(ngb[1]), int(ngb[2])]


### PR DESCRIPTION
fixups:
* print current time while dumping hdf or res via msg
* reduce code lines to summarize hdf dumps
* multiple_h5files to work again
* use the one routine to find file names
* visualize grid-only and using logscales
* cbar label includes log
* previously hardcoded fineqv moved to pvf_settings