### PR TITLE
PVF comparison between different levels and other improvements

### DIFF
--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -23,7 +23,7 @@ def plot_axes(ax, ulen, l1, min1, max1, l2, min2, max2):
 
 
 def plot1d(refis, field, parts, equip1d, ncut, n1, n2):
-    smin, smax, zoom, ulen, umin, umax, linstyl, output, timep, sctype = equip1d
+    smin, smax, zoom, ulen, sctype, umin, umax, linstyl, output, timep = equip1d
     fig1d = P.figure(ncut + 2, figsize=(10, 8))
     ax = fig1d.add_subplot(111)
     P.xlim(zoom[1][ncut], zoom[2][ncut])
@@ -34,7 +34,7 @@ def plot1d(refis, field, parts, equip1d, ncut, n1, n2):
         hybrid_plot = (parts[3] > 1)
 
     if field[0]:
-        vmin, vmax, sctype, symmin, cmap, autsc, labf = field[1:]
+        vmin, vmax, symmin, cmap, autsc, labf = field[1:]
         label.append(labf)
         if not autsc and not hybrid_plot:
             P.ylim(vmin, vmax)
@@ -86,11 +86,11 @@ def plot1d(refis, field, parts, equip1d, ncut, n1, n2):
 
 
 def draw_plotcomponent(ax, refis, field, parts, equip2d, ncut, n1, n2):
-    smin, smax, zoom, ulen, drawg, gcolor, center, sctype = equip2d
+    smin, smax, zoom, ulen, sctype, drawg, gcolor, center = equip2d
     ag, ah = [], []
     if field[0] or drawg:
         if field[0]:
-            vmin, vmax, sctype, symmin, cmap = field[1:-2]
+            vmin, vmax, symmin, cmap = field[1:-2]
         for blks in refis:
             for bl in blks:
                 bxyz, binb, ble, bre, level = bl[:-1]
@@ -232,7 +232,7 @@ def plotcompose(pthfilen, var, output, options):
                 vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, draw1D, draw2D, extr)
 
                 vlab = pu.labellog(sctype, symmin, cmpr[0]) + var + " [%s]" % pu.labelx()(uvar)
-                field = drawd, vmin, vmax, sctype, symmin, cmap, autsc, vlab
+                field = drawd, vmin, vmax, symmin, cmap, autsc, vlab
 
     zoom = rd.level_zoom(h5f, gridlist, zoom, smin, smax)
 
@@ -246,8 +246,8 @@ def plotcompose(pthfilen, var, output, options):
 
     cbar_mode = pu.colorbar_mode(drawd, drawh, figmode)
 
-    equip1d = smin, smax, zoom, ulen, umin, umax, linstyl, output, timep, sctype
-    equip2d = smin, smax, zoom, ulen, drawg, gcolor, center, sctype
+    equip1d = smin, smax, zoom, ulen, sctype, umin, umax, linstyl, output, timep
+    equip2d = smin, smax, zoom, ulen, sctype, drawg, gcolor, center
 
     if draw1D[0]:
         plot1d(refis, field, parts, equip1d, 0, 1, 2)

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -239,7 +239,7 @@ def plotcompose(pthfilen, var, output, options):
 
     h5f.close()
     if cmpr[0]:
-        cmpr[1].close()
+        cmpr[2].close()
 
     if not (parts[0] or drawd or drawg):
         print('No particles or datafields or grids to plot. Skipping.')

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -212,6 +212,8 @@ def plotcompose(pthfilen, var, output, options):
                 vlab = pu.labellog(sctype, symmin, cmpr[0]) + var + " [%s]" % pu.labelx()(uvar)
                 field = drawd, vmin, vmax, sctype, symmin, cmap, autsc, vlab
 
+    zoom = rd.level_zoom(h5f, gridlist, zoom, smin, smax)
+
     h5f.close()
     if cmpr[0]:
         cmpr[1].close()
@@ -221,9 +223,6 @@ def plotcompose(pthfilen, var, output, options):
         return
 
     cbar_mode = pu.colorbar_mode(drawd, drawh, figmode)
-
-    if not zoom[0]:
-        zoom = False, smin, smax
 
     equip1d = smin, smax, zoom, ulen, umin, umax, linstyl, output, timep
     equip2d = smin, smax, zoom, ulen, drawg, gcolor, center

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -183,7 +183,7 @@ def plotcompose(pthfilen, var, output, options):
     drawa, drawu = pu.choose_amr_or_uniform(drawa, drawu, drawd, drawg, drawp, maxglev, gridlist)
     plotlevels = pu.check_plotlevels(plotlevels, maxglev, True)
     gridlist = pu.sanitize_gridlist(gridlist, cgcount)
-    unavail, cmpr, drawa, drawu, drawg = rd.manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu, drawg)
+    unavail, cmpr, drawa, drawu = rd.manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu)
     if len(plotlevels) == 0 or unavail:
         print('No levels found. Skipping.')
         return

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -153,15 +153,6 @@ def plotcompose(pthfilen, var, output, options):
     labh = ps.particles_label
     drawh = drawp and nbins > 1
     h5f = h5py.File(pthfilen, 'r')
-    cmpr0, cmprf, cmprd, cmprt = cmpr
-    if cmpr0:
-        if cmprd == '':
-            cmprd = var
-        if cmprf == '':
-            cmpr = cmpr0, h5f, cmprd, cmprt
-        else:
-            h5c = h5py.File(cmprf, 'r')
-            cmpr = cmpr0, h5c, cmprd, cmprt
     time = h5f.attrs['time'][0]
     utim = h5f['dataset_units']['time_unit'].attrs['unit']
     ulenf = h5f['dataset_units']['length_unit'].attrs['unit']
@@ -199,6 +190,7 @@ def plotcompose(pthfilen, var, output, options):
     if drawg:
         gcolor = pu.reorder_gridcolorlist(gcolor, maxglev, plotlevels)
     gridlist = pu.sanitize_gridlist(gridlist, cgcount)
+    cmpr, drawa, drawu, drawg = rd.manage_compare(cmpr, h5f, var, maxglev, plotlevels, gridlist, drawa, drawu, drawg)
 
     if drawp:
         pinfile, pxyz, pm = rd.collect_particles(h5f, drawh, center, player, uupd, usc, plotlevels, gridlist)
@@ -225,12 +217,12 @@ def plotcompose(pthfilen, var, output, options):
             if drawd:
                 vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, any(draw1D), any(draw2D), extr)
 
-                vlab = pu.labellog(sctype, symmin, cmpr0) + var + " [%s]" % pu.labelx()(uvar)
+                vlab = pu.labellog(sctype, symmin, cmpr[0]) + var + " [%s]" % pu.labelx()(uvar)
                 field = drawd, vmin, vmax, sctype, symmin, cmap, autsc, vlab
 
     h5f.close()
-    if cmpr0:
-        h5c.close()
+    if cmpr[0]:
+        cmpr[1].close()
 
     if not (parts[0] or drawd or drawg):
         print('No particles or datafields or grids to plot. Skipping.')

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -181,16 +181,16 @@ def plotcompose(pthfilen, var, output, options):
         center = (smax[0] + smin[0]) / 2.0, (smax[1] + smin[1]) / 2.0, (smax[2] + smin[2]) / 2.0
 
     drawa, drawu = pu.choose_amr_or_uniform(drawa, drawu, drawd, drawg, drawp, maxglev, gridlist)
-    plotlevels = pu.check_plotlevels(plotlevels, maxglev, drawa)
-    if len(plotlevels) == 0:
+    plotlevels = pu.check_plotlevels(plotlevels, maxglev, drawa, True)
+    gridlist = pu.sanitize_gridlist(gridlist, cgcount)
+    unavail, cmpr, drawa, drawu, drawg = rd.manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu, drawg)
+    if len(plotlevels) == 0 or unavail:
         print('No levels found. Skipping.')
         return
 
     linstyl = pu.linestyles(linstyl, maxglev, plotlevels)
     if drawg:
         gcolor = pu.reorder_gridcolorlist(gcolor, maxglev, plotlevels)
-    gridlist = pu.sanitize_gridlist(gridlist, cgcount)
-    cmpr, drawa, drawu, drawg = rd.manage_compare(cmpr, h5f, var, maxglev, plotlevels, gridlist, drawa, drawu, drawg)
 
     if drawp:
         pinfile, pxyz, pm = rd.collect_particles(h5f, drawh, center, player, uupd, usc, plotlevels, gridlist)

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -231,7 +231,7 @@ def plotcompose(pthfilen, var, output, options):
             if drawd:
                 vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, draw1D, draw2D, extr)
 
-                vlab = pu.labellog(sctype, symmin, cmpr[0]) + var + " [%s]" % pu.labelx()(uvar)
+                vlab = pu.labellog(sctype, symmin, cmpr[0]) + var + pu.manage_units(uvar)
                 field = drawd, vmin, vmax, symmin, cmap, autsc, vlab
 
     zoom = rd.level_zoom(h5f, gridlist, zoom, smin, smax)

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -207,7 +207,7 @@ def plotcompose(pthfilen, var, output, options):
             drawd = False
         else:
             if drawd:
-                vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, any(draw1D), any(draw2D), extr)
+                vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, draw1D, draw2D, extr)
 
                 vlab = pu.labellog(sctype, symmin, cmpr[0]) + var + " [%s]" % pu.labelx()(uvar)
                 field = drawd, vmin, vmax, sctype, symmin, cmap, autsc, vlab

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -181,7 +181,7 @@ def plotcompose(pthfilen, var, output, options):
         center = (smax[0] + smin[0]) / 2.0, (smax[1] + smin[1]) / 2.0, (smax[2] + smin[2]) / 2.0
 
     drawa, drawu = pu.choose_amr_or_uniform(drawa, drawu, drawd, drawg, drawp, maxglev, gridlist)
-    plotlevels = pu.check_plotlevels(plotlevels, maxglev, drawa, True)
+    plotlevels = pu.check_plotlevels(plotlevels, maxglev, True)
     gridlist = pu.sanitize_gridlist(gridlist, cgcount)
     unavail, cmpr, drawa, drawu, drawg = rd.manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu, drawg)
     if len(plotlevels) == 0 or unavail:
@@ -201,15 +201,7 @@ def plotcompose(pthfilen, var, output, options):
 
     refis = []
     if drawd or drawg:
-        extr = [], [], [], [], [], []
-        if drawu:
-            if len(plotlevels) > 1:
-                print('For uniform grid plotting only the first given level!')
-            print('Plotting base level %s' % plotlevels[0])
-            refis, extr = rd.reconstruct_uniform(h5f, var, cmpr, plotlevels[0], gridlist, center, smin, smax, draw1D, draw2D)
-
-        if drawa or drawg:
-            refis, extr = rd.collect_gridlevels(h5f, var, cmpr, refis, extr, maxglev, plotlevels, gridlist, cgcount, center, usc, drawd, draw1D, draw2D)
+        refis, extr = rd.collect_gridlevels(h5f, var, cmpr, refis, maxglev, plotlevels, gridlist, cgcount, center, usc, drawd, drawu, drawa, drawg, draw1D, draw2D)
 
         if refis == []:
             drawd = False

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -168,7 +168,7 @@ def add_cbar(figmode, cbar_mode, grid, ab, ic, clab, sct, field):
     cbarh.ax.set_ylabel(clab)
     if cbar_mode == 'none':
         cbarh.ax.yaxis.set_label_coords(ps.cbar_label_coords[0], ps.cbar_label_coords[1])
-    if ic == 1 and pu.recognize_opt(sct, ('3', 'symlog')):
+    if ic == 1 and pu.whether_symlog(sct):
         slticks, sltlabs = [], []
         for tick in cbarh.get_ticks():
             if tick >= field[1] and tick <= field[2]:

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -225,8 +225,9 @@ def plotcompose(pthfilen, var, output, options):
     if drawd or drawg:
         refis, extr = rd.collect_gridlevels(h5f, var, cmpr, refis, maxglev, plotlevels, gridlist, cgcount, center, usc, drawd, drawu, drawa, drawg, draw1D, draw2D)
 
-        if refis == []:
+        if refis == [] or pu.list_any(extr, []):
             drawd = False
+            field = [drawd, ]
         else:
             if drawd:
                 vmin, vmax, symmin, autsc = pu.scale_manage(sctype, refis, umin, umax, draw1D, draw2D, extr)

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -168,7 +168,7 @@ def add_cbar(figmode, cbar_mode, grid, ab, ic, clab, sct, field):
     cbarh.ax.set_ylabel(clab)
     if cbar_mode == 'none':
         cbarh.ax.yaxis.set_label_coords(ps.cbar_label_coords[0], ps.cbar_label_coords[1])
