### PR TITLE
CRESP: active bins fixes, option to allow negatives

### DIFF
--- a/python/crs_h5.py
+++ b/python/crs_h5.py
@@ -417,7 +417,7 @@ def detect_active_bins_new(n_in, e_in):
     prn = p_fix[1:ncre]
     num_active_bins = 0
 
-    for i in range(0, i_up_tmp - i_lo_tmp + 1):
+    for i in range(0, min(i_up_tmp - i_lo_tmp + 1, ncre - 1)):
         q_tmp = 3.5
         exit_code = False
         if (q_explicit is True):

--- a/src/fluids/cosmicrays/cresp_crspectrum.F90
+++ b/src/fluids/cosmicrays/cresp_crspectrum.F90
@@ -110,7 +110,7 @@ contains
 #endif /* CRESP_VERBOSED */
       use diagnostics,    only: decr_vec
       use initcosmicrays, only: ncre
-      use initcrspectrum, only: allow_unnatural_transfer, crel, dfpq, e_small_approx_p, nullify_empty_bins, p_mid_fix, p_fix, spec_mod_trms
+      use initcrspectrum, only: allow_unnatural_transfer, crel, dfpq, e_small_approx_p, nullify_empty_bins, p_mid_fix, p_fix, spec_mod_trms, cresp_disallow_negatives
 
       implicit none
 
@@ -242,7 +242,7 @@ contains
 ! Compute momentum changes in after time period [t,t+dt]
          call cresp_update_bin_index(sptab%ub*dt, sptab%ud*dt, p_cut, p_cut_next, cfl_cresp_violation)
 
-         if (cfl_cresp_violation) then
+         if (cfl_cresp_violation) then !< cresp_disallow_negatives is not used here, as potential negatives do not appear in transfer of n,e but in p
             approx_p = e_small_approx_p         !< restore approximation after momenta computed
             call deallocate_active_arrays
 #ifdef CRESP_VERBOSED
@@ -294,13 +294,15 @@ contains
             deallocate(cooling_edges_next)      !< -//-
             deallocate(heating_edges_next)      !< -//-
 
-            call cresp_detect_negative_content(cfl_cresp_violation)
-            if (cfl_cresp_violation) then
-               call deallocate_active_arrays
+            if (cresp_disallow_negatives) then  !< cresp_disallow_negatives = .false. lets the program ignore negatives of n/e that arose in CRESP
+               call cresp_detect_negative_content(cfl_cresp_violation)  !< thus no point checking/returning cfl_cresp_violation here
+               if (cfl_cresp_violation) then
+                  call deallocate_active_arrays
 #ifdef CRESP_VERBOSED
-               write (msg, "(A)") "[cresp_crspectrum:cresp_update_cell] CFL violated, returning"   ;  call printinfo(msg)
+                  write (msg, "(A)") "[cresp_crspectrum:cresp_update_cell] CFL violated, returning"   ;  call printinfo(msg)
 #endif /* CRESP_VERBOSED */
-               return
+                  return
+               endif
             endif
 
             call ne_to_q(n, e, q, active_bins)  !< begins new step
@@ -342,12 +344,14 @@ contains
       call check_cutoff_ne(ndt(i_cut_next(LO) + I_ONE), edt(i_cut_next(LO) + I_ONE), i_cut_next(LO) + I_ONE, cfl_cresp_violation)
       call check_cutoff_ne(ndt(i_cut_next(HI)),         edt(i_cut_next(HI)),         i_cut_next(HI),         cfl_cresp_violation)
 
-      if (cfl_cresp_violation) then
-         call deallocate_active_arrays
+      if (cresp_disallow_negatives) then
+         if (cfl_cresp_violation) then
+            call deallocate_active_arrays
 #ifdef CRESP_VERBOSED
-         write (msg, "(A)") "[cresp_crspectrum:cresp_update_cell] CFL violated, returning"   ;  call printinfo(msg)
+            write (msg, "(A)") "[cresp_crspectrum:cresp_update_cell] CFL violated, returning"   ;  call printinfo(msg)
 #endif /* CRESP_VERBOSED */
-         return
+            return
+         endif
       endif
 
       if (nullify_empty_bins) call nullify_inactive_bins(ndt, edt)

--- a/src/fluids/cosmicrays/cresp_crspectrum.F90
+++ b/src/fluids/cosmicrays/cresp_crspectrum.F90
@@ -193,6 +193,8 @@ contains
                is_active_bin(i_cut(HI))  = .false.
                is_active_edge(i_cut(HI)) = .false.
                num_active_bins = num_active_bins - I_ONE
+               f(i_cut(HI)-I_ONE:) = zero
+               q(i_cut(HI))        = zero
                i_cut(HI) = i_cut(HI) - I_ONE
                p_cut(HI) = p_fix(i_cut(HI))
             else
@@ -219,6 +221,8 @@ contains
                is_active_bin(i_cut(LO)+1) = .false.
                is_active_edge(i_cut(LO))  = .false.
                num_active_bins = num_active_bins - I_ONE
