### PR TITLE
CRESP: fix MPI errors

### DIFF
--- a/src/fluids/cosmicrays/cresp_crspectrum.F90
+++ b/src/fluids/cosmicrays/cresp_crspectrum.F90
@@ -109,8 +109,9 @@ contains
       use dataio_pub,     only: msg, printinfo
 #endif /* CRESP_VERBOSED */
       use diagnostics,    only: decr_vec
+      use global,         only: disallow_CRnegatives
       use initcosmicrays, only: ncre
-      use initcrspectrum, only: allow_unnatural_transfer, crel, dfpq, e_small_approx_p, nullify_empty_bins, p_mid_fix, p_fix, spec_mod_trms, cresp_disallow_negatives
+      use initcrspectrum, only: allow_unnatural_transfer, crel, dfpq, e_small_approx_p, nullify_empty_bins, p_mid_fix, p_fix, spec_mod_trms
 
       implicit none
 
@@ -243,7 +244,7 @@ contains
 ! Compute momentum changes in after time period [t,t+dt]
          call cresp_update_bin_index(sptab%ub*dt, sptab%ud*dt, p_cut, p_cut_next, cfl_cresp_violation)
 
-         if (cfl_cresp_violation) then !< cresp_disallow_negatives is not used here, as potential negatives do not appear in transfer of n,e but in p
+         if (cfl_cresp_violation) then !< disallow_CRnegatives is not used here, as potential negatives do not appear in transfer of n,e but in p
             approx_p = e_small_approx_p         !< restore approximation after momenta computed
             call deallocate_active_arrays
 #ifdef CRESP_VERBOSED
@@ -295,7 +296,7 @@ contains
             deallocate(cooling_edges_next)      !< -//-
             deallocate(heating_edges_next)      !< -//-
 
-            if (cresp_disallow_negatives) then  !< cresp_disallow_negatives = .false. lets the program ignore negative n,e that show in CRESP
+            if (disallow_CRnegatives) then  !< unless disallow_CRnegatives, negative n,e in CRESP are ignored
                call cresp_detect_negative_content(cfl_cresp_violation)  !< thus no point checking/returning cfl_cresp_violation here
                if (cfl_cresp_violation) then
                   call deallocate_active_arrays
@@ -339,10 +340,10 @@ contains
 
       if (sum(approx_p) > 0) call print_failcounts
 
-      call cresp_detect_negative_content
+      call cresp_detect_negative_content(cfl_cresp_violation)
 #endif /* CRESP_VERBOSED */
 
-      if (cresp_disallow_negatives) then  !< cresp_disallow_negatives = .false. lets the program ignore negative n,e that show in CRESP
+      if (disallow_CRnegatives) then   !< unless disallow_CRnegatives, negative n,e in CRESP are ignored
          call check_cutoff_ne(ndt(i_cut_next(LO) + I_ONE), edt(i_cut_next(LO) + I_ONE), i_cut_next(LO) + I_ONE, cfl_cresp_violation)
          call check_cutoff_ne(ndt(i_cut_next(HI)),         edt(i_cut_next(HI)),         i_cut_next(HI),         cfl_cresp_violation)
          if (cfl_cresp_violation) then

--- a/src/fluids/cosmicrays/cresp_grid.F90
+++ b/src/fluids/cosmicrays/cresp_grid.F90
@@ -54,11 +54,11 @@ contains
       use cresp_crspectrum, only: cresp_allocate_all, cresp_init_state, p_rch_init
       use cresp_NR_method,  only: cresp_initialize_guess_grids
       use dataio,           only: vars
-      use dataio_pub,       only: printinfo, restarted_sim, warn
+      use dataio_pub,       only: printinfo, restarted_sim
       use global,           only: repetitive_steps, cflcontrol, disallow_CRnegatives
       use grid_cont,        only: grid_container
       use initcosmicrays,   only: iarr_cre_n, iarr_cre_e, ncre
-      use initcrspectrum,   only: norm_init_spectrum, dfpq, check_if_dump_fpq, use_cresp, cresp_disallow_negatives
+      use initcrspectrum,   only: norm_init_spectrum, dfpq, check_if_dump_fpq, use_cresp
       use mpisetup,         only: master
       use named_array_list, only: wna
 
@@ -103,11 +103,7 @@ contains
 
       call cresp_init_state(norm_init_spectrum%n, norm_init_spectrum%e)   !< initialize spectrum here, f_init should be 1.0
 
-      allow_loop_leave = (.not. cresp_disallow_negatives .and. repetitive_steps .and. cflcontrol /= "flex" .and. cflcontrol /= "flexible")
-
-      if (cresp_disallow_negatives .neqv. disallow_CRnegatives) then
-         if (master) call warn("[cresp_grid:cresp_init_grid] cresp_disallow_negatives /= disallow_CRnegatives - CFL handling may not be reliable.")
-      endif
+      allow_loop_leave = (disallow_CRnegatives .and. repetitive_steps .and. cflcontrol /= "flex" .and. cflcontrol /= "flexible")
 
       if (master) call printinfo(" [cresp_grid:cresp_init_grid] CRESP initialized")
 

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -41,7 +41,7 @@ module initcrspectrum
            & smallcren, smallcree, max_p_ratio, NR_iter_limit, force_init_NR, NR_run_refine_pf, NR_refine_solution_q, NR_refine_pf, nullify_empty_bins, synch_active, adiab_active, &
            & allow_source_spectrum_break, cre_active, tol_f, tol_x, tol_f_1D, tol_x_1D, arr_dim, arr_dim_q, eps, eps_det, w, p_fix, p_mid_fix, total_init_cree, p_fix_ratio,        &
            & spec_mod_trms, cresp_all_edges, cresp_all_bins, norm_init_spectrum, cresp, crel, dfpq, fsynchr, init_cresp, cleanup_cresp_sp, check_if_dump_fpq, cleanup_cresp_work_arrays, q_eps,       &
