### PR TITLE
0-dimensional simulations

### DIFF
--- a/problems/mcrtest/initproblem.F90
+++ b/problems/mcrtest/initproblem.F90
@@ -67,7 +67,7 @@ contains
       x0             = 0.0         !< x-position of the blob
       y0             = 0.0         !< y-position of the blob
       z0             = 0.0         !< z-position of the blob
-      r0             = 5.* minval(dom%L_(:)/dom%n_d(:), mask=dom%has_dir(:))  !< radius of the blob
+      r0             = merge(0., 5.* minval(dom%L_(:)/dom%n_d(:), mask=dom%has_dir(:)), dom%eff_dim == 0)  !< radius of the blob
 
       beta_cr        = 0.0         !< ambient level
       amp_cr1        = 1.0         !< amplitude of the blob
@@ -212,7 +212,8 @@ contains
                      do jpm = mantle(xdim,LO), mantle(xdim,HI)
                         do kpm = mantle(xdim,LO), mantle(xdim,HI)
                            r2 = (cg%x(i)-x0+real(ipm)*dom%L_(xdim))**2+(cg%y(j)-y0+real(jpm)*dom%L_(ydim))**2+(cg%z(k)-z0+real(kpm)*dom%L_(zdim))**2
-                           decr = decr + exp(-r2/r0**2)
+                           if (r2/r0 < 0.4999*log(huge(1.))) &  ! preventing numerical underflow
+                                decr = decr + exp(-r2/r0**2)
                         enddo
                      enddo
                   enddo

--- a/problems/mcrtest/initproblem.F90
+++ b/problems/mcrtest/initproblem.F90
@@ -212,7 +212,7 @@ contains
                      do jpm = mantle(xdim,LO), mantle(xdim,HI)
                         do kpm = mantle(xdim,LO), mantle(xdim,HI)
                            r2 = (cg%x(i)-x0+real(ipm)*dom%L_(xdim))**2+(cg%y(j)-y0+real(jpm)*dom%L_(ydim))**2+(cg%z(k)-z0+real(kpm)*dom%L_(zdim))**2
-                           if (r2/r0 < 0.4999*log(huge(1.))) &  ! preventing numerical underflow
+                           if (r2/r0**2 < 0.9999*log(huge(1.))) &  ! preventing numerical underflow
                                 decr = decr + exp(-r2/r0**2)
                         enddo
                      enddo

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -528,9 +528,15 @@ contains
 
       if (code_progress < PIERNIK_INIT_IO_IC) call die("[dataio:init_dataio] Some physics modules are not initialized.")
 