+               f(i_cut(LO):)      = zero
+               q(i_cut(LO)+I_ONE) = zero
                i_cut(LO) = i_cut(LO) + I_ONE
                p_cut(LO) = p_fix(i_cut(LO))
             else

--- a/src/fluids/cosmicrays/cresp_crspectrum.F90
+++ b/src/fluids/cosmicrays/cresp_crspectrum.F90
@@ -294,7 +294,7 @@ contains
             deallocate(cooling_edges_next)      !< -//-
             deallocate(heating_edges_next)      !< -//-
 
-            if (cresp_disallow_negatives) then  !< cresp_disallow_negatives = .false. lets the program ignore negatives of n/e that arose in CRESP
+            if (cresp_disallow_negatives) then  !< cresp_disallow_negatives = .false. lets the program ignore negative n,e that show in CRESP
                call cresp_detect_negative_content(cfl_cresp_violation)  !< thus no point checking/returning cfl_cresp_violation here
                if (cfl_cresp_violation) then
                   call deallocate_active_arrays
@@ -341,10 +341,9 @@ contains
       call cresp_detect_negative_content
 #endif /* CRESP_VERBOSED */
 
-      call check_cutoff_ne(ndt(i_cut_next(LO) + I_ONE), edt(i_cut_next(LO) + I_ONE), i_cut_next(LO) + I_ONE, cfl_cresp_violation)
-      call check_cutoff_ne(ndt(i_cut_next(HI)),         edt(i_cut_next(HI)),         i_cut_next(HI),         cfl_cresp_violation)
-
-      if (cresp_disallow_negatives) then
+      if (cresp_disallow_negatives) then  !< cresp_disallow_negatives = .false. lets the program ignore negative n,e that show in CRESP
+         call check_cutoff_ne(ndt(i_cut_next(LO) + I_ONE), edt(i_cut_next(LO) + I_ONE), i_cut_next(LO) + I_ONE, cfl_cresp_violation)
+         call check_cutoff_ne(ndt(i_cut_next(HI)),         edt(i_cut_next(HI)),         i_cut_next(HI),         cfl_cresp_violation)
          if (cfl_cresp_violation) then
             call deallocate_active_arrays
 #ifdef CRESP_VERBOSED

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -610,8 +610,8 @@ contains
          n_substeps_max = 1            !< for sanity assuming 1 substep if cresp_substep = .false.
       endif
 
-      if (cresp_disallow_negatives .eqv. .false.) then
-         if (use_smallecr .eqv. .false.) then
+      if (.not. cresp_disallow_negatives) then
+         if (.not. use_smallecr) then
             call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via cresp_disallow_negatives.")
             call warn("[initcrspectrum:init_cresp] as is 'use_smallecr'; should negative values show in CRESP, they will not be fixed.")
          else

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -614,7 +614,7 @@ contains
       if (cresp_disallow_negatives .eqv. .false.) then
          if (use_smallecr .eqv. .false.) then
             call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via cresp_disallow_negatives.")
-            call warn("[initcrspectrum:init_cresp] as is 'use_smallecr'; should negative values show in CRESP, they will not be fixed.")  ! FIXME die in this case?
+            call warn("[initcrspectrum:init_cresp] as is 'use_smallecr'; should negative values show in CRESP, they will not be fixed.")
          else
             call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via cresp_disallow_negatives.")
          endif

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -172,7 +172,7 @@ contains
       use dataio_pub,      only: printinfo, warn, msg, die, nh
       use diagnostics,     only: my_allocate_with_index
       use func,            only: emag
-      use initcosmicrays,  only: ncrn, ncre, K_crs_paral, K_crs_perp, K_cre_paral, K_cre_perp
+      use initcosmicrays,  only: ncrn, ncre, K_crs_paral, K_crs_perp, K_cre_paral, K_cre_perp, use_smallecr
       use mpisetup,        only: rbuff, ibuff, lbuff, cbuff, master, slave, piernik_MPI_Bcast
       use units,           only: clight, me, sigma_T
 
@@ -607,7 +607,14 @@ contains
          n_substeps_max = 1            !< for sanity assuming 1 substep if cresp_substep = .false.
       endif
 
