### PR TITLE
timestep: override repeat_step to false in simulations without repetitve_steps

### DIFF
--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -40,9 +40,9 @@ module global
 
    private
    public :: cleanup_global, init_global, &
-        &    cfl, cfl_max, cflcontrol, disallow_negatives, disallow_CRnegatives, unwanted_negatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
+        &    cfl, cfl_max, cflcontrol, disallow_negatives, disallow_CRnegatives, dn_negative, ei_negative, cr_negative, tstep_attempt, &
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_cur_shrink, dt_min, dt_max, dt_old, dt_full, dtm, t, t_saved, nstep, nstep_saved, max_redostep_attempts, &
-        &    repeat_step, repetitive_steps, integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
+        &    repetitive_steps, integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, skip_sweep, geometry25D, &
         &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, do_external_corners, prefer_merged_MPI, &
         &    divB_0_method, cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fluid_prolong, which_solver
@@ -50,8 +50,7 @@ module global
    logical         :: dn_negative = .false.
    logical         :: ei_negative = .false.
    logical         :: cr_negative = .false.
-   logical         :: repeat_step = .false.     !< order to repeat fluid step
-   logical         :: disallow_negatives, disallow_CRnegatives, unwanted_negatives = .false.
+   logical         :: disallow_negatives, disallow_CRnegatives
    logical         :: repetitive_steps         !< repetitve fluid step if cfl condition is violated (significantly increases mem usage)
    logical         :: dirty_debug              !< Allow initializing arrays with some insane values and checking if these values can propagate
    integer(kind=4) :: show_n_dirtys            !< use to limit the amount of printed messages on dirty values found

--- a/src/base/repeatstep.F90
+++ b/src/base/repeatstep.F90
@@ -1,0 +1,115 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+
+#include "piernik.h"
+
+!>
+!! \brief Module controlling the repeat_step flag .
+!!
+!! \details Mishandling this flag (i.e. having a non reduced state across processes) may lead to deadlocks.
+!! These deadlocks would likely to occur in places unrelated to the origin of the problem.
+!!
+!! Perhaps this module can be expressed as a type, if more synchonized logical variables are needed in the code.
+!<
+
+module repeatstep
+
+   implicit none
+
+   private
+   public :: repeat_step, set_repeat_step, clear_repeat_step, sync_repeat_step
+
+   logical :: repeat = .false.     ! this flag marks whether a timestep has to be repeated or not
+   logical :: need_sync = .false.  ! die if unsynchronized repeat is used anywhere
+
+   logical, parameter :: ultra_defensive = &
+#ifdef DEBUG
+        .true.   ! enforce unconditional global reduction or call die()
+#else /* !DEBUG */
+        .false.  ! allow the programmer to skip global reduction when it is known to be safe from some other sources
+#endif /* DEBUG */
+
+contains
+
+!> \brief Return repeat value, check for synchronisation first
+
+   logical function repeat_step()
+
+      use dataio_pub, only: die
+
+      implicit none
+
+      if (need_sync) call die("[repeatstep:repeat_step] The repeat flag was possibly unsynchronized.")
+      repeat_step = repeat
+
+   end function repeat_step
+
+!> \brief Change the state of the repeat flag, if required
+
+   subroutine set_repeat_step(repeat_flag)
+
+      implicit none
+
+      logical, intent(in) :: repeat_flag  ! if .true. then set the repeat flag in this module
+
+      need_sync = ultra_defensive .or. need_sync .or. (repeat_flag .and. .not. repeat)
+      repeat = repeat .or. repeat_flag
+
+   end subroutine set_repeat_step
+
+!> \brief Unset the repeat flag
+
+   subroutine clear_repeat_step(sync_flag)
+
+      implicit none
+
+      logical, optional, intent(in) :: sync_flag  ! if .true. then also do the synchronisation
+
+      need_sync = ultra_defensive .or. need_sync .or. repeat
+      repeat = .false.
+
+      if (present(sync_flag)) then
+         if (sync_flag) call sync_repeat_step
+      endif
+
+   end subroutine clear_repeat_step
+
+!> \brief Synchronize the repeat flag (MPI global reduction)
+
+   subroutine sync_repeat_step
+
+      use constants, only: pLOR
+      use mpisetup,  only: piernik_MPI_Allreduce
+
+      implicit none
+
+      need_sync = .false.
+      call piernik_MPI_Allreduce(repeat, pLOR)
+
+   end subroutine sync_repeat_step
+
+end module repeatstep

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -42,6 +42,7 @@ module timestep
    public :: init_time_step
 #endif /* __INTEL_COMPILER || _CRAYFTN */
 