-      write(fmt_loc,  '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,16x,            ",dom%eff_dim+1,"(1x,i4),",dom%eff_dim,"(1x,f12.4))"
-      write(fmt_dtloc,'(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'  dt=',es11.4, ",dom%eff_dim+1,"(1x,i4),",dom%eff_dim,"(1x,f12.4))"
-      write(fmt_vloc, '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'   v=',es11.4, ",dom%eff_dim+1,"(1x,i4),",dom%eff_dim,"(1x,f12.4))"
+      if (dom%eff_dim == 0) then
+         fmt_loc   = "(2x,a12,a3,'  = ',es16.9,16x,            1x,i4)"
+         fmt_dtloc = "(2x,a12,a3,'  = ',es16.9,'  dt=',es11.4, 1x,i4)"
+         fmt_vloc  = "(2x,a12,a3,'  = ',es16.9,'   v=',es11.4, 1x,i4)"
+      else
+         write(fmt_loc,  '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,16x,            ", dom%eff_dim+1, "(1x,i4),", dom%eff_dim, "(1x,f12.4))"
+         write(fmt_dtloc,'(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'  dt=',es11.4, ", dom%eff_dim+1, "(1x,i4),", dom%eff_dim, "(1x,f12.4))"
+         write(fmt_vloc, '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'   v=',es11.4, ", dom%eff_dim+1, "(1x,i4),", dom%eff_dim, "(1x,f12.4))"
+      endif
 
       if (master) tn = walltime_end%time_left(wend)
 

--- a/src/fluids/cosmicrays/sourcecosmicrays.F90
+++ b/src/fluids/cosmicrays/sourcecosmicrays.F90
@@ -117,6 +117,7 @@ contains
    subroutine src_cr_spallation_and_decay(uu, n, usrc, rk_coeff)
 
       use cr_data,        only: eCRSP, cr_table, cr_tau, cr_sigma, icr_Be10, icrH, icrL
+      use dataio_pub,     only: die
       use domain,         only: dom
       use fluids_pub,     only: has_ion, has_neu
       use fluidindex,     only: flind
@@ -135,6 +136,8 @@ contains
       real, parameter                            :: gamma_lor = 10.0 !< \todo should taken from cosmic ray species settings
       real                                       :: gn
       integer                                    :: i, j
+
+      if (dom%eff_dim == 0) call die("[sourcecosmicrays:src_cr_spallation_and_decay] dom%eff_dim == 0 is not supported yet")
 
       gn = 1.0 / dom%eff_dim / gamma_lor
       dgas = 0.0

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -314,7 +314,7 @@ contains
          case ("isolated", "iso")
             grav_bnd = bnd_isolated
          case ("periodic", "per")
-            if (any(dom%bnd(:,:) /= BND_PER)) &
+            if (any(dom%bnd(:,:) /= BND_PER) .and. (dom%eff_dim > 0)) &
                  call die("[multigrid_gravity:multigrid_grav_par] cannot enforce periodic boundaries for gravity on a not fully periodic domain")
             grav_bnd = bnd_periodic
          case ("dirichlet", "dir")
@@ -543,15 +543,22 @@ contains
 #endif /* !NO_FFT */
 
       ! this should work correctly also when dom%eff_dim < 3
-      cg%mg%r  = overrelax / 2.
-      cg%mg%rx = cg%dvol**2 * cg%idx2
-      cg%mg%ry = cg%dvol**2 * cg%idy2
-      cg%mg%rz = cg%dvol**2 * cg%idz2
-      cg%mg%r  = cg%mg%r / (cg%mg%rx + cg%mg%ry + cg%mg%rz)
-      cg%mg%rx = cg%mg%r * cg%mg%rx
-      cg%mg%ry = cg%mg%r * cg%mg%ry
-      cg%mg%rz = cg%mg%r * cg%mg%rz
-      cg%mg%r  = cg%mg%r * cg%dvol**2
+      if (dom%eff_dim == 0) then  ! disable relaxation at all
+         cg%mg%r  = 1.
+         cg%mg%rx = 0.
+         cg%mg%ry = 0.
+         cg%mg%rz = 0.
+      else
+         cg%mg%r  = overrelax / 2.
+         cg%mg%rx = cg%dvol**2 * cg%idx2
+         cg%mg%ry = cg%dvol**2 * cg%idy2
+         cg%mg%rz = cg%dvol**2 * cg%idz2
+         cg%mg%r  = cg%mg%r / (cg%mg%rx + cg%mg%ry + cg%mg%rz)
+         cg%mg%rx = cg%mg%r * cg%mg%rx
+         cg%mg%ry = cg%mg%r * cg%mg%ry
+         cg%mg%rz = cg%mg%r * cg%mg%rz
+         cg%mg%r  = cg%mg%r * cg%dvol**2
+      endif
 
       ! FFT solver storage and data
       curl => find_level(cg%l%id)

--- a/src/grid/decomposition.F90
+++ b/src/grid/decomposition.F90
@@ -174,7 +174,11 @@ contains
       endif
 
       ! this is the minimal total area of internal boundaries (periodic case), achievable for some perfect domain divisions
-      ideal_bnd_area = dom%eff_dim * (pieces * product(real(this%n_d(:)))**(dom%eff_dim-1))**(1./dom%eff_dim)
+      if (dom%eff_dim == 0) then
+         ideal_bnd_area = 1.
+      else
+         ideal_bnd_area = dom%eff_dim * (pieces * product(real(this%n_d(:)))**(dom%eff_dim-1))**(1./dom%eff_dim)
+      endif
 
       ! Try to find a close-to-optimal cartesian decomposition into same-sized blocks
       call decompose_patch_uniform(p_size(:), this%n_d, pieces, level_id)
@@ -559,8 +563,10 @@ contains
 
       if (master) then
 #ifdef VERBOSE
-         write(msg,'(a,3f10.2,a,i10)')"m:ddr id p_size = [",(pieces/product(real(n_d(:), kind=8)))**(1./dom%eff_dim)*n_d(:),"], cells= ", int(ideal_bnd_area)
-         call printinfo(msg)
+         if (dom%eff_dim /= 0) then
+            write(msg,'(a,3f10.2,a,i10)')"m:ddr id p_size = [",(pieces/product(real(n_d(:), kind=8)))**(1./dom%eff_dim)*n_d(:),"], cells= ", int(ideal_bnd_area)
+            call printinfo(msg)
+         endif
 #endif /* VERBOSE */
          write(msg,'(a,i3,a,3i4,a)') "[decomposition:decompose_patch_rectlinear] Level ",level_id,": grid divided to [",p_size(:)," ] pieces"
          call printinfo(msg)

--- a/src/grid/decomposition.F90
+++ b/src/grid/decomposition.F90
@@ -687,7 +687,7 @@ contains
       elsewhere
          n_bl(:) = 1
       endwhere
-      tot_bl = product(n_bl(:), mask=dom%has_dir(:))
+      tot_bl = product(n_bl(:))
 
       call this%allocate_pse(tot_bl)
 

--- a/src/grid/grid_container_base.F90
+++ b/src/grid/grid_container_base.F90
@@ -282,11 +282,19 @@ contains
             this%dvol = product(this%dl(:), mask=(dom%has_dir(:) .or. [.false., .true., .false.])) ! multiply by actual radius to get true cell volume
       end select
 
-      this%maxxyz = maxval(this%n_(:), mask=dom%has_dir(:))
+      if (dom%eff_dim == 0) then
+         this%maxxyz = 1
+      else
+         this%maxxyz = maxval(this%n_(:), mask=dom%has_dir(:))
+      endif
 
       call this%set_coords
 
-      this%dxmn  = minval(this%dl(:), mask=dom%has_dir(:))
+      if (dom%eff_dim == 0) then
+         this%dxmn  = minval(dom%L_(:))
+      else
+         this%dxmn  = minval(this%dl(:), mask=dom%has_dir(:))
+      endif
       this%dxmn2 = (this%dxmn)**2
 
       ! some shortcuts for convenience

--- a/src/grid/grid_container_base.F90
+++ b/src/grid/grid_container_base.F90
@@ -265,10 +265,11 @@ contains
       this%ksb = this%ijkseb(zdim, LO)
       this%keb = this%ijkseb(zdim, HI)
 
+      ! Beware: 0-dimensional simulations should not rely on cg%vol or cg%dvol
       select case (dom%geometry_type)
          case (GEO_XYZ)
-            this%vol = product(this%fbnd(:, HI)-this%fbnd(:, LO), mask=dom%has_dir(:))
-            this%dvol = product(this%dl(:), mask=dom%has_dir(:))
+            this%vol = merge(0., product(this%fbnd(:, HI)-this%fbnd(:, LO), mask=dom%has_dir(:)), dom%eff_dim == 0)
+            this%dvol = merge(0., product(this%dl(:), mask=dom%has_dir(:)), dom%eff_dim == 0)
          case (GEO_RPZ)
             if (.not. dom%has_dir(ydim)) then
                this%dl(ydim) = dpi

--- a/src/grid/ordering.F90
+++ b/src/grid/ordering.F90
@@ -66,6 +66,8 @@ contains
 
       id = INVALID
       select case (dom%eff_dim)
+         case (0) ! Special case
+            id = 1
          case (1) ! No need to process coordinate
             do j1 = xdim, zdim
                if (dom%has_dir(j1)) id = off(j1)

--- a/src/grid/refinement.F90
+++ b/src/grid/refinement.F90
@@ -292,7 +292,11 @@ contains
          do_refine = .false.
       endif
 
-      level_crit = (63 - int(log(maxval(dom%n_d)-1.)/log(2.)+1)*dom%eff_dim)/dom%eff_dim  ! these are the limits of ordering::Morton_id
+      if (dom%eff_dim == 0) then
+         level_crit = huge(1)
+      else
+         level_crit = (63 - int(log(maxval(dom%n_d)-1.)/log(2.)+1)*dom%eff_dim)/dom%eff_dim  ! these are the limits of ordering::Morton_id
+      endif
 
       ! Such large refinements may require additional work in I/O routines, visualization, computing MPI tags and so on.
       if (level_max >  level_crit) then
@@ -359,6 +363,11 @@ contains
       integer(kind=4) :: d, i
       integer(kind=4), dimension(ndims) :: b1, b2
       integer(kind=4) :: sq
+
+      if (dom%eff_dim == 0) then
+         bsize(:) = 1
+         return
+      endif
 
       b1 = INVALID
       b2 = b1

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -44,8 +44,8 @@ module multigrid
    private
    public :: multigrid_par, init_multigrid, cleanup_multigrid, init_multigrid_ext
 
-   integer, parameter    :: level_incredible = 50  !< Increase this value only if your base domain contains much more than 10^15 cells in any active direction ;-)
-   integer(kind=4)       :: level_depth            !< Maximum allowed levels of base grid coarsening
+   integer(kind=4), parameter :: level_incredible = 50  !< Should be enough for up to 10^15 cells in any active direction ;-)
+   integer(kind=4)            :: level_depth            !< Maximum allowed levels of base grid coarsening
 
 contains
 
@@ -74,7 +74,7 @@ contains
    subroutine multigrid_par
 
       use cg_list_global,      only: all_cg
-      use constants,           only: PIERNIK_INIT_DOMAIN, O_LIN, O_D3
+      use constants,           only: PIERNIK_INIT_DOMAIN, O_LIN, O_D3, I_ZERO
       use dataio_pub,          only: warn, die, code_progress, nh
       use domain,              only: dom
       use global,              only: dirty_debug, do_ascii_dump, show_n_dirtys !< \warning: alien variables go to local namelist
@@ -102,7 +102,7 @@ contains
       frun = .false.
 
       ! Default values for namelist variables
-      level_depth           = level_incredible
+      level_depth           = merge(level_incredible, I_ZERO, dom%eff_dim /= 0)
       ord_prolong           = O_D3
       show_n_dirtys         = 16
       ! May all the logical parameters be .false. by default
@@ -161,7 +161,7 @@ contains
       single_base = (nproc == 1)
 
       if (dirty_debug .and. master) call warn("[multigrid:multigrid_par] dirty_debug is supposed to be set only in debugging runs. Remember to disable it in production runs")
-      if (dom%eff_dim < 1 .or. dom%eff_dim > 3) call die("[multigrid:multigrid_par] Unsupported number of dimensions.")
+      if (dom%eff_dim < 0 .or. dom%eff_dim > 3) call die("[multigrid:multigrid_par] Unsupported number of dimensions.")
 
 !! \todo Make an array of subroutine pointers
 #ifdef SELF_GRAV

--- a/src/supernovae/snsources.F90
+++ b/src/supernovae/snsources.F90
@@ -243,11 +243,13 @@ contains
 #ifdef SHEAR
                      ysna = ysnoi(ipm+2)
 #endif /* SHEAR */
-                     do jpm = auxper(ydim,LO), auxper(ydim,HI)
-                        posr(ydim) = ((cg%y(j)-ysna + real(jpm)*dom%L_(ydim))/r_sn)**2
-                        ! BEWARE:  for num < -744.6 the exp(num) is the underflow
-                        decr = decr + exp(-sum(posr, mask=dom%has_dir))
-                     enddo
+                     if (dom%eff_dim > 0) then
+                        do jpm = auxper(ydim,LO), auxper(ydim,HI)
+                           posr(ydim) = ((cg%y(j)-ysna + real(jpm)*dom%L_(ydim))/r_sn)**2
+                           ! BEWARE:  for num < -744.6 the exp(num) is the underflow
+                           decr = decr + exp(-sum(posr, mask=dom%has_dir))
+                        enddo
+                     endif
                   enddo
                   decr = decr * ampl
 


### PR DESCRIPTION
An attempt to remove obstacles when the simulation is 0-dimensional (consists of single cell).

Such config may be useful for fast evolving CR spectrum, cooling prescriptions or even particles.

Typical pitfalls are:
* Division by zero: `1 / dom%eff_dim`.
* Uninitialized values: `product(something(:), mask = dom%has_dir(:))`.
* Precomputing dimension-dependent parameters for routines that are called only for existing dimensions.
* Unexpected logical flaws :-)

It is strongly recommended to use `F90FLAGS +=  -ffpe-trap=invalid,zero,overflow` when you test 0-dimensional setups. It may help to spot problematic places.

In order to make Piernik compatible with 0-dimensional setups we need to create a new Jenkins test that will do something sensible. Without that we may easily overlook something.