-    if ic == 1 and (sct == '3' or sct == 'symlog'):
+    if ic == 1 and pu.recognize_opt(sct, ('3', 'symlog')):
         slticks, sltlabs = [], []
         for tick in cbarh.get_ticks():
             if tick >= field[1] and tick <= field[2]:

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -147,7 +147,7 @@ def plot1d_particles(ax, p1, pm, nbins, ranges, pcolor, psize):
     return ax
 
 
-def add_cbar(figmode, cbar_mode, grid, ab, ic, clab):
+def add_cbar(figmode, cbar_mode, grid, ab, ic, clab, sct, field):
     icb = pu.cbsplace[figmode][ic]
     clf = [ps.cbar_hist2d_label_format, ps.cbar_plot2d_label_format][ic]
     if cbar_mode == 'none':
@@ -168,6 +168,13 @@ def add_cbar(figmode, cbar_mode, grid, ab, ic, clab):
     cbarh.ax.set_ylabel(clab)
     if cbar_mode == 'none':
         cbarh.ax.yaxis.set_label_coords(ps.cbar_label_coords[0], ps.cbar_label_coords[1])
+    if ic == 1 and (sct == '3' or sct == 'symlog'):
+        slticks, sltlabs = [], []
+        for tick in cbarh.get_ticks():
+            if tick >= field[1] and tick <= field[2]:
+                slticks.append(tick)
+                sltlabs.append(clf % (np.sign(tick) * 10.**(np.abs(tick)) * field[3]))
+        cbarh.set_ticks(slticks, labels=sltlabs)
 
 
 def plotcompose(pthfilen, var, output, options):
@@ -277,10 +284,10 @@ def plotcompose(pthfilen, var, output, options):
         ax.set_title(timep)
 
         if drawh:
-            add_cbar(figmode, cbar_mode, grid, ah[3], 0, labh)
+            add_cbar(figmode, cbar_mode, grid, ah[3], 0, labh, sctype, field)
 
         if drawd:
-            add_cbar(figmode, cbar_mode, grid, pu.take_nonempty([ag0, ag2, ag3]), 1, vlab)
+            add_cbar(figmode, cbar_mode, grid, pu.take_nonempty([ag0, ag2, ag3]), 1, vlab, sctype, field)
 
         P.draw()
         out2d = output[0] + pu.plane_in_outputname(figmode, draw2D) + output[1]

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -191,6 +191,10 @@ def plotcompose(pthfilen, var, output, options):
 
     drawa, drawu = pu.choose_amr_or_uniform(drawa, drawu, drawd, drawg, drawp, maxglev, gridlist)
     plotlevels = pu.check_plotlevels(plotlevels, maxglev, drawa)
+    if len(plotlevels) == 0:
+        print('No levels found. Skipping.')
+        return
+
     linstyl = pu.linestyles(linstyl, maxglev, plotlevels)
     if drawg:
         gcolor = pu.reorder_gridcolorlist(gcolor, maxglev, plotlevels)
@@ -229,7 +233,7 @@ def plotcompose(pthfilen, var, output, options):
         h5c.close()
 
     if not (parts[0] or drawd or drawg):
-        print('No particles or levels to plot. Skipping.')
+        print('No particles or datafields or grids to plot. Skipping.')
         return
 
     cbar_mode = pu.colorbar_mode(drawd, drawh, figmode)

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -174,7 +174,11 @@ def add_cbar(figmode, cbar_mode, grid, ab, ic, clab, sct, field):
             if tick >= field[1] and tick <= field[2]:
                 slticks.append(tick)
                 sltlabs.append(clf % (np.sign(tick) * 10.**(np.abs(tick)) * field[3]))
-        cbarh.set_ticks(slticks, labels=sltlabs)
+        if (matplotlib.__version__ >= '3.5.0'):
+            cbarh.set_ticks(slticks, labels=sltlabs)
+        else:
+            cbarh.set_ticks(slticks)
+            cbarh.set_ticklabels(sltlabs)
 
 
 def plotcompose(pthfilen, var, output, options):

--- a/visual/plot_compose.py
+++ b/visual/plot_compose.py
@@ -204,9 +204,9 @@ def plotcompose(pthfilen, var, output, options):
         extr = [], [], [], [], [], []
         if drawu:
             if len(plotlevels) > 1:
-                print('For uniform grid plotting only the firs given level!')
+                print('For uniform grid plotting only the first given level!')
             print('Plotting base level %s' % plotlevels[0])
-            refis, extr = rd.reconstruct_uniform(h5f, var, cmpr, plotlevels[0], gridlist, cu, center, smin, smax, draw1D, draw2D)
+            refis, extr = rd.reconstruct_uniform(h5f, var, cmpr, plotlevels[0], gridlist, center, smin, smax, draw1D, draw2D)
 
         if drawa or drawg:
             refis, extr = rd.collect_gridlevels(h5f, var, cmpr, refis, extr, maxglev, plotlevels, gridlist, cgcount, center, usc, drawd, draw1D, draw2D)

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -205,12 +205,9 @@ def find_indices(nd, cxyz, smin, smax, warn):
     return inb, icc
 
 
-def check_plotlevels(plotlevels, maxglev, drawa, toplot):
+def check_plotlevels(plotlevels, maxglev, toplot):
     if plotlevels == '':
-        if drawa:
-            plotlevels = range(maxglev + 1)
-        else:
-            plotlevels = 0,
+        plotlevels = range(maxglev + 1)
     else:
         npl = []
         for il in plotlevels:

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -177,6 +177,20 @@ def list3_or(l3, r3):
     return [l3[0] or r3[0], l3[1] or r3[1], l3[2] or r3[2]]
 
 
+def list_any(lst, strg):
+    for l in lst:
+        if l == strg:
+            return True
+    return False
+
+
+def list_all(lst, strg):
+    for l in lst:
+        if l != strg:
+            return False
+    return True
+
+
 def list3_other(l3, r3):
     ans = [False, False, False]
     if r3[0]:

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -188,10 +188,6 @@ def list3_other(l3, r3):
     return ans
 
 
-def labelx():
-    return lambda var: '$' + str(var)[2:-1].replace('**', '^') + '$'
-
-
 def labellog(sctype, symmin, cmpr0):
     logname = ''
     compare = ''
@@ -345,6 +341,16 @@ def check_1D2Ddefaults(axc, n_d, double_cbar):
     if double_cbar and (figmode == 1 or figmode == 2):
         figmode = figmode + 3
     return draw1D, draw2D, figmode
+
+
+def manage_units(var):
+    if var == b'dimensionless' and ps.dimensionless_print == '':
+        return ps.dimensionless_print
+    return " [%s]" % labelx()(var)
+
+
+def labelx():
+    return lambda var: '$' + str(var)[2:-1].replace('**', '^') + '$'
 
 
 def convert_units(infile, toplot):

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -88,9 +88,9 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
         vmax = vmax + ps.fineqv
 
     print('3D data value range: ', d3min, d3max)
-    if d2:
+    if any(d2):
         print('Slices  value range: ', d2min, d2max)
-    if d1:
+    if any(d1):
         print('1D data value range: ', d1min, d1max)
     print('Plotted value range: ', vmin, vmax)
     return vmin, vmax, symmin, autoscale
@@ -127,12 +127,9 @@ def check_extremes_absdata(refis, d1, d2):
 
 
 def scale_plotarray(pa, sctype, symmin):
-    print('moze zrobie log: ', sctype, symmin)
     if (sctype == '2' or sctype == 'log'):
-        print('robie log')
         pa = np.log10(pa)
     elif (sctype == '3' or sctype == 'symlog'):
-        print('robie symlog')
         pa = np.sign(pa) * np.log10(np.maximum(np.abs(pa) / symmin, 1.0))
     return pa
 

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -123,6 +123,10 @@ def scale_plotarray(pa, sctype, symmin):
     return pa
 
 
+def list3_subtraction(l3, s3):
+    return l3[0] - s3[0], l3[1] - s3[1], l3[2] - s3[2]
+
+
 def list3_division(l3, divisor):
     return l3[0] / divisor, l3[1] / divisor, l3[2] / divisor
 

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -153,8 +153,20 @@ def scale_plotarray(pa, sctype, symmin):
     return pa
 
 
+def list3_add(l3, s3):
+    return l3[0] + s3[0], l3[1] + s3[1], l3[2] + s3[2]
+
+
 def list3_subtraction(l3, s3):
     return l3[0] - s3[0], l3[1] - s3[1], l3[2] - s3[2]
+
+
+def list3_mult(l3, r3):
+    return l3[0] * r3[0], l3[1] * r3[1], l3[2] * r3[2]
+
+
+def list3_div(l3, r3):
+    return l3[0] / r3[0], l3[1] / r3[1], l3[2] / r3[2]
 
 
 def list3_division(l3, divisor):
@@ -175,6 +187,10 @@ def list3_and(l3, r3):
 
 def list3_or(l3, r3):
     return [l3[0] or r3[0], l3[1] or r3[1], l3[2] or r3[2]]
+
+
+def list3_alleq(l3, r3):
+    return [l3[0] == r3[0] and l3[1] == r3[1] and l3[2] == r3[2]]
 
 
 def list_any(lst, strg):

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -28,11 +28,14 @@ def fsym(vmin, vmax):
 
 def execute_comparison(orig, comp, ctype):
     if ctype == 1:
-        return orig - comp
+        maa = orig - comp
     elif ctype == 2:
-        return orig / comp
+        maa = orig / comp
     elif ctype == 3:
-        return (orig / comp) - 1
+        maa = (orig / comp) - 1
+    else:
+        maa = orig
+    return np.where(np.isnan(maa), ps.set_as_unexist, maa)
 
 
 def scale_translate(sctype, vmn, vmx, sm, hbd):

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -193,7 +193,7 @@ def find_indices(nd, cxyz, smin, smax, warn):
     return inb, icc
 
 
-def check_plotlevels(plotlevels, maxglev, drawa):
+def check_plotlevels(plotlevels, maxglev, drawa, toplot):
     if plotlevels == '':
         if drawa:
             plotlevels = range(maxglev + 1)
@@ -207,7 +207,10 @@ def check_plotlevels(plotlevels, maxglev, drawa):
             else:
                 print('LEVEL %s not met in the file!' % str(il))
         plotlevels = npl
-    print('LEVELS TO plot: ', plotlevels)
+    if toplot:
+        print('Levels to plot: ', plotlevels)
+    else:
+        print('Compare levels: ', plotlevels)
     return plotlevels
 
 

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -8,6 +8,13 @@ figplace = [(3, 2, 0), (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 0), (1, 0, 0)]
 cbsplace = [(1, 1), (-1, -1), (2, 2), (0, 1), (1, 1), (2, 2)]
 
 
+def recognize_opt(cur, lopt):
+    for op in lopt:
+        if cur == op:
+            return True
+    return False
+
+
 def plane_in_outputname(figmode, draw2D):
     to_insert = ''
     if figmode == 1 or figmode == 4:
@@ -39,17 +46,17 @@ def execute_comparison(orig, comp, ctype):
 
 
 def scale_translate(sctype, vmn, vmx, sm, hbd):
-    if (sctype == '0' or sctype == 'linear'):
+    if recognize_opt(sctype, ('0', 'linear')):
         return 0, vmn, vmx
-    elif (sctype == '1' or sctype == 'symlin'):
+    elif recognize_opt(sctype, ('1', 'symlin')):
         vmin, vmax = fsym(vmn, vmx)
         return 1, vmin, vmax
-    elif (sctype == '2' or sctype == 'log'):
+    elif recognize_opt(sctype, ('2', 'log')):
         if hbd:
             return 2, 10.**vmn, 10.**vmx
         else:
             return 2, vmn, vmx
-    elif (sctype == '3' or sctype == 'symlog'):
+    elif recognize_opt(sctype, ('3', 'symlog')):
         if hbd:
             return 3, -1.*10.**np.abs(vmn), 10.**np.abs(vmx) * sm, sm
         else:
@@ -75,10 +82,10 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
     else:
         vmin, vmax = umin, umax
 
-    if (sctype == '1' or sctype == 'symlin'):
+    if recognize_opt(sctype, ('1', 'symlin')):
         vmin, vmax = fsym(vmin, vmax)
 