+   logical :: unwanted_negatives = .false.
    logical :: flexible_shrink
 #if defined(__INTEL_COMPILER) || defined(_CRAYFTN)
    !! \deprecated remove this clause as soon as Intel Compiler gets required features and/or bug fixes
@@ -243,8 +244,9 @@ contains
       use constants,      only: pLOR
       use dataio_pub,     only: warn
       use fluidtypes,     only: var_numbers
-      use global,         only: dn_negative, ei_negative, disallow_negatives, repeat_step, repetitive_steps, unwanted_negatives
+      use global,         only: dn_negative, ei_negative, disallow_negatives, repetitive_steps
       use mpisetup,       only: piernik_MPI_Allreduce, master
+      use repeatstep,     only: repeat_step, set_repeat_step, sync_repeat_step
       use timestep_pub,   only: c_all
       use timestep_retry, only: reset_freezing_speed
 #ifdef COSM_RAYS
@@ -295,8 +297,9 @@ contains
          ei_negative  = .false.
       endif
 
-      repeat_step = repeat_step .or. unwanted_negatives
-      if (repeat_step) call reset_freezing_speed
+      call set_repeat_step(unwanted_negatives)
+      call sync_repeat_step
+      if (repeat_step()) call reset_freezing_speed
 
    end subroutine check_cfl_violation
 
@@ -309,8 +312,9 @@ contains
 
       use constants,    only: I_ONE, one
       use dataio_pub,   only: msg, warn
-      use global,       only: cfl, cfl_max, dt_cur_shrink, dt_shrink, repeat_step, repetitive_steps, tstep_attempt, unwanted_negatives
-      use mpisetup,     only: piernik_MPI_Bcast, master
+      use global,       only: cfl, cfl_max, dt_cur_shrink, dt_shrink, repetitive_steps, tstep_attempt
+      use mpisetup,     only: master
+      use repeatstep,   only: repeat_step, set_repeat_step, sync_repeat_step, clear_repeat_step
       use timestep_pub, only: c_all, c_all_old, stepcfl
 
       implicit none
@@ -318,12 +322,13 @@ contains
       stepcfl = cfl * dt_cur_shrink
       if (c_all_old > 0.) stepcfl = c_all / c_all_old * cfl * dt_cur_shrink
 
+      call clear_repeat_step
+      call set_repeat_step(unwanted_negatives)  ! \> information about unwanted_negatives from the last fluid_update call if disallow_negatives
       if (master) then
          msg = ''
-         repeat_step = unwanted_negatives ! \> information about unwanted_negatives from the last fluid_update call if disallow_negatives
          if (stepcfl > cfl_max) then
             write(msg,'(a,g10.3)') "[timestep:cfl_warn] Possible violation of CFL: ", stepcfl
-            repeat_step = .true.
+            call set_repeat_step(.true.)
          else if (stepcfl < 2*cfl - cfl_max) then
             write(msg,'(2(a,g10.3))') "[timestep:cfl_warn] Low CFL: ", stepcfl, " << ", cfl
          endif
@@ -331,8 +336,8 @@ contains
       endif
 
       if (repetitive_steps) then
-         call piernik_MPI_Bcast(repeat_step)
-         if (repeat_step) then
+         call sync_repeat_step
+         if (repeat_step()) then
             if (flexible_shrink) then
                dt_cur_shrink = cfl_max / stepcfl
                if (tstep_attempt >= I_ONE) dt_cur_shrink = dt_cur_shrink * dt_shrink
@@ -343,7 +348,7 @@ contains
             dt_cur_shrink = one
          endif
       else
-         repeat_step = repetitive_steps   ! overwrite this flag if step is not meant to be repeated
+         call clear_repeat_step(.true.)  ! ignore repeat flag if step is not meant to be repeated
       endif
 
    end subroutine cfl_warn

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -342,6 +342,8 @@ contains
          else
             dt_cur_shrink = one
          endif