-           & u_b_max, def_dtsynch, def_dtadiab, write_cresp_to_restart, NR_smap_file, NR_allow_old_smaps, cresp_substep, n_substeps_max, allow_unnatural_transfer, cresp_disallow_negatives
+           & u_b_max, def_dtsynch, def_dtadiab, write_cresp_to_restart, NR_smap_file, NR_allow_old_smaps, cresp_substep, n_substeps_max, allow_unnatural_transfer
 
 ! contains routines reading namelist in problem.par file dedicated to cosmic ray electron spectrum and initializes types used.
 ! available via namelist COSMIC_RAY_SPECTRUM
@@ -90,7 +90,6 @@ module initcrspectrum
    logical         :: nullify_empty_bins          !< nullifies empty bins when entering CRESP module / exiting empty cell.
    logical         :: allow_source_spectrum_break !< allow extension of spectrum to adjacent bins if momenta found exceed set p_fix
    logical         :: allow_unnatural_transfer    !< allows unnatural transfer of n & e with 'manually_deactivate_bins_via_transfer'
-   logical         :: cresp_disallow_negatives    !< disallows (by default) negative n,e in cresp_update_cell
    logical         :: synch_active                !< TEST feature - turns on / off synchrotron cooling @ CRESP
    logical         :: adiab_active                !< TEST feature - turns on / off adiabatic   cooling @ CRESP
    real            :: cre_active                  !< electron contribution to Pcr
@@ -171,6 +170,7 @@ contains
       use cresp_variables, only: clight_cresp
       use dataio_pub,      only: printinfo, warn, msg, die, nh
       use diagnostics,     only: my_allocate_with_index
+      use global,          only: disallow_CRnegatives
       use func,            only: emag
       use initcosmicrays,  only: ncrn, ncre, ncra, ncrs, K_crs_paral, K_crs_perp, K_cre_paral, K_cre_perp, use_smallecr
       use mpisetup,        only: rbuff, ibuff, lbuff, cbuff, master, slave, piernik_MPI_Bcast
@@ -187,7 +187,7 @@ contains
       &                         NR_iter_limit, max_p_ratio, synch_active, adiab_active, arr_dim, arr_dim_q, q_br_init,             &
       &                         Gamma_min_fix, Gamma_max_fix, nullify_empty_bins, approx_cutoffs, NR_run_refine_pf, b_max_db,      &
       &                         NR_refine_solution_q, NR_refine_pf_lo, NR_refine_pf_up, smallcree, smallcren, p_br_init_up, p_diff,&
-      &                         q_eps, NR_smap_file, cresp_substep, n_substeps_max, allow_unnatural_transfer, cresp_disallow_negatives
+      &                         q_eps, NR_smap_file, cresp_substep, n_substeps_max, allow_unnatural_transfer
 
 ! Default values
       use_cresp         = .true.
@@ -234,7 +234,6 @@ contains
       smallcree            = 0.0
       allow_source_spectrum_break  = .false.
       allow_unnatural_transfer     = .false.
-      cresp_disallow_negatives     = .true.
       synch_active         = .true.
       adiab_active         = .true.
       cre_active           = 0.0
@@ -300,7 +299,6 @@ contains
 
          lbuff(14) =  cresp_substep
          lbuff(15) =  allow_unnatural_transfer
-         lbuff(16) =  cresp_disallow_negatives
 
          rbuff(1)  = cfl_cre
          rbuff(2)  = cre_eff
@@ -374,7 +372,6 @@ contains
 
          cresp_substep               = lbuff(14)
          allow_unnatural_transfer    = lbuff(15)
-         cresp_disallow_negatives    = lbuff(16)
 
          cfl_cre                     = rbuff(1)
          cre_eff                     = rbuff(2)
@@ -610,12 +607,12 @@ contains
          n_substeps_max = 1            !< for sanity assuming 1 substep if cresp_substep = .false.
       endif
 
-      if (.not. cresp_disallow_negatives) then
+      if (.not. disallow_CRnegatives) then
          if (.not. use_smallecr) then
-            if (master) call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via cresp_disallow_negatives.")
+            if (master) call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via disallow_CRnegatives.")
             if (master) call warn("[initcrspectrum:init_cresp] as is 'use_smallecr'; should negative values show in CRESP, they will not be fixed.")
          else
-            if (master) call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via cresp_disallow_negatives.")
+            if (master) call warn("[initcrspectrum:init_cresp] Detecting negative values of n,e in CRESP module & performing CFL violation actions related is DISABLED via disallow_CRnegatives.")
          endif
       endif
 


### PR DESCRIPTION
This PR fixes errors within MPI that occured due to uncontrolled update loop exit (via return statement), without properly stopping ppp/cg cost counters.