-      if (cresp_disallow_negatives .eqv. .false.) call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module and performing CFL violation action due to that problem is DISABLED.")
+      if (cresp_disallow_negatives .eqv. .false.) then
+         if (use_smallecr .eqv. .false.) then
+            call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via cresp_disallow_negatives.")
+            call warn("[initcrspectrum:init_cresp] as is 'use_smallecr'; should negative values show in CRESP, they will not be fixed.")  ! FIXME die in this case?
+         else
+            call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via cresp_disallow_negatives.")
+         endif
+      endif
 
       if ((q_init < three) .and. any(e_small_approx_p == I_ONE)) then
          call warn("[initcrspectrum:init_cresp] Initial parameters: q_init < 3.0 and approximation of outer momenta is on, approximation of outer momenta with hard energy spectrum might not work.")

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -41,7 +41,7 @@ module initcrspectrum
            & smallcren, smallcree, max_p_ratio, NR_iter_limit, force_init_NR, NR_run_refine_pf, NR_refine_solution_q, NR_refine_pf, nullify_empty_bins, synch_active, adiab_active, &
            & allow_source_spectrum_break, cre_active, tol_f, tol_x, tol_f_1D, tol_x_1D, arr_dim, arr_dim_q, eps, eps_det, w, p_fix, p_mid_fix, total_init_cree, p_fix_ratio,        &
            & spec_mod_trms, cresp_all_edges, cresp_all_bins, norm_init_spectrum, cresp, crel, dfpq, fsynchr, init_cresp, cleanup_cresp_sp, check_if_dump_fpq, cleanup_cresp_work_arrays, q_eps,       &
-           & u_b_max, def_dtsynch, def_dtadiab, write_cresp_to_restart, NR_smap_file, NR_allow_old_smaps, cresp_substep, n_substeps_max, allow_unnatural_transfer
+           & u_b_max, def_dtsynch, def_dtadiab, write_cresp_to_restart, NR_smap_file, NR_allow_old_smaps, cresp_substep, n_substeps_max, allow_unnatural_transfer, cresp_disallow_negatives
 
 ! contains routines reading namelist in problem.par file dedicated to cosmic ray electron spectrum and initializes types used.
 ! available via namelist COSMIC_RAY_SPECTRUM
@@ -90,6 +90,7 @@ module initcrspectrum
    logical         :: nullify_empty_bins          !< nullifies empty bins when entering CRESP module / exiting empty cell.
    logical         :: allow_source_spectrum_break !< allow extension of spectrum to adjacent bins if momenta found exceed set p_fix
    logical         :: allow_unnatural_transfer    !< allows unnatural transfer of n & e with 'manually_deactivate_bins_via_transfer'
+   logical         :: cresp_disallow_negatives    !< disallows (by default) negative n,e in cresp_update_cell
    logical         :: synch_active                !< TEST feature - turns on / off synchrotron cooling @ CRESP
    logical         :: adiab_active                !< TEST feature - turns on / off adiabatic   cooling @ CRESP
    real            :: cre_active                  !< electron contribution to Pcr
@@ -186,7 +187,7 @@ contains
       &                         NR_iter_limit, max_p_ratio, synch_active, adiab_active, arr_dim, arr_dim_q, q_br_init,             &
       &                         Gamma_min_fix, Gamma_max_fix, nullify_empty_bins, approx_cutoffs, NR_run_refine_pf, b_max_db,      &
       &                         NR_refine_solution_q, NR_refine_pf_lo, NR_refine_pf_up, smallcree, smallcren, p_br_init_up, p_diff,&
-      &                         q_eps, NR_smap_file, cresp_substep, n_substeps_max, allow_unnatural_transfer
+      &                         q_eps, NR_smap_file, cresp_substep, n_substeps_max, allow_unnatural_transfer, cresp_disallow_negatives
 
 ! Default values
       use_cresp         = .true.
@@ -233,6 +234,7 @@ contains
       smallcree            = 0.0
       allow_source_spectrum_break  = .false.
       allow_unnatural_transfer     = .false.
+      cresp_disallow_negatives     = .true.
       synch_active         = .true.
       adiab_active         = .true.
       cre_active           = 0.0
@@ -298,6 +300,7 @@ contains
 
          lbuff(14) =  cresp_substep
          lbuff(15) =  allow_unnatural_transfer
+         lbuff(16) =  cresp_disallow_negatives
 
          rbuff(1)  = cfl_cre
          rbuff(2)  = cre_eff
@@ -371,6 +374,7 @@ contains
 
          cresp_substep               = lbuff(14)
          allow_unnatural_transfer    = lbuff(15)
+         cresp_disallow_negatives    = lbuff(16)
 
          cfl_cre                     = rbuff(1)
          cre_eff                     = rbuff(2)
@@ -602,6 +606,8 @@ contains
       else
          n_substeps_max = 1            !< for sanity assuming 1 substep if cresp_substep = .false.
       endif
+
+      if (cresp_disallow_negatives .eqv. .false.) call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module and performing CFL violation action due to that problem is DISABLED.")
 
       if ((q_init < three) .and. any(e_small_approx_p == I_ONE)) then
          call warn("[initcrspectrum:init_cresp] Initial parameters: q_init < 3.0 and approximation of outer momenta is on, approximation of outer momenta with hard energy spectrum might not work.")


### PR DESCRIPTION
After the list of active bins is constructed and lists of distribution function f with slope q are computed, assume zero where the bins are inactive in order to avoid flux problems. 
Additionally add 'cresp_disallow_negatives' switch (by default .true. - CFL checks and actions performed); if set to .false. it triggers tolerance of negative values of number density n and energy density e, appearing within CRESP and preventing part of 
CFL violation actions to be taken in that case; these errors are normally fixed via use_smallecr.