-    elif (sctype == '2' or sctype == 'log'):
+    elif recognize_opt(sctype, ('2', 'log')):
         if (vmin > 0.0):
             vmin = np.log10(vmin)
         else:
@@ -89,7 +96,7 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
             vmax = ps.fineqv
         if (vmin == np.inf):
             vmin = vmax - ps.fineqv
-    elif (sctype == '3' or sctype == 'symlog'):
+    elif recognize_opt(sctype, ('3', 'symlog')):
         if (umin > 0.0 and umax > 0.0):
             symmin = umin
             vmax = np.log10(umax / symmin)
@@ -149,9 +156,9 @@ def check_extremes_absdata(refis, d1, d2):
 
 
 def scale_plotarray(pa, sctype, symmin):
-    if (sctype == '2' or sctype == 'log'):
+    if recognize_opt(sctype, ('2', 'log')):
         pa = np.log10(pa)
-    elif (sctype == '3' or sctype == 'symlog'):
+    elif recognize_opt(sctype, ('3', 'symlog')):
         pa = np.sign(pa) * np.log10(np.maximum(np.abs(pa) / symmin, 1.0))
     return pa
 
@@ -226,9 +233,9 @@ def labellog(sctype, symmin, cmpr0):
     compare = ''
     if cmpr0:
         compare = '(compared) '
-    if (sctype == '2' or sctype == 'log'):
+    if recognize_opt(sctype, ('2', 'log')):
         logname = 'log '
-    elif (sctype == '3' or sctype == 'symlog'):
+    elif recognize_opt(sctype, ('3', 'symlog')):
         logname = '{symmetry level = %8.3e} log ' % symmin
     return logname + compare
 

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -125,9 +125,9 @@ def check_minimum_data(refis, d1, d2):
             bxyz, binb, b1 = bl[0], bl[1], bl[5]
             for ncut in range(3):
                 if binb[ncut]:
-                    if d1[ncut]:
+                    if d1[ncut] and b1 != []:
                         cmdmin = min(cmdmin, np.min(b1[ncut], initial=np.inf, where=(b1[ncut] > 0.0)))
-                    if d2[ncut]:
+                    if d2[ncut] and bxyz != []:
                         cmdmin = min(cmdmin, np.min(bxyz[ncut], initial=np.inf, where=(bxyz[ncut] > 0.0)))
     return cmdmin
 
@@ -139,10 +139,10 @@ def check_extremes_absdata(refis, d1, d2):
             bxyz, binb, b1 = bl[0], bl[1], bl[5]
             for ncut in range(3):
                 if binb[ncut]:
-                    if d1[ncut]:
+                    if d1[ncut] and b1 != []:
                         cmdmin = min(cmdmin, np.min(np.abs(b1[ncut]), initial=np.inf, where=(np.abs(b1[ncut]) > 0.0)))
                         cmdmax = max(cmdmax, np.max(np.abs(b1[ncut]), initial=-np.inf, where=(np.abs(b1[ncut]) > 0.0)))
-                    if d2[ncut]:
+                    if d2[ncut] and bxyz != []:
                         cmdmin = min(cmdmin, np.min(np.abs(bxyz[ncut]), initial=np.inf, where=(np.abs(bxyz[ncut]) > 0.0)))
                         cmdmax = max(cmdmax, np.max(np.abs(bxyz[ncut]), initial=-np.inf, where=(np.abs(bxyz[ncut]) > 0.0)))
     return cmdmin, cmdmax

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -216,7 +216,7 @@ def list3_or(l3, r3):
 
 
 def list3_alleq(l3, r3):
-    return [l3[0] == r3[0] and l3[1] == r3[1] and l3[2] == r3[2]]
+    return l3[0] == r3[0] and l3[1] == r3[1] and l3[2] == r3[2]
 
 
 def list_any(lst, strg):

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -131,6 +131,14 @@ def list3_division(l3, divisor):
     return l3[0] / divisor, l3[1] / divisor, l3[2] / divisor
 
 
+def list3_max(l3, r3):
+    return [max(l3[0], r3[0]), max(l3[1], r3[1]), max(l3[2], r3[2])]
+
+
+def list3_min(l3, r3):
+    return [min(l3[0], r3[0]), min(l3[1], r3[1]), min(l3[2], r3[2])]
+
+
 def labelx():
     return lambda var: '$' + str(var)[2:-1].replace('**', '^') + '$'
 

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -199,6 +199,14 @@ def check_plotlevels(plotlevels, maxglev, drawa):
             plotlevels = range(maxglev + 1)
         else:
             plotlevels = 0,
+    else:
+        npl = []
+        for il in plotlevels:
+            if il in range(maxglev + 1):
+                npl.append(il)
+            else:
+                print('LEVEL %s not met in the file!' % str(il))
+        plotlevels = npl
     print('LEVELS TO plot: ', plotlevels)
     return plotlevels
 

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -35,6 +35,25 @@ def execute_comparison(orig, comp, ctype):
         return (orig / comp) - 1
 
 
+def scale_translate(sctype, vmn, vmx, sm, hbd):
+    if (sctype == '0' or sctype == 'linear'):
+        return 0, vmn, vmx
+    elif (sctype == '1' or sctype == 'symlin'):
+        vmin, vmax = fsym(vmn, vmx)
+        return 1, vmin, vmax
+    elif (sctype == '2' or sctype == 'log'):
+        if hbd:
+            return 2, 10.**vmn, 10.**vmx
+        else:
+            return 2, vmn, vmx
+    elif (sctype == '3' or sctype == 'symlog'):
+        if hbd:
+            return 3, -1.*10.**np.abs(vmn), 10.**np.abs(vmx) * sm, sm
+        else:
+            return 3, -1.*vmx, vmx, sm
+    return 0, vmn, vmx
+
+
 def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
     symmin = 1.0
     autoscale = False

--- a/visual/plot_utils.py
+++ b/visual/plot_utils.py
@@ -15,6 +15,22 @@ def recognize_opt(cur, lopt):
     return False
 
 
+def whether_linear(sct):
+    return recognize_opt(sct, ('0', 'linear'))
+
+
+def whether_symlin(sct):
+    return recognize_opt(sct, ('1', 'symlin'))
+
+
+def whether_log(sct):
+    return recognize_opt(sct, ('2', 'log'))
+
+
+def whether_symlog(sct):
+    return recognize_opt(sct, ('3', 'symlog'))
+
+
 def plane_in_outputname(figmode, draw2D):
     to_insert = ''
     if figmode == 1 or figmode == 4:
@@ -46,17 +62,17 @@ def execute_comparison(orig, comp, ctype):
 
 
 def scale_translate(sctype, vmn, vmx, sm, hbd):
-    if recognize_opt(sctype, ('0', 'linear')):
+    if whether_linear(sctype):
         return 0, vmn, vmx
-    elif recognize_opt(sctype, ('1', 'symlin')):
+    elif whether_symlin(sctype):
         vmin, vmax = fsym(vmn, vmx)
         return 1, vmin, vmax
-    elif recognize_opt(sctype, ('2', 'log')):
+    elif whether_log(sctype):
         if hbd:
             return 2, 10.**vmn, 10.**vmx
         else:
             return 2, vmn, vmx
-    elif recognize_opt(sctype, ('3', 'symlog')):
+    elif whether_symlog(sctype):
         if hbd:
             return 3, -1.*10.**np.abs(vmn), 10.**np.abs(vmx) * sm, sm
         else:
@@ -82,10 +98,10 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
     else:
         vmin, vmax = umin, umax
 
-    if recognize_opt(sctype, ('1', 'symlin')):
+    if whether_symlin(sctype):
         vmin, vmax = fsym(vmin, vmax)
 
-    elif recognize_opt(sctype, ('2', 'log')):
+    elif whether_log(sctype):
         if (vmin > 0.0):
             vmin = np.log10(vmin)
         else:
@@ -96,7 +112,7 @@ def scale_manage(sctype, refis, umin, umax, d1, d2, extr):
             vmax = ps.fineqv
         if (vmin == np.inf):
             vmin = vmax - ps.fineqv
-    elif recognize_opt(sctype, ('3', 'symlog')):
+    elif whether_symlog(sctype):
         if (umin > 0.0 and umax > 0.0):
             symmin = umin
             vmax = np.log10(umax / symmin)
@@ -156,9 +172,9 @@ def check_extremes_absdata(refis, d1, d2):
 
 
 def scale_plotarray(pa, sctype, symmin):
-    if recognize_opt(sctype, ('2', 'log')):
+    if whether_log(sctype):
         pa = np.log10(pa)
-    elif recognize_opt(sctype, ('3', 'symlog')):
+    elif whether_symlog(sctype):
         pa = np.sign(pa) * np.log10(np.maximum(np.abs(pa) / symmin, 1.0))
     return pa
 
@@ -233,9 +249,9 @@ def labellog(sctype, symmin, cmpr0):
     compare = ''
     if cmpr0:
         compare = '(compared) '
-    if recognize_opt(sctype, ('2', 'log')):
+    if whether_log(sctype):
         logname = 'log '
-    elif recognize_opt(sctype, ('3', 'symlog')):
+    elif whether_symlog(sctype):
         logname = '{symmetry level = %8.3e} log ' % symmin
     return logname + compare
 

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -118,7 +118,6 @@ def cli_params(argv):
             cmprn = cmprn + '_' + cmprd
 
         elif recognize_opt(opt, ("--compare-file",)):
-            print('rozpoznalem opcje')
             global cmprf
             cmpr = True
             cmprf = str(arg)

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -260,7 +260,7 @@ if '1z' in axcuts:
     p1z = True
 axc = [p1x, p1y, p1z], [p2yz, p2xz, p2xy]
 
-compare = cmpr, cmprf, cmprd, cmprt
+compare = cmpr, cmprf, cmprd, cmprt, False
 
 options = axc, zmin, zmax, cmap, pcolor, player, psize, sctype, cu, center, compare, draw_grid, draw_data, draw_uni, draw_amr, draw_part, nbins, uaxes, zoom, plotlevels, gridlist, gcolor, linstyl
 if not os.path.exists(plotdir):

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -26,7 +26,7 @@ draw_data = False
 draw_grid = False
 draw_uni, draw_amr = False, False
 plotlevels, gridlist = '', ''
-cmpr, cmprf, cmprd, cmprl, cmprn, cmprt = False, '', '', '', '', ps.plot2d_comparetype
+cmpr, cmprb, cmprf, cmprd, cmprl, cmprn, cmprt = False, False, '', '', '', '', ps.plot2d_comparetype
 dnames = ''
 uaxes = ''
 nbins = 1
@@ -50,6 +50,7 @@ def print_usage():
     print(' -c CX,CY,CZ, \t\t--center CX,CY,CZ \t\t\tplot cuts across given point coordinates CX, CY, CZ [default: computed domain center]')
     print('\t\t\t--compare-datafield VAR \t\tcompare chosen datafields to another VAR')
     print('\t\t\t--compare-file FILE \t\t\tcompare chosen datafields to another FILE')
+    print('\t\t\t--compare-frame \t\t\tframe grids to compare [default: switched-off]')
     print('\t\t\t--compare-level LEVEL1[,LEVEL2] \tspecify different grid levels to compare accross files [default: the same levels]')
     print('\t\t\t--compare-type TYPE \t\t\toperation executed as a comparison: 1 - subtraction, 2 - division, 3 - relative error [default: %s]' % ps.plot2d_comparetype)
     print(' -d VAR[,VAR2], \t--dataset VAR[,VAR2] \t\t\tspecify one or more datafield(s) to plot [default: print available datafields; all or _all_ to plot all available datafields]')
@@ -75,7 +76,7 @@ def print_usage():
 
 def cli_params(argv):
     try:
-        opts, args = getopt.getopt(argv, "a:b:c:d:D:e:g:hl:o:pP:r:R:s:t:T:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-datafield=", "compare-file=", "compare-level=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-h2d-scale=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
+        opts, args = getopt.getopt(argv, "a:b:c:d:D:e:g:hl:o:pP:r:R:s:t:T:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-datafield=", "compare-file=", "compare-frame", "compare-level=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-h2d-scale=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
     except getopt.GetoptError:
         print("Unrecognized options: %s \n" % argv)
         print_usage()
@@ -125,6 +126,10 @@ def cli_params(argv):
                 cmprn = '_vs'
             cmprn = cmprn + '_' + cmprf.split('/')[-1]
             cmprn = ''.join(cmprn.split('.')[:-1])
+
+        elif recognize_opt(opt, ("--compare-frame",)):
+            global cmprb
+            cmprb = True
 
         elif recognize_opt(opt, ("--compare-type",)):
             global cmprt
@@ -296,7 +301,7 @@ if '1z' in axcuts:
     p1z = True
 axc = [p1x, p1y, p1z], [p2yz, p2xz, p2xy]
 
-compare = cmpr, cmprf, cmprd, cmprl, cmprt, False
+compare = cmpr, cmprb, cmprf, cmprd, cmprl, cmprt, False
 
 options = axc, zmin, zmax, cmap, pcolor, player, psize, sctype, pstype, cu, center, compare, draw_grid, draw_data, draw_uni, draw_amr, draw_part, nbins, uaxes, zoom, plotlevels, gridlist, gcolor, linstyl
 if not os.path.exists(plotdir):

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -7,6 +7,7 @@ import os
 import sys
 import plot_compose as pc
 import pvf_settings as ps
+import plot_utils as pu
 
 exten = ps.f_exten
 plotdir = ps.f_plotdir
@@ -82,34 +83,34 @@ def cli_params(argv):
         print_usage()
         sys.exit(2)
     for opt, arg in opts:
-        if recognize_opt(opt, ("-h", "--help")):
+        if pu.recognize_opt(opt, ("-h", "--help")):
             print_usage()
             sys.exit()
 
-        elif recognize_opt(opt, ("-a", "--axes")):
+        elif pu.recognize_opt(opt, ("-a", "--axes")):
             global axcuts
             axcuts = arg.split(',')
 
-        elif recognize_opt(opt, ("-b", "--bins")):
+        elif pu.recognize_opt(opt, ("-b", "--bins")):
             global nbins
             nbins = int(arg)
 
-        elif recognize_opt(opt, ("-c", "--center")):
+        elif pu.recognize_opt(opt, ("-c", "--center")):
             global center, cu
             cx, cy, cz = arg.split(',')
             cu, center = True, [float(cx), float(cy), float(cz)]
 
-        elif recognize_opt(opt, ("-d", "--dataset")):
+        elif pu.recognize_opt(opt, ("-d", "--dataset")):
             global dnames
             global draw_data
             dnames = str(arg)
             draw_data = True
 
-        elif recognize_opt(opt, ("-D", "--colormap")):
+        elif pu.recognize_opt(opt, ("-D", "--colormap")):
             global cmap
             cmap = str(arg)
 
-        elif recognize_opt(opt, ("--compare-datafield",)):
+        elif pu.recognize_opt(opt, ("--compare-datafield",)):
             global cmpr, cmprd, cmprn
             cmpr = True
             cmprd = str(arg)
@@ -117,7 +118,7 @@ def cli_params(argv):
                 cmprn = '_vs'
             cmprn = cmprn + '_' + cmprd
 
-        elif recognize_opt(opt, ("--compare-file",)):
+        elif pu.recognize_opt(opt, ("--compare-file",)):
             global cmprf
             cmpr = True
             cmprf = str(arg)
@@ -126,53 +127,53 @@ def cli_params(argv):
             cmprn = cmprn + '_' + cmprf.split('/')[-1]
             cmprn = ''.join(cmprn.split('.')[:-1])
 
-        elif recognize_opt(opt, ("--compare-frame",)):
+        elif pu.recognize_opt(opt, ("--compare-frame",)):
             global cmprb
             cmprb = True
 
-        elif recognize_opt(opt, ("--compare-type",)):
+        elif pu.recognize_opt(opt, ("--compare-type",)):
             global cmprt
             cmprt = int(arg)
             if cmprt != 1 and cmprt != 2 and cmprt != 3:
                 print('Warning: Unrecognized type of comparison: %s. Taking 1 (subtraction).' % arg)
 
-        elif recognize_opt(opt, ("-e", "--extension")):
+        elif pu.recognize_opt(opt, ("-e", "--extension")):
             global exten
             exten = '.' + str(arg)
             print(exten)
 
-        elif recognize_opt(opt, ("-g", "--gridcolor")):
+        elif pu.recognize_opt(opt, ("-g", "--gridcolor")):
             global gcolor, draw_grid
             gcolor = str(arg)
             draw_grid = True
 
-        elif recognize_opt(opt, ("-l", "--level")):
+        elif pu.recognize_opt(opt, ("-l", "--level")):
             global plotlevels
             plotlevels = [int(i) for i in arg.split(',')]
 
-        elif recognize_opt(opt, ("--compare-level",)):
+        elif pu.recognize_opt(opt, ("--compare-level",)):
             global cmprl
             cmpr = True
             cmprl = [int(i) for i in arg.split(',')]
 
-        elif recognize_opt(opt, ("--linestyle",)):
+        elif pu.recognize_opt(opt, ("--linestyle",)):
             global linstyl
             linstyl = arg.split(',')
 
-        elif recognize_opt(opt, ("-o", "--output")):
+        elif pu.recognize_opt(opt, ("-o", "--output")):
             global plotdir
             plotdir = str(arg)
             print('PLOTDIR: ', plotdir)
 
-        elif recognize_opt(opt, ("-p", "--particles")):
+        elif pu.recognize_opt(opt, ("-p", "--particles")):
             global draw_part
             draw_part = True
 
-        elif recognize_opt(opt, ("-P", "--particle-color")):
+        elif pu.recognize_opt(opt, ("-P", "--particle-color")):
             global pcolor
             pcolor = str(arg)
 
-        elif recognize_opt(opt, ("-r", "--particle-slice")):
+        elif pu.recognize_opt(opt, ("-r", "--particle-slice")):
             global player
             aux = arg.split(',')
             if len(aux) >= 3:
@@ -180,18 +181,18 @@ def cli_params(argv):
             else:
                 player = True, aux[0], aux[0], aux[0]
 
-        elif recognize_opt(opt, ("-R", "--particle-space")):
+        elif pu.recognize_opt(opt, ("-R", "--particle-space")):
             aux = arg.split(',')
             if len(aux) >= 3:
                 player = False, aux[0], aux[1], aux[2]
             else:
                 player = False, aux[0], aux[0], aux[0]
 
-        elif recognize_opt(opt, ("-s", "--particle-sizes")):
+        elif pu.recognize_opt(opt, ("-s", "--particle-sizes")):
             global psize
             psize = float(arg)
 
-        elif recognize_opt(opt, ("-T", "--particle-h2d-scale")):
+        elif pu.recognize_opt(opt, ("-T", "--particle-h2d-scale")):
             global pstype
             aux = arg.split(',')
             if len(aux) > 2:
@@ -208,34 +209,34 @@ def cli_params(argv):
                 l3 = None
             pstype = l1, l2, l3
 
-        elif recognize_opt(opt, ("-t", "--scale")):
+        elif pu.recognize_opt(opt, ("-t", "--scale")):
             global sctype
             sctype = str(arg)
 
-        elif recognize_opt(opt, ("-u", "--units")):
+        elif pu.recognize_opt(opt, ("-u", "--units")):
             global uaxes
             uaxes = str(arg)
 
-        elif recognize_opt(opt, ("-z", "--zlim")):
+        elif pu.recognize_opt(opt, ("-z", "--zlim")):
             global zmin, zmax
             zmin, zmax = arg.split(',')
             zmin = float(zmin)
             zmax = float(zmax)
             print("zmin, zmax = ", zmin, zmax)
 
-        elif recognize_opt(opt, ("--amr",)):
+        elif pu.recognize_opt(opt, ("--amr",)):
             global draw_amr
             draw_amr = True
 
-        elif recognize_opt(opt, ("--grid-list",)):
+        elif pu.recognize_opt(opt, ("--grid-list",)):
             global gridlist
             gridlist = [int(i) for i in arg.split(',')]
 
-        elif recognize_opt(opt, ("--uniform",)):
+        elif pu.recognize_opt(opt, ("--uniform",)):
             global draw_uni
             draw_uni = True
 
-        elif recognize_opt(opt, ("--zoom",)):
+        elif pu.recognize_opt(opt, ("--zoom",)):
             global zoom
             aux = arg.split(',')
             if len(aux) > 1:
@@ -243,13 +244,6 @@ def cli_params(argv):
                 print("ZOOM: xmin, xmax = ", zoom[1][0], zoom[2][0], 'ymin, ymax = ', zoom[1][1], zoom[2][1], 'zmin, zmax = ', zoom[1][2], zoom[2][2])
             else:
                 zoom = True, int(aux[0])
-
-
-def recognize_opt(cur, lopt):
-    for op in lopt:
-        if cur == op:
-            return True
-    return False
 
 
 if (len(sys.argv) < 2):
@@ -329,7 +323,7 @@ for pthfilen in files_list:
     print("Reading file: %s" % pthfilen)
     prd, prp, prg = '', '', ''
     if draw_data:
-        if dnames == "_all_" or dnames == "all":
+        if pu.recognize_opt(dnames, ("_all_", "all")):
             varlist = h5f['field_types'].keys()
         else:
             varlist = dnames.split(',')

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -49,17 +49,17 @@ def print_usage():
     print('\t\t\t--amr\t\t\t\t\tcollect all refinement levels of grid to plot [default: True while AMR refinement level structure exists]')
     print(' -b BINS, \t\t--bins BINS \t\t\t\tmake a 2D histogram plot using BINS number instead of scattering particles [default: 1, which leads to scattering]')
     print(' -c CX,CY,CZ, \t\t--center CX,CY,CZ \t\t\tplot cuts across given point coordinates CX, CY, CZ [default: computed domain center]')
-    print('\t\t\t--compare-datafield VAR \t\tcompare chosen datafields to another VAR')
-    print('\t\t\t--compare-file FILE \t\t\tcompare chosen datafields to another FILE')
-    print('\t\t\t--compare-frame \t\t\tframe grids to compare [default: switched-off]')
-    print('\t\t\t--compare-level LEVEL1[,LEVEL2] \tspecify different grid levels to compare accross files [default: the same levels]')
-    print('\t\t\t--compare-type TYPE \t\t\toperation executed as a comparison: 1 - subtraction, 2 - division, 3 - relative error [default: %s]' % ps.plot2d_comparetype)
+    print(' -C\t\t\t--compare-adjusted-grids \t\tadjust ranges of grids to compare [default: switched-off]')
     print(' -d VAR[,VAR2], \t--dataset VAR[,VAR2] \t\t\tspecify one or more datafield(s) to plot [default: print available datafields; all or _all_ to plot all available datafields]')
     print(' -D COLORMAP, \t\t--colormap COLORMAP \t\t\tuse COLORMAP palette [default: %s]' % ps.plot2d_colormap)
+    print('\t\t\t--compare-datafield VAR \t\tcompare chosen datafields to another VAR')
+    print('\t\t\t--compare-type TYPE \t\t\toperation executed as a comparison: 1 - subtraction, 2 - division, 3 - relative error [default: %s]' % ps.plot2d_comparetype)
     print(' -e EXTENSION, \t\t--extension EXTENSION \t\t\tsave plot in file using filename extension EXTENSION [default: %s]' % ps.f_exten[1:])
+    print(' -F FILE\t\t--compare-file FILE \t\t\tcompare chosen datafields to another FILE')
     print(' -g COLOR, \t\t--gridcolor COLOR \t\t\tshow grids in color COLOR; possible list of colors for different grid refinement levels [default: none]')
     print('\t\t\t--grid-list GRID1[,GRID2] \t\tplot only selected numbered grid blocks [default: all existing blocks]')
     print(' -l LEVEL1[,LEVEL2], \t--level LEVEL1[,LEVEL2] \t\tplot only requested grid levels [default: all]')
+    print(' -L LEVEL1[,LEVEL2]\t--compare-level LEVEL1[,LEVEL2] \tspecify different grid levels to compare accross files [default: the same levels]')
     print('\t\t\t--linestyle STYLELIST \t\t\tline styles list for different refinement levels in 1D plots [default: %s]' % ps.plot1d_linestyle)
     print(' -o OUTPUT, \t\t--output OUTPUT \t\t\tdump plot files into OUTPUT directory [default: %s]' % ps.f_plotdir)
     print(' -p,\t\t\t--particles\t\t\t\tscatter particles onto slices [default: switched-off]')
@@ -77,7 +77,7 @@ def print_usage():
 
 def cli_params(argv):
     try:
-        opts, args = getopt.getopt(argv, "a:b:c:d:D:e:g:hl:o:pP:r:R:s:t:T:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-datafield=", "compare-file=", "compare-frame", "compare-level=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-h2d-scale=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
+        opts, args = getopt.getopt(argv, "a:b:c:Cd:D:e:F:g:hl:L:o:pP:r:R:s:t:T:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-adjusted-grids", "compare-datafield=", "compare-file=", "compare-level=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-h2d-scale=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
     except getopt.GetoptError:
         print("Unrecognized options: %s \n" % argv)
         print_usage()
@@ -118,7 +118,7 @@ def cli_params(argv):
                 cmprn = '_vs'
             cmprn = cmprn + '_' + cmprd
 
-        elif pu.recognize_opt(opt, ("--compare-file",)):
+        elif pu.recognize_opt(opt, ("-F", "--compare-file")):
             global cmprf
             cmpr = True
             cmprf = str(arg)
@@ -127,7 +127,7 @@ def cli_params(argv):
             cmprn = cmprn + '_' + cmprf.split('/')[-1]
             cmprn = ''.join(cmprn.split('.')[:-1])
 
-        elif pu.recognize_opt(opt, ("--compare-frame",)):
+        elif pu.recognize_opt(opt, ("-C", "--compare-adjusted-grids")):
             global cmprb
             cmprb = True
 
@@ -151,7 +151,7 @@ def cli_params(argv):
             global plotlevels
             plotlevels = [int(i) for i in arg.split(',')]
 
-        elif pu.recognize_opt(opt, ("--compare-level",)):
+        elif pu.recognize_opt(opt, ("-L", "--compare-level")):
             global cmprl
             cmpr = True
             cmprl = [int(i) for i in arg.split(',')]
@@ -259,7 +259,7 @@ for word in sys.argv[1:]:
     else:
         optilist.append(word)
     opt_cmpf = False
-    if word == '--compare-file':
+    if pu.recognize_opt(word, ("-F", "--compare-file")):
         opt_cmpf = True
 
 if files_list == []:

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -188,15 +188,11 @@ def cli_params(argv):
         elif recognize_opt(opt, ("-T", "--particle-h2d-scale")):
             global pstype
             aux = arg.split(',')
-            print(len(aux))
             if len(aux) > 2:
-                print('sa 3 argumenty')
                 pstype = aux[0], aux[1], aux[2]
             elif len(aux) > 1:
-                print('sa 2 argumenty')
                 pstype = aux[0], aux[1], pstype[2]
             elif len(aux) > 0:
-                print('jest jeden argument')
                 pstype = aux[0], pstype[1], pstype[2]
             l1 = aux[0].lower() in ("yes", "true", "t", "1")
             l2, l3 = pstype[1:3]

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -68,7 +68,7 @@ def print_usage():
     print(' -u UNIT, \t\t--units UNIT \t\t\tscale plot axes with UNIT [default: dataset units]')
     print('\t\t\t--uniform\t\t\treconstruct uniform grid to plot [default: True while no AMR refinement level structure exists]')
     print(' -z ZMIN,ZMAX, \t\t--zlim ZMIN,ZMAX \t\tlimit colorscale to ZMIN and ZMAX [default: computed data maxima symmetrized]')
-    print('\t\t\t--zoom XL,XR,YL,YR,ZL,ZR \tset plot axes ranges [default: domain edges]')
+    print('\t\t\t--zoom XL,XR,YL,YR,ZL,ZR | LEVEL \tset plot axes ranges or take ranges from LEVEL [default: domain edges | 0]')
 
 
 def cli_params(argv):
@@ -213,8 +213,11 @@ def cli_params(argv):
         elif opt in ("--zoom",):
             global zoom
             aux = arg.split(',')
-            zoom = True, [float(aux[0]), float(aux[2]), float(aux[4])], [float(aux[1]), float(aux[3]), float(aux[5])]
-            print("ZOOM: xmin, xmax = ", zoom[1][0], zoom[2][0], 'ymin, ymax = ', zoom[1][1], zoom[2][1], 'zmin, zmax = ', zoom[1][2], zoom[2][2])
+            if len(aux) > 1:
+                zoom = True, [float(aux[0]), float(aux[2]), float(aux[4])], [float(aux[1]), float(aux[3]), float(aux[5])]
+                print("ZOOM: xmin, xmax = ", zoom[1][0], zoom[2][0], 'ymin, ymax = ', zoom[1][1], zoom[2][1], 'zmin, zmax = ', zoom[1][2], zoom[2][2])
+            else:
+                zoom = True, int(aux[0])
 
 
 if (len(sys.argv) < 2):

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -25,7 +25,7 @@ draw_data = False
 draw_grid = False
 draw_uni, draw_amr = False, False
 plotlevels, gridlist = '', ''
-cmpr, cmprf, cmprd, cmprn, cmprt = False, '', '', '', ps.plot2d_comparetype
+cmpr, cmprf, cmprd, cmprl, cmprn, cmprt = False, '', '', '', '', ps.plot2d_comparetype
 dnames = ''
 uaxes = ''
 nbins = 1
@@ -49,6 +49,7 @@ def print_usage():
     print(' -c CX,CY,CZ, \t\t--center CX,CY,CZ \t\tplot cuts across given point coordinates CX, CY, CZ [default: computed domain center]')
     print('\t\t\t--compare-datafield VAR \tcompare chosen datafields to another VAR')
     print('\t\t\t--compare-file FILE \t\tcompare chosen datafields to another FILE')
+    print('\t\t\t--compare-level LEVEL1[,LEVEL2] \tspecify different grid levels to compare accross files [default: the same levels]')
     print('\t\t\t--compare-type TYPE \t\toperation executed as a comparison: 1 - subtraction, 2 - division, 3 - relative error [default: %s]' % ps.plot2d_comparetype)
     print(' -d VAR[,VAR2], \t--dataset VAR[,VAR2] \t\tspecify one or more datafield(s) to plot [default: print available datafields; all or _all_ to plot all available datafields]')
     print(' -D COLORMAP, \t\t--colormap COLORMAP \t\tuse COLORMAP palette [default: %s]' % ps.plot2d_colormap)
@@ -72,7 +73,7 @@ def print_usage():
 
 def cli_params(argv):
     try:
-        opts, args = getopt.getopt(argv, "a:b:c:d:D:e:g:hl:o:pP:r:R:s:t:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-datafield=", "compare-file=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
+        opts, args = getopt.getopt(argv, "a:b:c:d:D:e:g:hl:o:pP:r:R:s:t:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-datafield=", "compare-file=", "compare-level=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
     except getopt.GetoptError:
         print("Unrecognized options: %s \n" % argv)
         print_usage()
@@ -141,6 +142,10 @@ def cli_params(argv):
         elif opt in ("-l", "--level"):
             global plotlevels
             plotlevels = [int(i) for i in arg.split(',')]
+
+        elif opt in ("--compare-level"):
+            global cmprl
+            cmprl = [int(i) for i in arg.split(',')]
 
         elif opt in ("--linestyle"):
             global linstyl
@@ -260,7 +265,7 @@ if '1z' in axcuts:
     p1z = True
 axc = [p1x, p1y, p1z], [p2yz, p2xz, p2xy]
 
-compare = cmpr, cmprf, cmprd, cmprt, False
+compare = cmpr, cmprf, cmprd, cmprl, cmprt, False
 
 options = axc, zmin, zmax, cmap, pcolor, player, psize, sctype, cu, center, compare, draw_grid, draw_data, draw_uni, draw_amr, draw_part, nbins, uaxes, zoom, plotlevels, gridlist, gcolor, linstyl
 if not os.path.exists(plotdir):

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -108,7 +108,7 @@ def cli_params(argv):
             global cmap
             cmap = str(arg)
 
-        elif recognize_opt(opt, ("--compare-datafield")):
+        elif recognize_opt(opt, ("--compare-datafield",)):
             global cmpr, cmprd, cmprn
             cmpr = True
             cmprd = str(arg)
@@ -116,7 +116,8 @@ def cli_params(argv):
                 cmprn = '_vs'
             cmprn = cmprn + '_' + cmprd
 
-        elif recognize_opt(opt, ("--compare-file")):
+        elif recognize_opt(opt, ("--compare-file",)):
+            print('rozpoznalem opcje')
             global cmprf
             cmpr = True
             cmprf = str(arg)
@@ -125,7 +126,7 @@ def cli_params(argv):
             cmprn = cmprn + '_' + cmprf.split('/')[-1]
             cmprn = ''.join(cmprn.split('.')[:-1])
 
-        elif recognize_opt(opt, ("--compare-type")):
+        elif recognize_opt(opt, ("--compare-type",)):
             global cmprt
             cmprt = int(arg)
             if cmprt != 1 and cmprt != 2 and cmprt != 3:
@@ -145,11 +146,11 @@ def cli_params(argv):
             global plotlevels
             plotlevels = [int(i) for i in arg.split(',')]
 
-        elif recognize_opt(opt, ("--compare-level")):
+        elif recognize_opt(opt, ("--compare-level",)):
             global cmprl
             cmprl = [int(i) for i in arg.split(',')]
 
-        elif recognize_opt(opt, ("--linestyle")):
+        elif recognize_opt(opt, ("--linestyle",)):
             global linstyl
             linstyl = arg.split(',')
 

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -12,6 +12,7 @@ exten = ps.f_exten
 plotdir = ps.f_plotdir
 cmap = ps.plot2d_colormap
 sctype = ps.plot2d_sctype
+pstype = ps.hist2d_sctype
 psize = ps.particles_size
 pcolor = 'default'
 gcolor = ''
@@ -42,38 +43,39 @@ def print_usage():
     print('Usage for particles:       ./pvf.py <HDF5 files> -p [options]')
     print('')
     print('Options:')
-    print(' -h, \t\t\t--help \t\t\t\tprint this help')
-    print(' -a CUT1[,CUT2], \t--axes CUT1[,CUT2] \t\tselect plot cuts from the following: 1x, 1y, 1z, xy, xz, yz, 1D, 2D [default: all 2D cuts, otherwise all 1D]')
-    print('\t\t\t--amr\t\t\t\tcollect all refinement levels of grid to plot [default: True while AMR refinement level structure exists]')
-    print(' -b BINS, \t\t--bins BINS \t\t\tmake a 2D histogram plot using BINS number instead of scattering particles [default: 1, which leads to scattering]')
-    print(' -c CX,CY,CZ, \t\t--center CX,CY,CZ \t\tplot cuts across given point coordinates CX, CY, CZ [default: computed domain center]')
-    print('\t\t\t--compare-datafield VAR \tcompare chosen datafields to another VAR')
-    print('\t\t\t--compare-file FILE \t\tcompare chosen datafields to another FILE')
+    print(' -h, \t\t\t--help \t\t\t\t\tprint this help')
+    print(' -a CUT1[,CUT2], \t--axes CUT1[,CUT2] \t\t\tselect plot cuts from the following: 1x, 1y, 1z, xy, xz, yz, 1D, 2D [default: all 2D cuts, otherwise all 1D]')
+    print('\t\t\t--amr\t\t\t\t\tcollect all refinement levels of grid to plot [default: True while AMR refinement level structure exists]')
+    print(' -b BINS, \t\t--bins BINS \t\t\t\tmake a 2D histogram plot using BINS number instead of scattering particles [default: 1, which leads to scattering]')
+    print(' -c CX,CY,CZ, \t\t--center CX,CY,CZ \t\t\tplot cuts across given point coordinates CX, CY, CZ [default: computed domain center]')
+    print('\t\t\t--compare-datafield VAR \t\tcompare chosen datafields to another VAR')
+    print('\t\t\t--compare-file FILE \t\t\tcompare chosen datafields to another FILE')
     print('\t\t\t--compare-level LEVEL1[,LEVEL2] \tspecify different grid levels to compare accross files [default: the same levels]')
-    print('\t\t\t--compare-type TYPE \t\toperation executed as a comparison: 1 - subtraction, 2 - division, 3 - relative error [default: %s]' % ps.plot2d_comparetype)
-    print(' -d VAR[,VAR2], \t--dataset VAR[,VAR2] \t\tspecify one or more datafield(s) to plot [default: print available datafields; all or _all_ to plot all available datafields]')
-    print(' -D COLORMAP, \t\t--colormap COLORMAP \t\tuse COLORMAP palette [default: %s]' % ps.plot2d_colormap)
-    print(' -e EXTENSION, \t\t--extension EXTENSION \t\tsave plot in file using filename extension EXTENSION [default: %s]' % ps.f_exten[1:])
-    print(' -g COLOR, \t\t--gridcolor COLOR \t\tshow grids in color COLOR; possible list of colors for different grid refinement levels [default: none]')
-    print('\t\t\t--grid-list GRID1[,GRID2] \tplot only selected numbered grid blocks [default: all existing blocks]')
-    print(' -l LEVEL1[,LEVEL2], \t--level LEVEL1[,LEVEL2] \tplot only requested grid levels [default: 0 for --uniform, all for --amr]')
-    print('\t\t\t--linestyle STYLELIST \t\tline styles list for different refinement levels in 1D plots [default: %s]' % ps.plot1d_linestyle)
-    print(' -o OUTPUT, \t\t--output OUTPUT \t\tdump plot files into OUTPUT directory [default: %s]' % ps.f_plotdir)
-    print(' -p,\t\t\t--particles\t\t\tscatter particles onto slices [default: switched-off]')
-    print(' -P,\t\t\t--particle-color\t\tuse color for particles scattering or colormap for particles histogram plot [default: %s or %s]' % (ps.particles_color, ps.hist2d_colormap))
-    print(' -r W1[,W2,W3],\t\t--particle-slice W1[,W2,W3]\tread particles from layers +/-W1 around center; uses different widths for different projections if W1,W2,W3 requested [default: all particles]')
-    print(' -R W1[,W2,W3],\t\t--particle-space W1[,W2,W3]\tread particles from square +/-W1 around center or cuboid if W1,W2,W3 requested [default: no limits]')
-    print(' -s,\t\t\t--particle-sizes\t\tmarker sizes for scattering particles onto slices [default: switched-off]')
-    print(' -t SCALETYPE, \t\t--scale SCALETYPE \t\tdump use SCALETYPE scale type for displaying data (possible values: 0 | linear, 1 | symlin, 2 | log, 3 | symlog) [default: %s]' % ps.plot2d_sctype)
-    print(' -u UNIT, \t\t--units UNIT \t\t\tscale plot axes with UNIT [default: dataset units]')
-    print('\t\t\t--uniform\t\t\treconstruct uniform grid to plot [default: True while no AMR refinement level structure exists]')
-    print(' -z ZMIN,ZMAX, \t\t--zlim ZMIN,ZMAX \t\tlimit colorscale to ZMIN and ZMAX [default: computed data maxima symmetrized]')
+    print('\t\t\t--compare-type TYPE \t\t\toperation executed as a comparison: 1 - subtraction, 2 - division, 3 - relative error [default: %s]' % ps.plot2d_comparetype)
+    print(' -d VAR[,VAR2], \t--dataset VAR[,VAR2] \t\t\tspecify one or more datafield(s) to plot [default: print available datafields; all or _all_ to plot all available datafields]')
+    print(' -D COLORMAP, \t\t--colormap COLORMAP \t\t\tuse COLORMAP palette [default: %s]' % ps.plot2d_colormap)
+    print(' -e EXTENSION, \t\t--extension EXTENSION \t\t\tsave plot in file using filename extension EXTENSION [default: %s]' % ps.f_exten[1:])
+    print(' -g COLOR, \t\t--gridcolor COLOR \t\t\tshow grids in color COLOR; possible list of colors for different grid refinement levels [default: none]')
+    print('\t\t\t--grid-list GRID1[,GRID2] \t\tplot only selected numbered grid blocks [default: all existing blocks]')
+    print(' -l LEVEL1[,LEVEL2], \t--level LEVEL1[,LEVEL2] \t\tplot only requested grid levels [default: 0 for --uniform, all for --amr]')
+    print('\t\t\t--linestyle STYLELIST \t\t\tline styles list for different refinement levels in 1D plots [default: %s]' % ps.plot1d_linestyle)
+    print(' -o OUTPUT, \t\t--output OUTPUT \t\t\tdump plot files into OUTPUT directory [default: %s]' % ps.f_plotdir)
+    print(' -p,\t\t\t--particles\t\t\t\tscatter particles onto slices [default: switched-off]')
+    print(' -P,\t\t\t--particle-color\t\t\tuse color for particles scattering or colormap for particles histogram plot [default: %s or %s]' % (ps.particles_color, ps.hist2d_colormap))
+    print(' -r W1[,W2,W3],\t\t--particle-slice W1[,W2,W3]\t\tread particles from layers +/-W1 around center; uses different widths for different projections if W1,W2,W3 requested [default: all particles]')
+    print(' -R W1[,W2,W3],\t\t--particle-space W1[,W2,W3]\t\tread particles from square +/-W1 around center or cuboid if W1,W2,W3 requested [default: no limits]')
+    print(' -s,\t\t\t--particle-sizes\t\t\tmarker sizes for scattering particles onto slices [default: switched-off]')
+    print(' -T LOG[,MIN,MAX]\t--particle-h2d-scale LOG[,MIN,MAX]\tscaling particle 2D histogram [default: %s %s %s]' % ps.hist2d_sctype)
+    print(' -t SCALETYPE, \t\t--scale SCALETYPE \t\t\tdump use SCALETYPE scale type for displaying data (possible values: 0 | linear, 1 | symlin, 2 | log, 3 | symlog) [default: %s]' % ps.plot2d_sctype)
+    print(' -u UNIT, \t\t--units UNIT \t\t\t\tscale plot axes with UNIT [default: dataset units]')
+    print('\t\t\t--uniform\t\t\t\treconstruct uniform grid to plot [default: True while no AMR refinement level structure exists]')
+    print(' -z ZMIN,ZMAX, \t\t--zlim ZMIN,ZMAX \t\t\tlimit colorscale to ZMIN and ZMAX [default: computed data maxima symmetrized]')
     print('\t\t\t--zoom XL,XR,YL,YR,ZL,ZR | LEVEL \tset plot axes ranges or take ranges from LEVEL [default: domain edges | 0]')
 
 
 def cli_params(argv):
     try:
-        opts, args = getopt.getopt(argv, "a:b:c:d:D:e:g:hl:o:pP:r:R:s:t:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-datafield=", "compare-file=", "compare-level=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
+        opts, args = getopt.getopt(argv, "a:b:c:d:D:e:g:hl:o:pP:r:R:s:t:T:u:z:", ["help", "amr", "axes=", "bins=", "center=", "colormap=", "compare-datafield=", "compare-file=", "compare-level=", "compare-type=", "dataset=", "extension=", "gridcolor=", "grid-list=", "level=", "linestyle=", "output=", "particles", "particle-color=", "particle-h2d-scale=", "particle-space=", "particle-sizes=", "particle-slice=", "scale=", "uniform", "units=", "zlim=", "zoom="])
     except getopt.GetoptError:
         print("Unrecognized options: %s \n" % argv)
         print_usage()
@@ -183,6 +185,27 @@ def cli_params(argv):
             global psize
             psize = float(arg)
 
+        elif recognize_opt(opt, ("-T", "--particle-h2d-scale")):
+            global pstype
+            aux = arg.split(',')
+            print(len(aux))
+            if len(aux) > 2:
+                print('sa 3 argumenty')
+                pstype = aux[0], aux[1], aux[2]
+            elif len(aux) > 1:
+                print('sa 2 argumenty')
+                pstype = aux[0], aux[1], pstype[2]
+            elif len(aux) > 0:
+                print('jest jeden argument')
+                pstype = aux[0], pstype[1], pstype[2]
+            l1 = aux[0].lower() in ("yes", "true", "t", "1")
+            l2, l3 = pstype[1:3]
+            if l2 == 'auto':
+                l2 = None
+            if l3 == 'auto':
+                l3 = None
+            pstype = l1, l2, l3
+
         elif recognize_opt(opt, ("-t", "--scale")):
             global sctype
             sctype = str(arg)
@@ -277,7 +300,7 @@ axc = [p1x, p1y, p1z], [p2yz, p2xz, p2xy]
 
 compare = cmpr, cmprf, cmprd, cmprl, cmprt, False
 
-options = axc, zmin, zmax, cmap, pcolor, player, psize, sctype, cu, center, compare, draw_grid, draw_data, draw_uni, draw_amr, draw_part, nbins, uaxes, zoom, plotlevels, gridlist, gcolor, linstyl
+options = axc, zmin, zmax, cmap, pcolor, player, psize, sctype, pstype, cu, center, compare, draw_grid, draw_data, draw_uni, draw_amr, draw_part, nbins, uaxes, zoom, plotlevels, gridlist, gcolor, linstyl
 if not os.path.exists(plotdir):
     os.makedirs(plotdir)
 

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -59,7 +59,7 @@ def print_usage():
     print(' -e EXTENSION, \t\t--extension EXTENSION \t\t\tsave plot in file using filename extension EXTENSION [default: %s]' % ps.f_exten[1:])
     print(' -g COLOR, \t\t--gridcolor COLOR \t\t\tshow grids in color COLOR; possible list of colors for different grid refinement levels [default: none]')
     print('\t\t\t--grid-list GRID1[,GRID2] \t\tplot only selected numbered grid blocks [default: all existing blocks]')
-    print(' -l LEVEL1[,LEVEL2], \t--level LEVEL1[,LEVEL2] \t\tplot only requested grid levels [default: 0 for --uniform, all for --amr]')
+    print(' -l LEVEL1[,LEVEL2], \t--level LEVEL1[,LEVEL2] \t\tplot only requested grid levels [default: all]')
     print('\t\t\t--linestyle STYLELIST \t\t\tline styles list for different refinement levels in 1D plots [default: %s]' % ps.plot1d_linestyle)
     print(' -o OUTPUT, \t\t--output OUTPUT \t\t\tdump plot files into OUTPUT directory [default: %s]' % ps.f_plotdir)
     print(' -p,\t\t\t--particles\t\t\t\tscatter particles onto slices [default: switched-off]')

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -148,6 +148,7 @@ def cli_params(argv):
 
         elif recognize_opt(opt, ("--compare-level",)):
             global cmprl
+            cmpr = True
             cmprl = [int(i) for i in arg.split(',')]
 
         elif recognize_opt(opt, ("--linestyle",)):

--- a/visual/pvf.py
+++ b/visual/pvf.py
@@ -79,34 +79,34 @@ def cli_params(argv):
         print_usage()
         sys.exit(2)
     for opt, arg in opts:
-        if opt in ("-h", "--help"):
+        if recognize_opt(opt, ("-h", "--help")):
             print_usage()
             sys.exit()
 
-        elif opt in ("-a", "--axes"):
+        elif recognize_opt(opt, ("-a", "--axes")):
             global axcuts
             axcuts = arg.split(',')
 
-        elif opt in ("-b", "--bins"):
+        elif recognize_opt(opt, ("-b", "--bins")):
             global nbins
             nbins = int(arg)
 
-        elif opt in ("-c", "--center"):
+        elif recognize_opt(opt, ("-c", "--center")):
             global center, cu
             cx, cy, cz = arg.split(',')
             cu, center = True, [float(cx), float(cy), float(cz)]
 
-        elif opt in ("-d", "--dataset"):
+        elif recognize_opt(opt, ("-d", "--dataset")):
             global dnames
             global draw_data
             dnames = str(arg)
             draw_data = True
 
-        elif opt in ("-D", "--colormap"):
+        elif recognize_opt(opt, ("-D", "--colormap")):
             global cmap
             cmap = str(arg)
 
-        elif opt in ("--compare-datafield"):
+        elif recognize_opt(opt, ("--compare-datafield")):
             global cmpr, cmprd, cmprn
             cmpr = True
             cmprd = str(arg)
@@ -114,7 +114,7 @@ def cli_params(argv):
                 cmprn = '_vs'
             cmprn = cmprn + '_' + cmprd
 
-        elif opt in ("--compare-file"):
+        elif recognize_opt(opt, ("--compare-file")):
             global cmprf
             cmpr = True
             cmprf = str(arg)
@@ -123,48 +123,48 @@ def cli_params(argv):
             cmprn = cmprn + '_' + cmprf.split('/')[-1]
             cmprn = ''.join(cmprn.split('.')[:-1])
 
-        elif opt in ("--compare-type"):
+        elif recognize_opt(opt, ("--compare-type")):
             global cmprt
             cmprt = int(arg)
             if cmprt != 1 and cmprt != 2 and cmprt != 3:
                 print('Warning: Unrecognized type of comparison: %s. Taking 1 (subtraction).' % arg)
 
-        elif opt in ("-e", "--extension"):
+        elif recognize_opt(opt, ("-e", "--extension")):
             global exten
             exten = '.' + str(arg)
             print(exten)
 
-        elif opt in ("-g", "--gridcolor"):
+        elif recognize_opt(opt, ("-g", "--gridcolor")):
             global gcolor, draw_grid
             gcolor = str(arg)
             draw_grid = True
 
-        elif opt in ("-l", "--level"):
+        elif recognize_opt(opt, ("-l", "--level")):
             global plotlevels
             plotlevels = [int(i) for i in arg.split(',')]
 
-        elif opt in ("--compare-level"):
+        elif recognize_opt(opt, ("--compare-level")):
             global cmprl
             cmprl = [int(i) for i in arg.split(',')]
 
-        elif opt in ("--linestyle"):
+        elif recognize_opt(opt, ("--linestyle")):
             global linstyl
             linstyl = arg.split(',')
 
-        elif opt in ("-o", "--output"):
+        elif recognize_opt(opt, ("-o", "--output")):
             global plotdir
             plotdir = str(arg)
             print('PLOTDIR: ', plotdir)
 
-        elif opt in ("-p", "--particles"):
+        elif recognize_opt(opt, ("-p", "--particles")):
             global draw_part
             draw_part = True
 
-        elif opt in ("-P", "--particle-color"):
+        elif recognize_opt(opt, ("-P", "--particle-color")):
             global pcolor
             pcolor = str(arg)
 
-        elif opt in ("-r", "--particle-slice"):
+        elif recognize_opt(opt, ("-r", "--particle-slice")):
             global player
             aux = arg.split(',')
             if len(aux) >= 3:
@@ -172,45 +172,45 @@ def cli_params(argv):
             else:
                 player = True, aux[0], aux[0], aux[0]
 
-        elif opt in ("-R", "--particle-space"):
+        elif recognize_opt(opt, ("-R", "--particle-space")):
             aux = arg.split(',')
             if len(aux) >= 3:
                 player = False, aux[0], aux[1], aux[2]
             else:
                 player = False, aux[0], aux[0], aux[0]
 
-        elif opt in ("-s", "--particle-sizes"):
+        elif recognize_opt(opt, ("-s", "--particle-sizes")):
             global psize
             psize = float(arg)
 
-        elif opt in ("-t", "--scale"):
+        elif recognize_opt(opt, ("-t", "--scale")):
             global sctype
             sctype = str(arg)
 
-        elif opt in ("-u", "--units"):
+        elif recognize_opt(opt, ("-u", "--units")):
             global uaxes
             uaxes = str(arg)
 
-        elif opt in ("-z", "--zlim"):
+        elif recognize_opt(opt, ("-z", "--zlim")):
             global zmin, zmax
             zmin, zmax = arg.split(',')
             zmin = float(zmin)
             zmax = float(zmax)
             print("zmin, zmax = ", zmin, zmax)
 
-        elif opt in ("--amr",):
+        elif recognize_opt(opt, ("--amr",)):
             global draw_amr
             draw_amr = True
 
-        elif opt in ("--grid-list",):
+        elif recognize_opt(opt, ("--grid-list",)):
             global gridlist
             gridlist = [int(i) for i in arg.split(',')]
 
-        elif opt in ("--uniform",):
+        elif recognize_opt(opt, ("--uniform",)):
             global draw_uni
             draw_uni = True
 
-        elif opt in ("--zoom",):
+        elif recognize_opt(opt, ("--zoom",)):
             global zoom
             aux = arg.split(',')
             if len(aux) > 1:
@@ -218,6 +218,13 @@ def cli_params(argv):
                 print("ZOOM: xmin, xmax = ", zoom[1][0], zoom[2][0], 'ymin, ymax = ', zoom[1][1], zoom[2][1], 'zmin, zmax = ', zoom[1][2], zoom[2][2])
             else:
                 zoom = True, int(aux[0])
+
+
+def recognize_opt(cur, lopt):
+    for op in lopt:
+        if cur == op:
+            return True
+    return False
 
 
 if (len(sys.argv) < 2):

--- a/visual/pvf_settings.py
+++ b/visual/pvf_settings.py
@@ -26,6 +26,10 @@ centertick_length = 6.
 # scaletypes
 fineqv = 1.0
 
+#units
+#dimensionless_print = b'dimensionless'
+dimensionless_print = ''
+
 # colorbars
 cbar_hist2d_shift = 0.7
 cbar_plot2d_shift = 0.1

--- a/visual/pvf_settings.py
+++ b/visual/pvf_settings.py
@@ -29,6 +29,7 @@ fineqv = 1.0
 #units
 #dimensionless_print = b'dimensionless'
 dimensionless_print = ''
+set_as_unexist = 0.
 
 # colorbars
 cbar_hist2d_shift = 0.7

--- a/visual/pvf_settings.py
+++ b/visual/pvf_settings.py
@@ -43,3 +43,4 @@ particles_size = 0
 hist2d_colormap = 'viridis'
 hist2d_alpha = 1.0
 hist2d_facecolor = 'xkcd:black'
+hist2d_sctype = True, 'auto', 'auto'

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -61,11 +61,11 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
             print('Comparison for levels: %s and %s not available due to unmet resolution constraints.' % (level, cmprl[levnum]))
             return False, [], []
 
-    inb, ind = pu.find_indices(nd, center, ledg, redg, True)
+    inb, ind = pu.find_indices(nd, center, ledg, redg, draw1D, draw2D, True)
     print('Plot center', center[0], center[1], center[2], 'gives indices:', ind[0], ind[1], ind[2], 'for uniform grid level', level)
 
     b2d, b1d, d1min, d1max, d2min, d2max, d3min, d3max = take_cuts_and_lines(dset, ind, draw1D, draw2D)
-    block = b2d, [True, True, True], pu.list3_division(ledg, usc), pu.list3_division(redg, usc), level, b1d
+    block = b2d, inb, pu.list3_division(ledg, usc), pu.list3_division(redg, usc), level, b1d
 
     return levelmet, block, [d1min, d1max, d2min, d2max, d3min, d3max]
 
@@ -188,7 +188,7 @@ def read_block(h5f, dset_name, cmpr, ig, olev, oc, usc, getmap, draw1D, draw2D):
     ledge = h5g.attrs['left_edge']
     redge = h5g.attrs['right_edge']
     ngb = h5g.attrs['n_b']
-    inb, ind = pu.find_indices(ngb, oc, ledge, redge, False)
+    inb, ind = pu.find_indices(ngb, oc, ledge, redge, draw1D, draw2D, False)
     if not any(inb):
         return False, [], []
     if not getmap:

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -5,10 +5,49 @@ import plot_utils as pu
 import pvf_settings as ps
 
 
+def manage_compare(cmpr, h5f, var, maxglev, plotlevels, gridlist, drawa, drawu, drawg):
+    cmpr0, cmprf, cmprd, cmprt, diff_struct = cmpr
+    if cmpr0:
+        if cmprd == '':
+            cmprd = var
+        if cmprf == '':
+            cmpr = cmpr0, h5f, cmprd, cmprt, diff_struct
+        else:
+            h5c = h5.File(cmprf, 'r')
+            diff_struct = compare_grids(h5f, h5c, maxglev, plotlevels, gridlist)
+            if diff_struct:
+                print('Difference in h5 files structure')
+                drawa, drawu, drawg = False, True, False
+            cmpr = cmpr0, h5c, cmprd, cmprt, diff_struct
+    return cmpr, drawa, drawu, drawg
+
+
+def compare_grids(h1, h2, maxglev, plotlevels, gridlist):
+    if maxglev != max(h2['grid_level'][:]):
+        return True
+    for level in range(maxglev + 1):
+        if level in plotlevels:
+            for ig in gridlist:
+                h5g1 = h1['data']['grid_' + str(ig).zfill(10)]
+                h5g2 = h2['data']['grid_' + str(ig).zfill(10)]
+                if h5g1.attrs['level'] == level:
+                    if h5g2.attrs['level'] != level:
+                        return True
+                    if any(h5g1.attrs['off'] != h5g2.attrs['off']):
+                        return True
+                    if any(h5g1.attrs['n_b'] != h5g2.attrs['n_b']):
+                        return True
+    return False
+
 def reconstruct_uniform(h5f, var, cmpr, level, gridlist, cu, center, smin, smax, draw1D, draw2D):
     dset, nd, levelmet = collect_dataset(h5f, var, cmpr, level, gridlist)
     if not levelmet:
         return [], []
+    cmpr0, h5c, cmprd, cmprt, diff_struct = cmpr
+    if diff_struct:
+        dc, ndc, lmc = collect_dataset(h5c, cmprd, cmpr, level, range(int(h5c['data'].attrs['cg_count'])))
+        if nd == ndc and lmc:
+            dset = pu.execute_comparison(dset, dc, cmprt)
 
     if cu:
         inb, ind = pu.find_indices(nd, center, smin, smax, True)
@@ -39,9 +78,9 @@ def collect_dataset(h5f, dset_name, cmpr, level, gridlist):
             n_b = [int(ngb[0]), int(ngb[1]), int(ngb[2])]
             ce = n_b + off
             dset[off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]] = h5g[dset_name][:, :, :].swapaxes(0, 2)
-            cmpr0, h5c, cmprd, cmprt = cmpr
-            if cmpr0:
-                dset[off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]] = pu.execute_comparison(dset[off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]], h5c['data']['grid_' + str(ig).zfill(10)][dset_name][:, :, :].swapaxes(0, 2), cmprt)
+            cmpr0, h5c, cmprd, cmprt, diff_struct = cmpr
+            if cmpr0 and not diff_struct:
+                dset[off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]] = pu.execute_comparison(dset[off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]], h5c['data']['grid_' + str(ig).zfill(10)][cmprd][:, :, :].swapaxes(0, 2), cmprt)
 
     return dset, nd, levelmet
 
@@ -88,7 +127,7 @@ def read_block(h5f, dset_name, cmpr, ig, olev, oc, usc, getmap, draw1D, draw2D):
     n_b = [int(ngb[0]), int(ngb[1]), int(ngb[2])]
     ce = n_b + off
     dset = h5g[dset_name][:, :, :].swapaxes(0, 2)
-    cmpr0, h5c, cmprd, cmprt = cmpr
+    cmpr0, h5c, cmprd, cmprt, diff_struct = cmpr
     if cmpr0:
         dset = pu.execute_comparison(dset, h5c['data']['grid_' + str(ig).zfill(10)][cmprd][:, :, :].swapaxes(0, 2), cmprt)
 

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -86,7 +86,6 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
                 nd, ndc = ndgg, ndgg
                 loff, loc = lofg, lofg
         else:
-            print('offsety: ', loff, loc, roff, roc)
             print('Comparison for levels: %s and %s not available due to unmet resolution constraints. Dimensions %s and %s do not match.' % (level, cmprl[levnum], nd, ndc))
             return False, [], []
 

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -64,7 +64,7 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
             return False, [], []
         if nd == ndc and not cmprb:
             if ledg != lec or redg != rec:
-                print('WARNING: Edges for level %s: %s %s are different than for level %s: %s %s. Consider excluding levels.' % (level, ledg, redg, cmprl[levnum], lec, rec))
+                print('WARNING: Edges for level %s: %s %s are different than for level %s: %s %s. Consider excluding levels or -C / --compare-adjusted-grids option.' % (level, ledg, redg, cmprl[levnum], lec, rec))
         elif cmprb:
             if (nd, ledg, redg) != (ndc, lec, rec):
                 sfmin = h5f['simulation_parameters'].attrs['domain_left_edge']

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -162,7 +162,7 @@ def frame_level(h5f, level, gridlist):
 def level_zoom(h5f, gridlist, zoom, smin, smax):
     if zoom[0]:
         if len(zoom) == 2:
-            nd, loff, ledg, redg, levelmet = frame_level(h5f, zoom[1], gridlist)
+            nd, loff, roff, ledg, redg, levelmet = frame_level(h5f, zoom[1], gridlist)
             if levelmet:
                 zoom = True, ledg, redg
             else:

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -127,6 +127,19 @@ def frame_level(h5f, level, gridlist):
         return [], [], [], [], False
 
 
+def level_zoom(h5f, gridlist, zoom, smin, smax):
+    if zoom[0]:
+        if len(zoom) == 2:
+            nd, loff, ledg, redg, levelmet = frame_level(h5f, zoom[1], gridlist)
+            if levelmet:
+                zoom = True, ledg, redg
+            else:
+                zoom = False,
+    if not zoom[0]:
+        zoom = False, smin, smax
+    return zoom
+
+
 def collect_gridlevels(h5f, var, cmpr, refis, maxglev, plotlevels, gridlist, cgcount, center, usc, getmap, drawu, drawa, drawg, draw1D, draw2D):
     l1, h1, l2, h2, l3, h3 = [], [], [], [], [], []
     lev_num = -1

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -5,7 +5,7 @@ import plot_utils as pu
 import pvf_settings as ps
 
 
-def manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu, drawg):
+def manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu):
     cmpr0, cmprf, cmprd, cmprl, cmprt, diff_struct = cmpr
     cunavail = False
     if cmpr0:
@@ -22,9 +22,9 @@ def manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu, drawg):
             cunavail = (cmprl == [])
             if diff_struct:
                 print('Difference in h5 files structure')
-                drawa, drawu, drawg = False, True, False
+                drawa, drawu = False, True
             cmpr = cmpr0, h5c, cmprd, cmprl, cmprt, diff_struct
-    return cunavail, cmpr, drawa, drawu, drawg
+    return cunavail, cmpr, drawa, drawu
 
 
 def compare_grids(h1, h2, plotlevels, cmprl, gridlist):
@@ -163,10 +163,10 @@ def collect_gridlevels(h5f, var, cmpr, refis, maxglev, plotlevels, gridlist, cgc
 
             if drawa or drawg:
                 for ib in gridlist:
-                    levok, block, extr = read_block(h5f, var, cmpr, ib, iref, center, usc, getmap, draw1D, draw2D)
+                    levok, block, extr = read_block(h5f, var, cmpr, ib, iref, center, usc, (getmap and drawa), draw1D, draw2D)
                     if levok:
                         blks.append(block)
-                        if getmap:
+                        if getmap and drawa:
                             l1.append(extr[0])
                             h1.append(extr[1])
                             l2.append(extr[2])

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -110,10 +110,10 @@ def frame_level(h5f, level, gridlist):
             n_b = [int(ngb[0]), int(ngb[1]), int(ngb[2])]
             ce = n_b + off
             if off_started:
-                lind = [min(lind[0], off[0]), min(lind[1], off[1]), min(lind[2], off[2])]
-                rind = [max(rind[0],  ce[0]), max(rind[1],  ce[1]), max(rind[2],  ce[2])]
-                ledg = [min(ledg[0], lft[0]), min(ledg[1], lft[1]), min(ledg[2], lft[2])]
-                redg = [max(redg[0], rht[0]), max(redg[1], rht[1]), max(redg[2], rht[2])]
+                lind = pu.list3_min(lind, off)
+                rind = pu.list3_max(rind, ce)
+                ledg = pu.list3_min(ledg, lft)
+                redg = pu.list3_max(redg, rht)
             else:
                 lind = off
                 rind = ce

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -107,7 +107,7 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
 
 def collect_dataset(h5f, dset_name, cmpr, level, gridlist, nd, loff):
     print('Reading', dset_name)
-    dset = np.empty((nd[0], nd[1], nd[2]))
+    dset = np.full((nd[0], nd[1], nd[2]), np.nan)
 
     print('Reconstructing domain from cg parts')
     for ig in gridlist:

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -73,7 +73,7 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
                 scmax = h5c['simulation_parameters'].attrs['domain_right_edge']
                 sfdom = sfmin, sfmax
                 scdom = scmin, scmax
-                if not pu.list3_alleq(sfmin, sfmax) or pu.list3_alleq(sfmax, scmax):
+                if not pu.list3_alleq(sfmin, sfmax) or not pu.list3_alleq(sfmax, scmax):
                     print('Framing levels from domains of different edges! %svs. %s' % (sfdom, scdom))
                 lofg = pu.list3_min(loff, loc)
                 rofg = pu.list3_max(roff, roc)

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -71,10 +71,8 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
                 sfmax = h5f['simulation_parameters'].attrs['domain_right_edge']
                 scmin = h5c['simulation_parameters'].attrs['domain_left_edge']
                 scmax = h5c['simulation_parameters'].attrs['domain_right_edge']
-                sfdom = sfmin, sfmax
-                scdom = scmin, scmax
-                if not pu.list3_alleq(sfmin, sfmax) or not pu.list3_alleq(sfmax, scmax):
-                    print('Framing levels from domains of different edges! %svs. %s' % (sfdom, scdom))
+                if not pu.list3_alleq(sfmin, scmin) or not pu.list3_alleq(sfmax, scmax):
+                    print('Framing levels from domains of different edges! %s %s vs. %s %s' % (sfmin, sfmax, scmin, scmax))
                 lofg = pu.list3_min(loff, loc)
                 rofg = pu.list3_max(roff, roc)
 
@@ -84,6 +82,8 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
                 ledg = pu.list3_add(ledg, pu.list3_mult(pu.list3_subtraction(lofg, loff), dlf))
                 rec = pu.list3_add(rec, pu.list3_mult(pu.list3_subtraction(rofg, roc), dlc))
                 lec = pu.list3_add(lec, pu.list3_mult(pu.list3_subtraction(lofg, loc), dlc))
+                if not pu.list3_alleq(dlf, dlc):
+                    print('Comparison for %s and %s may give weird results as cell sizes are different: %s %s' % (level, cmprl[levnum], dlf, dlc))
 
                 ndgg = pu.list3_subtraction(rofg, lofg)
                 nd, ndc = ndgg, ndgg

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -58,7 +58,7 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
             if ledg != lec or redg != rec:
                 print('WARNING: Edges for level %s: %s %s are different than for level %s: %s %s. Consider excluding levels.' % (level, ledg, redg, cmprl[levnum], lec, rec))
         else:
-            print('Comparison for levels: %s and %s not available due to unmet resolution constraints.' % (level, cmprl[levnum]))
+            print('Comparison for levels: %s and %s not available due to unmet resolution constraints. Dimensions do not match.' % (level, cmprl[levnum]))
             return False, [], []
 
     inb, ind = pu.find_indices(nd, center, ledg, redg, draw1D, draw2D, True)

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -46,7 +46,7 @@ def compare_grids(h1, h2, plotlevels, cmprl, gridlist):
                     return True
     return False
 
-def reconstruct_uniform(h5f, var, cmpr, level, gridlist, cu, center, smin, smax, draw1D, draw2D):
+def reconstruct_uniform(h5f, var, cmpr, level, gridlist, center, smin, smax, draw1D, draw2D):
     dset, nd, levelmet = collect_dataset(h5f, var, cmpr, level, gridlist)
     if not levelmet:
         return [], []
@@ -59,11 +59,8 @@ def reconstruct_uniform(h5f, var, cmpr, level, gridlist, cu, center, smin, smax,
             print('Comparison not available due to unmet resolution constraints.')
             return [], []
 
-    if cu:
-        inb, ind = pu.find_indices(nd, center, smin, smax, True)
-        print('Ordered plot center', center[0], center[1], center[2], ' gives following uniform grid indices:', ind[0], ind[1], ind[2])
-    else:
-        ind = int(nd[0] / 2), int(nd[1] / 2), int(nd[2] / 2)
+    inb, ind = pu.find_indices(nd, center, smin, smax, True)
+    print('Plot center', center[0], center[1], center[2], 'gives indices:', ind[0], ind[1], ind[2], 'for uniform grid level', level)
 
     b2d, b1d, d1min, d1max, d2min, d2max, d3min, d3max = take_cuts_and_lines(dset, ind, draw1D, draw2D)
     block = b2d, [True, True, True], smin, smax, level, b1d
@@ -85,6 +82,7 @@ def collect_dataset(h5f, dset_name, cmpr, level, gridlist):
             levelmet = True
             off = h5g.attrs['off']
             ngb = h5g.attrs['n_b']
+
             n_b = [int(ngb[0]), int(ngb[1]), int(ngb[2])]
             ce = n_b + off
             dset[off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]] = h5g[dset_name][:, :, :].swapaxes(0, 2)

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -13,17 +13,17 @@ def manage_compare(cmpr, h5f, var, plotlevels, gridlist, drawa, drawu):
             cmprd = var
         if cmprf == '':
             if cmprl != plotlevels:
-                print('Levels to compare in the same file cannot be different. Ignoring.')
-            cmpr = cmpr0, h5f, cmprd, plotlevels, cmprt, diff_struct
+                print('Different levels to compare in the same file. Might be weird.')
+            h5c = h5f
         else:
             h5c = h5.File(cmprf, 'r')
-            cmprl = pu.check_plotlevels(cmprl, max(h5c['grid_level'][:]), False)
-            diff_struct = compare_grids(h5f, h5c, plotlevels, cmprl, gridlist)
-            cunavail = (cmprl == [])
-            if diff_struct:
-                print('Difference in h5 files structure')
-                drawa, drawu = False, True
-            cmpr = cmpr0, h5c, cmprd, cmprl, cmprt, diff_struct
+        cmprl = pu.check_plotlevels(cmprl, max(h5c['grid_level'][:]), False)
+        diff_struct = compare_grids(h5f, h5c, plotlevels, cmprl, gridlist)
+        cunavail = (cmprl == [])
+        if diff_struct:
+            print('Difference in datafields structure or not matching levels.')
+            drawa, drawu = False, True
+        cmpr = cmpr0, h5c, cmprd, cmprl, cmprt, diff_struct
     return cunavail, cmpr, drawa, drawu
 
 

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -58,7 +58,7 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
             if ledg != lec or redg != rec:
                 print('WARNING: Edges for level %s: %s %s are different than for level %s: %s %s. Consider excluding levels.' % (level, ledg, redg, cmprl[levnum], lec, rec))
         else:
-            print('Comparison for levels: %s and %s not available due to unmet resolution constraints. Dimensions do not match.' % (level, cmprl[levnum]))
+            print('Comparison for levels: %s and %s not available due to unmet resolution constraints. Dimensions %s and %s do not match.' % (level, cmprl[levnum], nd, ndc))
             return False, [], []
 
     inb, ind = pu.find_indices(nd, center, ledg, redg, draw1D, draw2D, True)

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -78,9 +78,9 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
                 dlf = pu.list3_div(pu.list3_subtraction(redg, ledg), nd)
                 dlc = pu.list3_div(pu.list3_subtraction(rec, lec), ndc)
                 redg = pu.list3_add(redg, pu.list3_mult(pu.list3_subtraction(rofg, roff), dlf))
-                ledg = pu.list3_add(ledg, pu.list3_mult(pu.list3_subtraction(loff, lofg), dlf))
+                ledg = pu.list3_add(ledg, pu.list3_mult(pu.list3_subtraction(lofg, loff), dlf))
                 rec = pu.list3_add(rec, pu.list3_mult(pu.list3_subtraction(rofg, roc), dlc))
-                lec = pu.list3_add(lec, pu.list3_mult(pu.list3_subtraction(loc, lofg), dlc))
+                lec = pu.list3_add(lec, pu.list3_mult(pu.list3_subtraction(lofg, loc), dlc))
 
                 ndgg = pu.list3_subtraction(rofg, lofg)
                 nd, ndc = ndgg, ndgg

--- a/visual/read_dataset.py
+++ b/visual/read_dataset.py
@@ -56,6 +56,9 @@ def reconstruct_uniform(h5f, var, cmpr, levnum, level, gridlist, center, usc, dr
         return False, [], []
     cmpr0, cmprb, h5c, cmprd, cmprl, cmprt, diff_struct = cmpr
     if diff_struct:
+        if len(cmprl) <= levnum:
+            print('Level to compare not found. Consider more detailed requirement for level comparison.')
+            return False, [], []
         ndc, loc, roc, lec, rec, lmc = frame_level(h5c, cmprl[levnum], range(int(h5c['data'].attrs['cg_count'])))
         if not lmc:
             return False, [], []


### PR DESCRIPTION
Improvemetns enable:
* comparing files with the same domains but divided into different block structure
* reconstruction of uniform grid for framed blocks of any refinement level
* zooming to refinement level area passed by --zoom LEVEL
* comparing different refinement levels from different file provided that got meshes that matches
* 1d hybrid plots of grid datafield and particles histrogram
* usage of --scale and -z/--zlim  for 1d particles histogram
* introduced -T/--particle-h2d-scale option to mange colorscale for 2d particle histogram separately
* user managing labels of dimensionless units
* print true values instead of symmin-coded to colorbar labels while using symlog scale type