+      else
+         repeat_step = repetitive_steps   ! overrides this flag if step is not meant to be repeated
       endif
 
    end subroutine cfl_warn

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -343,7 +343,7 @@ contains
             dt_cur_shrink = one
          endif
       else
-         repeat_step = repetitive_steps   ! overrides this flag if step is not meant to be repeated
+         repeat_step = repetitive_steps   ! overwrite this flag if step is not meant to be repeated
       endif
 
    end subroutine cfl_warn

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -88,11 +88,12 @@ contains
       use cg_list,          only: cg_list_element
       use constants,        only: pSUM, I_ZERO, I_ONE, dsetnamelen, AT_IGNORE, INVALID
       use dataio_pub,       only: warn, msg, die
-      use global,           only: dt, dt_full, t, t_saved, max_redostep_attempts, nstep, nstep_saved, dt_cur_shrink, repeat_step, repetitive_steps, tstep_attempt
+      use global,           only: dt, dt_full, t, t_saved, max_redostep_attempts, nstep, nstep_saved, dt_cur_shrink, repetitive_steps, tstep_attempt
       use mass_defect,      only: downgrade_magic_mass
       use mpisetup,         only: master, piernik_MPI_Allreduce
       use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
       use ppp,              only: ppp_main
+      use repeatstep,       only: repeat_step
       use user_hooks,       only: user_reaction_to_redo_step
 #ifdef RANDOMIZE
       use randomization,    only: randoms_redostep
@@ -110,7 +111,7 @@ contains
 
       call restart_arrays
 
-      if (repeat_step) then
+      if (repeat_step()) then
          tstep_attempt = tstep_attempt + I_ONE
          if (tstep_attempt > max_redostep_attempts) then
             write(msg, '(a,i2,a)')"[timestep_retry:repeat_fluidstep] tstep_attempt > ", max_redostep_attempts, " (max_redostep_attempts)"
@@ -130,7 +131,7 @@ contains
          t_saved = t
       endif
 #ifdef RANDOMIZE
-      call randoms_redostep(repeat_step)
+      call randoms_redostep(repeat_step())
 #endif /* RANDOMIZE */
 
       ! refresh na_lists(:)%indices
@@ -155,7 +156,7 @@ contains
          end associate
       enddo
 
-      if (repeat_step) then
+      if (repeat_step()) then
          call ppp_main%start(rs_label // "reverting")
       else
          call ppp_main%start(rs_label // "saving")
@@ -172,7 +173,7 @@ contains
                do i = lbound(na%lst(:), dim=1), ubound(na%lst(:), dim=1)
                   if (na%lst(i)%restart_mode > AT_IGNORE) then
                      rname = get_rname(na%lst(i)%name)
-                     if (repeat_step) then
+                     if (repeat_step()) then
                         if (cgl%cg%has_previous_timestep) then
                            select type(na)  !! ToDo: unify qna and wna somehow at least in the grid_container
                               type is (na_var_list_q)
@@ -204,7 +205,7 @@ contains
          call cgl%cg%costs%stop(I_OTHER)
          cgl => cgl%nxt
       enddo
-      if (repeat_step) then
+      if (repeat_step()) then
          call ppp_main%stop(rs_label // "reverting")
       else
          call ppp_main%stop(rs_label // "saving")

--- a/src/supernovae/snsources.F90
+++ b/src/supernovae/snsources.F90
@@ -159,14 +159,15 @@ contains
 !<
    subroutine random_sn
 
-      use global, only: t, repeat_step
+      use global,     only: t
+      use repeatstep, only: repeat_step
 
       implicit none
 
       real, dimension(ndims) :: snpos
       integer                :: isn, nsn_per_timestep
 
-      if (.not.repeat_step) nsn_last = nsn
+      if (.not. repeat_step()) nsn_last = nsn
 
       nsn = int(t * f_sn, kind=4)
       nsn_per_timestep = nsn - nsn_last


### PR DESCRIPTION
This fixes problems (hanging up) occuring on some larger simulations in which repetitive_steps are not allowed. 
Due to possible CFL violation 'repeat_step' flag was being triggered and in setups without repetitive steps, left unattended, this later causes the simulation to stall during an attempt to reduce chspeed (hdc:update_chspeed).