### PR TITLE
Tiny and huge domains

### DIFF
--- a/problems/jeans/initproblem.F90
+++ b/problems/jeans/initproblem.F90
@@ -34,7 +34,6 @@ module initproblem
 
    private
    public :: read_problem_par, problem_initial_conditions, problem_pointers
-   public :: d0, mode
 
    ! Private variables
    real :: kx, ky, kz
@@ -77,13 +76,13 @@ contains
       implicit none
 
       ! namelist default parameter values
-      d0          = 1.0                   !< Average density of the medium (density bias required for correct EOS evaluation)
-      p0          = 1.e-3                 !< Average pressure of the medium (for calculating sound speed ot temperature)
-      ix          = 2                     !< Number of perturbation waves in the x direction
-      iy          = 0                     !< Number of perturbation waves in the y direction
-      iz          = 0                     !< Number of perturbation waves in the z direction
-      amp         = 0.0                   !< Perturbation relative amplitude
-      mode        = 0                     !< Variant of the test. 0: cos(kx *x + ky*y + kz*z), 1: cos(kx *x) * cos(ky*y) * cos(kz*z)
+      d0          = 1.0    !< Average density of the medium (density bias required for correct EOS evaluation)
+      p0          = 1.e-3  !< Average pressure of the medium (for calculating sound speed of temperature)
+      ix          = 2      !< Number of perturbation waves in the x direction
+      iy          = 0      !< Number of perturbation waves in the y direction
+      iz          = 0      !< Number of perturbation waves in the z direction
+      amp         = 0.0    !< Perturbation relative amplitude
+      mode        = 0      !< Variant of the test. 0: cos(kx*x + ky*y + kz*z), 1: cos(kx*x) * cos(ky*y) * cos(kz*z)
 
       if (master) then
 

--- a/problems/jeans/problem.par.big_domain
+++ b/problems/jeans/problem.par.big_domain
@@ -1,0 +1,103 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+50.  All hydrodynamical structures should remain
+# identical.
+# Bigger domains are likely to crash due to floating point overflow in fluxes.
+# Dirty debug is not possible here because it is based on huge(real(1.0,4))
+
+ $BASE_DOMAIN
+    n_d = 64, 64, 1
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   = 0.0
+    xmax   = 1.1446968195470935e+50
+    ymin   = 0.0
+    ymax   = 1.1446968195470935e+50
+    zmin   = 0.0
+    zmax   = 1.1446968195470935e+50
+ /
+
+ $MPI_BLOCKS
+    allow_uneven = .true.
+    allow_noncart = .true.
+    dd_unif_quality = 1.1
+    dd_rect_quality = 1.1
+ /
+
+ $UNITS
+    units_set = "cgs"
+ /
+
+ $RESTART_CONTROL
+    restart  = 'last'
+    res_id   = ''
+    nrestart = 0
+ /
+
+ $END_CONTROL
+    tend   = 1.0
+    nend   = 1000
+ /
+
+ $OUTPUT_CONTROL
+    problem_name ='jeans'
+    run_id =  'ts1'
+    dt_hdf  = 1.0
+    dt_res  = 0.0
+    dt_log  = 0.001
+    dt_tsl  = 0.001
+    vars(1:) = 'ener', 'dens', 'gpot', 'velx', 'vely', 'velz'
+    H5_64bit = .true.
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.67
+    selfgrav = .true.
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.67
+    selfgrav = .false.
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    limiter= 'vanleer'
+ /
+
+ $GRAVITY
+    external_gp = "null"
+ /
+
+ $RESISTIVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.5e7
+    p0     = 1.5e+107
+    amp    = 0.001
+    ix     = 2
+    iy     = 0
+    iz     = 0
+    mode   = 0
+ /
+
+ $MULTIGRID_SOLVER
+    stdout    = .true.
+!    dirty_debug = .true.
+ /
+
+ $MULTIGRID_GRAVITY
+    grav_bnd_str  = "periodic"
+ /
+
+ $INTERACTIONS
+ /
+
+ $AMR
+ /

--- a/problems/jeans/problem.par.dirichlet
+++ b/problems/jeans/problem.par.dirichlet
@@ -1,3 +1,12 @@
+! This is a 3D variant of the Jeans test.
+
+! Here we use Dirichlet boundary conditions for gravitational potential in
+! a way that should match periodic boundaries.
+
+!  The default Jeans config is quite minimalistic and tests only most
+! essential parts of the multigrid solver.  This config has more extensive
+! coverage of the multigrid and multipole solvers.
+
  $BASE_DOMAIN
     n_d = 64, 64, 64
     bnd_xl = 'per'
@@ -84,7 +93,7 @@
 
  $MULTIGRID_GRAVITY
     grav_bnd_str  = "dirichlet"
-    gb_no_fft = .true.
+    base_no_fft = .true.
  /
 
  $INTERACTIONS

--- a/problems/jeans/problem.par.small_domain
+++ b/problems/jeans/problem.par.small_domain
@@ -1,0 +1,102 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e-35. All hydrodynamical structures should remain
+# identical.
+# Smaller domains are likely to grind wrong values of timestep because of the
+# relatively high magnitude of constants::small.
+
+ $BASE_DOMAIN
+    n_d = 64, 64, 1
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   = 0.0
+    xmax   = 1.1446968195470935e-35
+    ymin   = 0.0
+    ymax   = 1.1446968195470935e-35
+    zmin   = 0.0
+    zmax   = 1.1446968195470935e-35
+ /
+
+ $MPI_BLOCKS
+    allow_uneven = .true.
+    allow_noncart = .true.
+    dd_unif_quality = 1.1
+    dd_rect_quality = 1.1
+ /
+
+ $UNITS
+    units_set = "cgs"
+ /
+
+ $RESTART_CONTROL
+    restart  = 'last'
+    res_id   = ''
+    nrestart = 0
+ /
+
+ $END_CONTROL
+    tend   = 1.0
+    nend   = 1000
+ /
+
+ $OUTPUT_CONTROL
+    problem_name ='jeans'
+    run_id =  'ts1'
+    dt_hdf  = 1.0
+    dt_res  = 0.0
+    dt_log  = 0.001
+    dt_tsl  = 0.001
+    vars(1:) = 'ener', 'dens', 'gpot', 'velx', 'vely', 'velz'
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.67
+    selfgrav = .true.
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.67
+    selfgrav = .false.
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    limiter= 'vanleer'
+ /
+
+ $GRAVITY
+    external_gp = "null"
+ /
+
+ $RESISTIVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.5e7
+    p0     = 1.5e-63
+    amp    = 0.001
+    ix     = 2
+    iy     = 0
+    iz     = 0
+    mode   = 0
+ /
+
+ $MULTIGRID_SOLVER
+    stdout    = .true.
+    dirty_debug = .true.
+ /
+
+ $MULTIGRID_GRAVITY
+    grav_bnd_str  = "periodic"
+ /
+
+ $INTERACTIONS
+ /
+
+ $AMR
+ /

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -384,7 +384,8 @@ contains
          write(msg,'(a,f13.10)')"[initproblem:problem_initial_conditions] Analytical norm residual/source= ",leaves%norm_sq(qna%ind(ares_n))/dm
          if (master) call printinfo(msg)
       else
-         write(msg,'(2(a,f13.10))')"[initproblem:problem_initial_conditions] Analytical norm residual= ",leaves%norm_sq(qna%ind(ares_n)), " point mass= ", d0
+         write(msg, '(2(a,g14.6))')"[initproblem:problem_initial_conditions] Analytical norm residual= ", leaves%norm_sq(qna%ind(ares_n)), " point mass= ", d0
+         ! Is leaves%norm_sq(qna%ind(ares_n)) ~ sqrt(cg%dvol) ?
          if (master) call printinfo(msg)
       endif
 
@@ -560,7 +561,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: GEO_RPZ, pSUM, pMIN, pMAX
+      use constants,        only: GEO_RPZ, pSUM, pMIN, pMAX, idlen
       use dataio_pub,       only: msg, printinfo, warn
       use domain,           only: dom
       use grid_cont,        only: grid_container
@@ -574,6 +575,7 @@ contains
       real                           :: potential, fac
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg
+      character(len=idlen)           :: ffmt
 
       fac = 1.
       norm(:) = 0.
@@ -612,7 +614,9 @@ contains
       call piernik_MPI_Allreduce(dev(2), pMAX)
 
       if (master) then
-         write(msg,'(a,f12.6,a,2f12.6)')"[initproblem:finalize_problem_maclaurin] L2 error norm = ", sqrt(norm(1)/norm(2)), ", min and max error = ", dev(1:2)
+         ffmt = "f12"
+         if (any(abs(dev) > 1e6) .or. any(abs(dev) < 1e-4)) ffmt = "g14"
+         write(msg,'(a,' // ffmt // '.6,a,2' // ffmt // '.6)')"[initproblem:finalize_problem_maclaurin] L2 error norm = ", sqrt(norm(1)/norm(2)), ", min and max error = ", dev(1:2)
          call printinfo(msg)
       endif
 

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -91,7 +91,6 @@ contains
       use dataio_pub,            only: die, warn, msg, printinfo, nh
       use domain,                only: dom
       use fluidindex,            only: iarr_all_dn
-      use func,                  only: operator(.equals.)
       use global,                only: smalld
       use mpisetup,              only: rbuff, ibuff, lbuff, master, slave, piernik_MPI_Bcast
       use multigridvars,         only: ord_prolong
@@ -204,7 +203,7 @@ contains
       endif
 
 #ifdef NBODY
-      if (a1 .equals. 0.) call add_part_in_proper_cg(I_ONE, d0, [ x0, y0, z0 ], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], 0.0)
+      if (abs(a1) < tiny(1.)) call add_part_in_proper_cg(I_ONE, d0, [ x0, y0, z0 ], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], 0.0)
 #endif /* NBODY */
 
       if (master) then
@@ -252,7 +251,6 @@ contains
       use dataio_pub,        only: die, msg, printinfo
       use domain,            only: dom
       use fluidindex,        only: iarr_all_dn, iarr_all_mx, iarr_all_my, iarr_all_mz
-      use func,              only: operator(.notequals.)
       use global,            only: dirty_debug, no_dirty_checks
       use grid_cont,         only: grid_container
       use named_array_list,  only: qna
@@ -263,7 +261,7 @@ contains
       implicit none
 
       integer                        :: i, j, k, ii, jj, kk
-      real                           :: xx, yy, zz, rr, dm
+      real                           :: xx, yy, zz, rr, dm, n_res
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg
 
@@ -380,12 +378,13 @@ contains
       enddo
 
       dm = leaves%norm_sq(qna%ind(asrc_n))
-      if (dm .notequals. 0.) then
-         write(msg,'(a,f13.10)')"[initproblem:problem_initial_conditions] Analytical norm residual/source= ",leaves%norm_sq(qna%ind(ares_n))/dm
+      n_res = leaves%norm_sq(qna%ind(ares_n))
+      if (abs(dm) > tiny(1.)) then  ! An FP overflow will occur when n_res > dm/tiny(1.)
+         write(msg, '(a,f13.10)')"[initproblem:problem_initial_conditions] Analytical norm residual/source= ", n_res/dm
          if (master) call printinfo(msg)
       else
-         write(msg, '(2(a,g14.6))')"[initproblem:problem_initial_conditions] Analytical norm residual= ", leaves%norm_sq(qna%ind(ares_n)), " point mass= ", d0
-         ! Is leaves%norm_sq(qna%ind(ares_n)) ~ sqrt(cg%dvol) ?
+         write(msg, '(2(a,g14.6))')"[initproblem:problem_initial_conditions] Analytical norm residual= ", n_res, " point mass= ", d0
+         ! Is n_res ~ sqrt(cg%dvol) ?
          if (master) call printinfo(msg)
       endif
 
@@ -432,7 +431,6 @@ contains
       use constants,        only: pi, GEO_XYZ, GEO_RPZ, PPP_PROB
       use dataio_pub,       only: warn, die
       use domain,           only: dom
-      use func,             only: operator(.equals.), operator(.notequals.)
       use grid_cont,        only: grid_container
       use mpisetup,         only: master
       use named_array_list, only: qna
@@ -478,7 +476,7 @@ contains
             z02 = (cg%z(k)-z0)**2
             do j = cg%js, cg%je
                do i = cg%is, cg%ie
-                  if (a12 .notequals. 0.) then
+                  if (abs(a12) > tiny(1.)) then
                      select case (dom%geometry_type)
                         case (GEO_XYZ)
                            y02 = (cg%y(j)-y0)**2
@@ -524,13 +522,12 @@ contains
                              &      (2.*(a32 - a12) + x02 + y02 - 2.*z02)/sqrt(a32 - a12) * log(h + sqrt(1. + h**2)) - &
                              &      (x02 + y02) * sqrt(a32 + lam)/(a12 + lam) + 2.*z02 / sqrt(a32 + lam) )
                      else
-                        if (a1 .equals. 0.) then
-                           if (rr .notequals. 0.) then
+                        if (abs(a1) < tiny(1.)) then
+                           if (abs(rr) > sum(cg%dl**2)/8.) then  ! Warning: may need some small factor for better smoothness
                               potential = - 1. / (pi * sqrt(rr)) ! A bit dirty: we interpret d0 as a mass for point-like sources
                            else
-                              potential = - sqrt(sum(cg%idl2))*0.5
-                              ! The factor of 0.5 was guessed. It gives small departures of potential in the cell containing the particle for 4th order Laplacian.
-                              ! For 2nd order Laplacian (default) 0.58 looks a bit better because it compensates 4th order errors of the operator.
+                              potential = - 8. / (pi * sqrt(sum(cg%dl**2))) *.85
+                              ! The factor of 0.85 was guessed via minimizing L2 error norm for point-like setups
                            endif
                         else
                            potential = - 4./3. * a1**3 / sqrt(rr)
@@ -655,7 +652,6 @@ contains
    subroutine maclaurin_error_vars(var, tab, ierrh, cg)
 
       use dataio_pub,       only: die
-      use func,             only: operator(.notequals.)
       use grid_cont,        only: grid_container
       use named_array_list, only: qna
 
@@ -673,7 +669,7 @@ contains
          case ("errp")
             tab(:,:,:) = cg%q(qna%ind(apot_n))%span(cg%ijkse) - cg%sgp(RNG)
          case ("relerr")
-            where (cg%q(qna%ind(apot_n))%span(cg%ijkse) .notequals. 0.)
+            where (abs(cg%q(qna%ind(apot_n))%span(cg%ijkse)) > tiny(1.))  ! An FP overflow may occur when sgp > apot / tiny()
                tab(:,:,:) = cg%sgp(RNG)/cg%q(qna%ind(apot_n))%span(cg%ijkse) -1.
             elsewhere
                tab(:,:,:) = 0.
@@ -681,7 +677,7 @@ contains
          case ("errm")
             tab(:,:,:) = cg%q(qna%ind(apot_n))%span(cg%ijkse) - cg%q(qna%ind(mpole_n))%span(cg%ijkse)
          case ("relerrm")
-            where (cg%q(qna%ind(apot_n))%span(cg%ijkse) .notequals. 0.)
+            where (abs(cg%q(qna%ind(apot_n))%span(cg%ijkse)) > tiny(1.))  ! An FP overflow may occur when mpole > apot / tiny()
                tab(:,:,:) = cg%q(qna%ind(mpole_n))%span(cg%ijkse)/cg%q(qna%ind(apot_n))%span(cg%ijkse) -1.
             elsewhere
                tab(:,:,:) = 0.

--- a/problems/maclaurin/problem.par.big_domain
+++ b/problems/maclaurin/problem.par.big_domain
@@ -1,0 +1,98 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+62.  All hydrodynamical structures should remain identical.
+# Bigger domains are likely to crash due to floating point overflow in dataio.
+
+ $BASE_DOMAIN
+    n_d = 3*16
+    bnd_xl = 'out'
+    bnd_xr = 'out'
+    bnd_yl = 'out'
+    bnd_yr = 'out'
+    bnd_zl = 'out'
+    bnd_zr = 'out'
+    xmin   = -2.e+62
+    xmax   =  2.e+62
+    ymin   = -2.e+62
+    ymax   =  2.e+62
+    zmin   = -2.e+62
+    zmax   =  2.e+62
+ /
+
+ $MPI_BLOCKS
+    allow_uneven = .true.
+    allow_noncart = .true.
+    dd_unif_quality = 1.1
+    dd_rect_quality = 1.1
+ /
+
+ $UNITS
+    units_set = "cgs"
+ /
+
+ $RESTART_CONTROL
+    restart  = 'none'
+    res_id   = ''
+    nrestart = 0
+ /
+
+ $END_CONTROL
+    tend   = 0.0
+    nend   = 1 ! we can set here 0 as well, but this would issue a warning
+ /
+
+ $OUTPUT_CONTROL
+    problem_name ='maclaurin'
+    run_id =  'sph'
+    dt_hdf  = 10.0
+    dt_res  = 0.0
+    dt_log  = 0.0
+    dt_tsl  = 0.0
+    vars(1:) = 'dens', 'gpot', 'apot', 'errp', 'relerr', 'level'
+    h5_64bit = .true.
+ /
+
+ $FLUID_DUST
+    selfgrav = .true.
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 1e-50
+    smallei= 1e-50
+    limiter= 'vanleer'
+ /
+
+ $GRAVITY
+ /
+
+ $RESISTIVITY
+ /
+
+ $PROBLEM_CONTROL
+    x0     = 0.
+    y0     = 0.5e+62
+    z0     = 1.e+62
+    d0     = 1.
+    a1     = 0.7e+62
+    e      = 0.
+    nsub   = 3
+ /
+
+ $MULTIGRID_SOLVER
+    stdout    = .true.
+!    dirty_debug = .true.
+ /
+
+ $MULTIGRID_GRAVITY
+    grav_bnd_str  = "isolated"
+    mpole_solver  = "3d"
+    mpole_level   = 0   ! base level evaluation of multipole moments seems to be good enough for maclaurin, even -2 would be sufficient
+ /
+
+ $INTERACTIONS
+ /
+
+ $AMR
+    bsize = 3*8
+    level_max = 3
+ /

--- a/problems/maclaurin/problem.par.small_domain
+++ b/problems/maclaurin/problem.par.small_domain
@@ -1,0 +1,99 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e-75.  All gravitational potential structures should
+# remain identical.
+# Smaller domains are crashing due to evaluation of the refinement criteria.
+
+ $BASE_DOMAIN
+    n_d = 3*16
+    bnd_xl = 'out'
+    bnd_xr = 'out'
+    bnd_yl = 'out'
+    bnd_yr = 'out'
+    bnd_zl = 'out'
+    bnd_zr = 'out'
+    xmin   = -2.e-75
+    xmax   =  2.e-75
+    ymin   = -2.e-75
+    ymax   =  2.e-75
+    zmin   = -2.e-75
+    zmax   =  2.e-75
+ /
+
+ $MPI_BLOCKS
+    allow_uneven = .true.
+    allow_noncart = .true.
+    dd_unif_quality = 1.1
+    dd_rect_quality = 1.1
+ /
+
+ $UNITS
+    units_set = "cgs"
+ /
+
+ $RESTART_CONTROL
+    restart  = 'none'
+    res_id   = ''
+    nrestart = 0
+ /
+
+ $END_CONTROL
+    tend   = 0.0
+    nend   = 1 ! we can set here 0 as well, but this would issue a warning
+ /
+
+ $OUTPUT_CONTROL
+    problem_name ='maclaurin'
+    run_id =  'sph'
+    dt_hdf  = 10.0
+    dt_res  = 0.0
+    dt_log  = 0.0
+    dt_tsl  = 0.0
+    vars(1:) = 'dens', 'gpot', 'apot', 'errp', 'relerr', 'level'
+    h5_64bit = .true.
+ /
+
+ $FLUID_DUST
+    selfgrav = .true.
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 1e-50
+    smallei= 1e-50
+    limiter= 'vanleer'
+ /
+
+ $GRAVITY
+ /
+
+ $RESISTIVITY
+ /
+
+ $PROBLEM_CONTROL
+    x0     = 0.
+    y0     = 0.5e-75
+    z0     = 1.e-75
+    d0     = 1.
+    a1     = 0.7e-75
+    e      = 0.
+    nsub   = 3
+ /
+
+ $MULTIGRID_SOLVER
+    stdout    = .true.
+!    dirty_debug = .true.
+ /
+
+ $MULTIGRID_GRAVITY
+    grav_bnd_str  = "isolated"
+    mpole_solver  = "3d"
+    mpole_level   = 0   ! base level evaluation of multipole moments seems to be good enough for maclaurin, even -2 would be sufficient
+ /
+
+ $INTERACTIONS
+ /
+
+ $AMR
+    bsize = 3*8
+    level_max = 3
+ /

--- a/problems/sedov/MHD_blast_wave/problem.par.big_domain
+++ b/problems/sedov/MHD_blast_wave/problem.par.big_domain
@@ -1,0 +1,107 @@
+! 2D MHD blast wave, see
+! http://www.astro.princeton.edu/~jstone/Athena/tests/blast/blast.html
+! or
+! https://academic.oup.com/mnras/article/455/1/51/983632/Accurate-meshless-methods-for-magnetohydrodynamics
+! for more inspiration
+
+! The setup mostly follows the Athena approach except that we have different resolution and square domain.
+!
+! To mimic their setup use
+! n_d = 400, 600, 1
+! ymin = -0.75
+! ymax =  0.75
+! in the BASE_DOMAIN section below and also increase tend from END_CONTROL for full match
+
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+81. All hydrodynamical structures should remain
+# identical.
+# On bigger domains the refinement criteria start to produce different refinements.
+
+ $BASE_DOMAIN
+    n_d = 2*64, 1
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   =-0.5e+81
+    xmax   = 0.5e+81
+    ymin   =-0.5e+81
+    ymax   = 0.5e+81
+    zmin   =-0.5e+81
+    zmax   = 0.5e+81
+ /
+
+ $MPI_BLOCKS
+ /
+
+ $UNITS
+    units_set = 'cgs'
+ /
+
+ $RESTART_CONTROL
+ /
+
+ $END_CONTROL
+    tend   = 0.2e+81
+ /
+
+ $OUTPUT_CONTROL
+    problem_name = 'sedov'
+    run_id =  'tst'
+    dt_hdf  = 0.1e+81
+    dt_res  = 0.0
+    dt_log  = 0.01e+81
+    dt_tsl  = 0.01e+81
+    vars(1:) = 'ener', 'dens', 'magx', 'magy', 'magz', 'velx', 'vely', 'ethr', 'magB', "pres", "divb", "divb4", "psi", "level", "ref_01"
+    H5_64bit = .true.
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.666666666
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.666666666
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    print_divb = 10
+    solver_str = "Riemann"
+ /
+
+ $GRAVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.0
+    p0     = 0.1
+    Eexpl  = 14.85
+    bx0    = 0.7071067811865475
+    by0    = 0.7071067811865475
+    bz0    = 0.0
+    x0     = -0.0
+    y0     = -0.0
+    z0     = -0.0
+    r0     = 0.1e+81
+    smooth = 0.
+ /
+
+ $MULTIGRID_SOLVER
+ /
+
+ $INTERACTIONS
+ /
+
+ $FLUID_TRACER
+ /
+
+ $AMR
+    bsize = 3*16
+    level_max = 2
+    n_updAMR = 3
+ /

--- a/problems/sedov/MHD_blast_wave/problem.par.small_domain
+++ b/problems/sedov/MHD_blast_wave/problem.par.small_domain
@@ -1,0 +1,108 @@
+! 2D MHD blast wave, see
+! http://www.astro.princeton.edu/~jstone/Athena/tests/blast/blast.html
+! or
+! https://academic.oup.com/mnras/article/455/1/51/983632/Accurate-meshless-methods-for-magnetohydrodynamics
+! for more inspiration
+
+! The setup mostly follows the Athena approach except that we have different resolution and square domain.
+!
+! To mimic their setup use
+! n_d = 400, 600, 1
+! ymin = -0.75
+! ymax =  0.75
+! in the BASE_DOMAIN section below and also increase tend from END_CONTROL for full match
+
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e-72. All hydrodynamical structures should remain
+# identical.
+# Smaller domains are crashing due to evaluation of the default refinement
+# criteria during construction of the IC.
+
+ $BASE_DOMAIN
+    n_d = 2*64, 1
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   =-0.5e-72
+    xmax   = 0.5e-72
+    ymin   =-0.5e-72
+    ymax   = 0.5e-72
+    zmin   =-0.5e-72
+    zmax   = 0.5e-72
+ /
+
+ $MPI_BLOCKS
+ /
+
+ $UNITS
+    units_set = 'cgs'
+ /
+
+ $RESTART_CONTROL
+ /
+
+ $END_CONTROL
+    tend   = 0.2e-72
+ /
+
+ $OUTPUT_CONTROL
+    problem_name = 'sedov'
+    run_id =  'tst'
+    dt_hdf  = 0.1e-72
+    dt_res  = 0.0
+    dt_log  = 0.01e-72
+    dt_tsl  = 0.01e-72
+    vars(1:) = 'ener', 'dens', 'magx', 'magy', 'magz', 'velx', 'vely', 'ethr', 'magB', "pres", "divb", "divb4", "psi", "level", "ref_01"
+    H5_64bit = .true.
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.666666666
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.666666666
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    print_divb = 10
+    solver_str = "Riemann"
+ /
+
+ $GRAVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.0
+    p0     = 0.1
+    Eexpl  = 14.85
+    bx0    = 0.7071067811865475
+    by0    = 0.7071067811865475
+    bz0    = 0.0
+    x0     = -0.0
+    y0     = -0.0
+    z0     = -0.0
+    r0     = 0.1e-72
+    smooth = 0.
+ /
+
+ $MULTIGRID_SOLVER
+ /
+
+ $INTERACTIONS
+ /
+
+ $FLUID_TRACER
+ /
+
+ $AMR
+    bsize = 3*16
+    level_max = 2
+    n_updAMR = 3
+ /

--- a/problems/sedov/problem.par.big_domain
+++ b/problems/sedov/problem.par.big_domain
@@ -1,0 +1,87 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+101. All hydrodynamical structures should remain
+# identical.
+# Bigger domains are crashing due to FP overflows in dataio.
+
+ $BASE_DOMAIN
+    n_d = 64, 64, 64
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   =-1.0e+101
+    xmax   = 1.0e+101
+    ymin   =-1.0e+101
+    ymax   = 1.0e+101
+    zmin   =-1.0e+101
+    zmax   = 1.0e+101
+ /
+
+ $MPI_BLOCKS
+ /
+
+ $UNITS
+    units_set = 'cgs'
+ /
+
+ $RESTART_CONTROL
+ /
+
+ $END_CONTROL
+    tend   = 0.002e+101
+ /
+
+ $OUTPUT_CONTROL
+    problem_name = 'sedov'
+    run_id =  'tst'
+    dt_hdf  = 0.001e+101
+    dt_res  = 0.0
+    dt_log  = 0.0001e+101
+    dt_tsl  = 0.0001e+101
+    vars(1:) = 'ener', 'dens', 'velx', 'vely', 'velz'
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.666666666
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.666666666
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    solver_str = "Riemann"
+ /
+
+ $GRAVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.0
+    p0     = 1.0
+    Eexpl  = 1.e6
+    bx0    = 1.0
+    by0    = 1.0
+    bz0    = 1.0
+    x0     = -0.0
+    y0     = -0.0
+    z0     = -0.0
+    r0     = 0.25e+101
+ /
+
+ $MULTIGRID_SOLVER
+ /
+
+ $INTERACTIONS
+ /
+
+ $FLUID_TRACER
+ /
+
+ $AMR
+ /

--- a/problems/sedov/problem.par.small_domain
+++ b/problems/sedov/problem.par.small_domain
@@ -1,0 +1,88 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e-72. All hydrodynamical structures should remain
+# identical.
+# Smaller domains are crashing due to evaluation of the default refinement
+# criteria during construction of the IC.
+
+ $BASE_DOMAIN
+    n_d = 64, 64, 64
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   =-1.0e-72
+    xmax   = 1.0e-72
+    ymin   =-1.0e-72
+    ymax   = 1.0e-72
+    zmin   =-1.0e-72
+    zmax   = 1.0e-72
+ /
+
+ $MPI_BLOCKS
+ /
+
+ $UNITS
+    units_set = 'cgs'
+ /
+
+ $RESTART_CONTROL
+ /
+
+ $END_CONTROL
+    tend   = 0.002e-72
+ /
+
+ $OUTPUT_CONTROL
+    problem_name = 'sedov'
+    run_id =  'tst'
+    dt_hdf  = 0.001e-72
+    dt_res  = 0.0
+    dt_log  = 0.0001e-72
+    dt_tsl  = 0.0001e-72
+    vars(1:) = 'ener', 'dens', 'velx', 'vely', 'velz'
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.666666666
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.666666666
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    solver_str = "Riemann"
+ /
+
+ $GRAVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.0
+    p0     = 1.0
+    Eexpl  = 1.e6
+    bx0    = 1.0
+    by0    = 1.0
+    bz0    = 1.0
+    x0     = -0.0
+    y0     = -0.0
+    z0     = -0.0
+    r0     = 0.25e-72
+ /
+
+ $MULTIGRID_SOLVER
+ /
+
+ $INTERACTIONS
+ /
+
+ $FLUID_TRACER
+ /
+
+ $AMR
+ /

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -528,12 +528,19 @@ contains
 
       logical :: tn
       integer :: i
+      integer, parameter :: fg_len = 5  ! length of "f12.4" or "g14.4"
+      character(len=fg_len) :: fg_fmt
 
       if (code_progress < PIERNIK_INIT_IO_IC) call die("[dataio:init_dataio] Some physics modules are not initialized.")
 
-      write(fmt_loc,  '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,16x,            ",dom%eff_dim+1,"(1x,i4),",dom%eff_dim,"(1x,f12.4))"
-      write(fmt_dtloc,'(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'  dt=',es11.4, ",dom%eff_dim+1,"(1x,i4),",dom%eff_dim,"(1x,f12.4))"
-      write(fmt_vloc, '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'   v=',es11.4, ",dom%eff_dim+1,"(1x,i4),",dom%eff_dim,"(1x,f12.4))"
+      ! We strongly prefer to use f format where possible. Too bad that the g format is so compiler-dependent and often less smart than it could be.
+      fg_fmt = "f12.4"
+      if (maxval(dom%edge) < 1.) fg_fmt = "f12.9"
+      if ((maxval(dom%edge) > 1e6) .or. (maxval(dom%edge) < 1e-4)) fg_fmt = "e12.5"
+
+      write(fmt_loc,  '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,16x,            ", dom%eff_dim+1, "(1x,i4),", dom%eff_dim, "(1x," // fg_fmt // "))"
+      write(fmt_dtloc,'(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'  dt=',es11.4, ", dom%eff_dim+1, "(1x,i4),", dom%eff_dim, "(1x," // fg_fmt // "))"
+      write(fmt_vloc, '(2(a,i1),a)') "(2x,a12,a3,'  = ',es16.9,'   v=',es11.4, ", dom%eff_dim+1, "(1x,i4),", dom%eff_dim, "(1x," // fg_fmt // "))"
 
       if (master) tn = walltime_end%time_left(wend)
 

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -90,8 +90,12 @@ module constants
    real, parameter :: e          = 2.718281828459045235  !< Napier's constant (base of Natural logarithm)
 
    ! some numerical representation extrema
+   !> Warning: the valuses of big and small should be used only when exceeding the range od single precision is not desired
+   !! e.g. when when using the default, 32-bit data output in .h5 files.
+   !! In most cases it should be much safer to use tiny(1.) and huge(1.) (either directly or slightly scaled).
+   !! Careless relying on SP huge and tiny may result in incorrect calculations when the involved values exceed single precision range.
+   !! Such incorrect calculation may happen e.g. for extremely big or small cell sizes, extreme timestep length etc.
    real, parameter :: big        = huge(real(1.0,4))     !< a constant used as the upper limit number.
-   !> Warning: this value is causing numerical problems with domains bigger than ~1e42.
    real, parameter :: big_float  = huge(real(1.0,4))     !< replicated temporarily 'big' for compatibility \todo choose one and convert occurrences of the other one
    real, parameter :: dirtyH     = big                   !< If dirty_debug then pollute arrays with this insane value
    real, parameter :: dirtyH1    = 10.**int(log10(big))  !< this "round" dirty value makes it easier to detect which call contaminated the data
@@ -99,6 +103,12 @@ module constants
    real, parameter :: dirtyL     = sqrt(dirtyH)          !< If dirty_debug then assume that the array got contaminated by dirtyH by checking against this value
    real, parameter :: small      = tiny(real(1.0,4))     !< a constant used as the lower limit number
    integer, parameter :: big_int = huge(int(1,4))
+
+   !! Expected values of tiny, huge and epsilon for various lengths of real type (obtained from gfortran)
+   !! x=          0._4 (SP)        0._8 (DP, the default)    0._10 (ext precision)          0._16 (quad precision, software implementation)
+   !! tiny(x)     1.17549435E-38   2.2250738585072014E-308   3.36210314311209350626E-4932   3.36210314311209350626267781732175260E-4932
+   !! huge(x)     3.40282347E+38   1.7976931348623157E+308   1.18973149535723176502E+4932   1.18973149535723176508575932662800702E+4932
+   !! epsilon(x)  1.19209290E-07   2.2204460492503131E-016   1.08420217248550443401E-0019   1.92592994438723585305597794258492732E-0034
 
    ! dimensions
    enum, bind(C)

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -90,7 +90,8 @@ module constants
    real, parameter :: e          = 2.718281828459045235  !< Napier's constant (base of Natural logarithm)
 
    ! some numerical representation extrema
-   real, parameter :: big        = huge(real(1.0,4))     !< a constant used as the upper limit number
+   real, parameter :: big        = huge(real(1.0,4))     !< a constant used as the upper limit number.
+   !> Warning: this value is causing numerical problems with domains bigger than ~1e42.
    real, parameter :: big_float  = huge(real(1.0,4))     !< replicated temporarily 'big' for compatibility \todo choose one and convert occurrences of the other one
    real, parameter :: dirtyH     = big                   !< If dirty_debug then pollute arrays with this insane value
    real, parameter :: dirtyH1    = 10.**int(log10(big))  !< this "round" dirty value makes it easier to detect which call contaminated the data

--- a/src/base/func.F90
+++ b/src/base/func.F90
@@ -199,6 +199,13 @@ contains
 
    end subroutine append_int_to_array
 
+!>
+!! \brief An operator for avoiding direct comparision with floats (like 0.), because gfortran is complaining about that.
+!!
+!! Warning: use carefully as epsilon(<any double precision>) == 2.2204460492503131E-016.
+!! This may cause improper evaluation of the comparison when the difference of compared values is <= epsilon(0.)
+!<
+
    pure elemental function float_equals(x1, x2) result (tf)
 
       implicit none
@@ -206,9 +213,11 @@ contains
       real, intent(in) :: x1, x2
       logical :: tf
 
-      tf = abs(x1 - x2) <= epsilon(x1)
+      tf = abs(x1 - x2) <= epsilon(0.)
 
    end function float_equals
+
+!> \brief a complementary operator to .equals.
 
    pure elemental function float_notequals(x1, x2) result (tf)
 
@@ -217,7 +226,7 @@ contains
       real, intent(in) :: x1, x2
       logical :: tf
 
-      tf = .not.(x1.equals.x2)
+      tf = .not. (x1 .equals. x2)
 
    end function float_notequals
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -41,7 +41,6 @@ program piernik
    use finalizepiernik,   only: cleanup_piernik
    use fluidindex,        only: flind
    use fluidupdate,       only: fluid_update
-   use func,              only: operator(.equals.)
    use global,            only: t, nstep, dt, dtm, print_divB, tstep_attempt
    use initpiernik,       only: init_piernik
    use lb_helpers,        only: costs_maintenance
@@ -155,7 +154,7 @@ program piernik
       call check_cfl_violation(flind)
 
       rs = repeat_step()  ! enforce function call
-      if ((t .equals. tlast) .and. .not. first_step .and. .not. rs) call die("[piernik] timestep is too small: t == t + 2 * dt")
+      if ((t - tlast < tiny(1.0)) .and. .not. first_step .and. .not. rs) call die("[piernik] timestep is too small: t == t + 2 * dt")
 
       call piernik_MPI_Barrier
       call costs_maintenance

--- a/src/fluids/cosmicrays/timestep_cresp.F90
+++ b/src/fluids/cosmicrays/timestep_cresp.F90
@@ -48,7 +48,7 @@ contains
       use cg_cost_data,     only: I_OTHER
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: xdim, ydim, zdim, half, zero, big, pMIN, I_ONE
+      use constants,        only: xdim, ydim, zdim, half, zero, pMIN, I_ONE
       use cresp_crspectrum, only: cresp_find_prepare_spectrum
       use crhelpers,        only: div_v, divv_i
       use fluidindex,       only: flind
@@ -67,10 +67,10 @@ contains
       real                           :: K_cre_max_sum, abs_max_ud, dt_aux
       logical                        :: empty_cell
 
-      dt_cre       = big
-      dt_cre_K     = big
-      dt_cre_synch = big
-      dt_cre_adiab = big
+      dt_cre       = huge(1.)
+      dt_cre_K     = huge(1.)
+      dt_cre_synch = huge(1.)
+      dt_cre_adiab = huge(1.)
 
       if (.not. use_cresp_evol) return
 
@@ -176,20 +176,19 @@ contains
 
    subroutine cresp_timestep_cell(p_loss_terms, dt_cell, empty_cell)
 
-      use initcrspectrum,     only: adiab_active, cresp, synch_active, spec_mod_trms
-      use cresp_crspectrum,   only: cresp_find_prepare_spectrum
-      use constants,          only: big
+      use initcrspectrum,   only: adiab_active, cresp, synch_active, spec_mod_trms
+      use cresp_crspectrum, only: cresp_find_prepare_spectrum
 
       implicit none
 
-      type(spec_mod_trms), intent(in) :: p_loss_terms
-      real,               intent(out) :: dt_cell
-      logical,            intent(out) :: empty_cell
-      integer(kind=4)                 :: i_up_cell
+      type(spec_mod_trms), intent(in)  :: p_loss_terms
+      real,                intent(out) :: dt_cell
+      logical,             intent(out) :: empty_cell
+      integer(kind=4)                  :: i_up_cell
 
-      dt_cell = big
-      dt_cre_adiab = big
-      dt_cre_synch = big
+      dt_cell = huge(1.)
+      dt_cre_adiab = huge(1.)
+      dt_cre_synch = huge(1.)
 
       empty_cell = .false.
 

--- a/src/fluids/cosmicrays/timestepcosmicrays.F90
+++ b/src/fluids/cosmicrays/timestepcosmicrays.F90
@@ -50,7 +50,7 @@ contains
 
       use cg_leaves,           only: leaves
       use cg_list,             only: cg_list_element
-      use constants,           only: big, pMIN
+      use constants,           only: pMIN
       use domain,              only: is_multicg
       use initcosmicrays,      only: def_dtcrs, K_crs_valid
       use mpisetup,            only: piernik_MPI_Allreduce
@@ -79,7 +79,7 @@ contains
       ! with multiple cg% there are few cg%dxmn to be checked
       ! with AMR minval(cg%dxmn) may change with time
 
-         dt_crs = big
+         dt_crs = huge(1.)
          cgl => leaves%first
          do while (associated(cgl))
             dt_crs = min(dt_crs, def_dtcrs * cgl%cg%dxmn2)

--- a/src/fluids/interactions/timestepinteractions.F90
+++ b/src/fluids/interactions/timestepinteractions.F90
@@ -45,7 +45,7 @@ contains
 
       use cg_leaves,    only: leaves
       use cg_list,      only: cg_list_element
-      use constants,    only: big, pMIN, small
+      use constants,    only: pMIN, small
       use fluidindex,   only: flind
       use func,         only: L2norm
       use grid_cont,    only: grid_container
@@ -58,7 +58,7 @@ contains
       type(grid_container),  pointer :: cg
       real                           :: val        !< variable used to store the maximum value of relative momentum
 
-      dt_interact = big
+      dt_interact = huge(1.)
       if (.not.has_interactions) return
       !    dt_interact_proc = 1.0 / (maxval(collfaq)+small) / maxval(cg%u(iarr_all_dn,:,:,:))
 

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -525,7 +525,6 @@ contains
       use constants,          only: fft_none
       use dataio_pub,         only: die
       use find_lev,           only: find_level
-      use func,               only: operator(.notequals.)
       use grid_cont,          only: grid_container
       use multigridvars,      only: overrelax
 #ifndef NO_FFT
@@ -544,14 +543,14 @@ contains
 
       ! this should work correctly also when dom%eff_dim < 3
       cg%mg%r  = overrelax / 2.
-      cg%mg%rx = cg%dvol**2 * cg%idx2
-      cg%mg%ry = cg%dvol**2 * cg%idy2
-      cg%mg%rz = cg%dvol**2 * cg%idz2
+      cg%mg%rx = cg%idx2
+      cg%mg%ry = cg%idy2
+      cg%mg%rz = cg%idz2
       cg%mg%r  = cg%mg%r / (cg%mg%rx + cg%mg%ry + cg%mg%rz)
       cg%mg%rx = cg%mg%r * cg%mg%rx
       cg%mg%ry = cg%mg%r * cg%mg%ry
       cg%mg%rz = cg%mg%r * cg%mg%rz
-      cg%mg%r  = cg%mg%r * cg%dvol**2
+      cg%mg%r  = cg%mg%r
 
       ! FFT solver storage and data
       curl => find_level(cg%l%id)
@@ -627,7 +626,7 @@ contains
          ! compute Green's function for 7-point 3D discrete laplacian
          do i = 1, cg%mg%nxc
             do j = 1, cg%nyb
-               where ((kx(i) + ky(j) + kz(:)).notequals.zero)
+               where (abs(kx(i) + ky(j) + kz(:)) >  tiny(1.))
                   cg%mg%Green3D(i,j,:) = half * cg%mg%fft_norm / (kx(i) + ky(j) + kz(:))
                elsewhere
                   cg%mg%Green3D(i,j,:) = zero

--- a/src/gravity/multigridmultipole.F90
+++ b/src/gravity/multigridmultipole.F90
@@ -389,11 +389,10 @@ contains
       use cg_cost_data, only: I_MULTIPOLE
       use cg_leaves,    only: leaves
       use cg_list,      only: cg_list_element
-      use constants,    only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero, PPP_GRAV
+      use constants,    only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, PPP_GRAV
       use dataio_pub,   only: die
       use domain,       only: dom
       use grid_cont,    only: grid_container
-      use func,         only: operator(.notequals.)
       use ppp,          only: ppp_main
 
       implicit none
@@ -405,7 +404,7 @@ contains
       character(len=*), parameter :: m2m_label = "multipole_img2mom"
 
       call ppp_main%start(m2m_label, PPP_GRAV)
-      if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
+      if (dom%geometry_type /= GEO_XYZ .and. any(abs(Q%center(xdim:zdim)) > tiny(1.))) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
 
       geofac(:) = 1.
 
@@ -473,11 +472,10 @@ contains
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
-      use constants,          only: xdim, zdim, GEO_XYZ, zero, base_level_id, PPP_GRAV
+      use constants,          only: xdim, zdim, GEO_XYZ, base_level_id, PPP_GRAV
       use dataio_pub,         only: die, msg, warn
       use domain,             only: dom
       use grid_cont,          only: grid_container
-      use func,               only: operator(.notequals.)
       use multigridvars,      only: source
       use multipole_array,    only: mpole_level, mpole_level_auto
       use ppp,                only: ppp_main
@@ -492,7 +490,7 @@ contains
 
       call ppp_main%start(d2m_label, PPP_GRAV)
 
-      if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:domain2moments] Q%center /= 0. not implemented for non-cartesian geometry")
+      if (dom%geometry_type /= GEO_XYZ .and. any(abs(Q%center(xdim:zdim)) > tiny(1.))) call die("[multigridmultipole:domain2moments] Q%center /= 0. not implemented for non-cartesian geometry")
       if (dom%geometry_type /= GEO_XYZ) call die("[multigridmultipole:domain2moments] Noncartesian geometry haven't been tested. Verify it before use.")
 
       ! scan
@@ -614,11 +612,10 @@ contains
       use cg_cost_data, only: I_MULTIPOLE
       use cg_leaves,    only: leaves
       use cg_list,      only: cg_list_element
-      use constants,    only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, zero, PPP_GRAV
+      use constants,    only: xdim, ydim, zdim, GEO_XYZ, GEO_RPZ, LO, HI, PPP_GRAV
       use dataio_pub,   only: die
       use domain,       only: dom
       use grid_cont,    only: grid_container
-      use func,         only: operator(.notequals.)
       use ppp,          only: ppp_main
 
       implicit none
@@ -630,7 +627,7 @@ contains
 
       call ppp_main%start(m2p_label, PPP_GRAV)
 
-      if (dom%geometry_type /= GEO_XYZ .and. any(Q%center(xdim:zdim).notequals.zero)) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
+      if (dom%geometry_type /= GEO_XYZ .and. any(abs(Q%center(xdim:zdim)) > tiny(1.))) call die("[multigridmultipole:img_mass2moments] Q%center /= 0. not implemented for non-cartesian geometry")
 
       cgl => leaves%first
       do while (associated(cgl))

--- a/src/gravity/multipole_array.F90
+++ b/src/gravity/multipole_array.F90
@@ -600,10 +600,9 @@ contains
 
    subroutine geomfac4moments(this, factor, xx, yy, zz, sin_th, cos_th, sin_ph, cos_ph, ir)
 
-      use constants,  only: GEO_XYZ, GEO_RPZ, zero, xdim, ydim, zdim
+      use constants,  only: GEO_XYZ, GEO_RPZ, xdim, ydim, zdim
       use dataio_pub, only: die
       use domain,     only: dom
-      use func,       only: operator(.notequals.)
 
       implicit none
 
@@ -638,7 +637,7 @@ contains
       end select
       r    = sqrt(rxy + z**2)
       rxy  = sqrt(rxy)
-      if (r .notequals. zero) then
+      if (abs(r) > tiny(1.)) then
          rinv = 1. / r
       else
          rinv = 0.
@@ -655,7 +654,7 @@ contains
       ! azimuthal angle sine and cosine tables
       ! ph = atan2(y, x); this%cfac(m) = cos(m * ph); this%sfac(m) = sin(m * ph)
       ! this%cfac(0) and this%sfac(0) are set in init_multigrid
-      if (rxy .notequals. zero) then
+      if (abs(rxy) > tiny(1.)) then
          select case (dom%geometry_type)
             case (GEO_XYZ)
                cos_ph = x / rxy

--- a/src/grid/grid_container_base.F90
+++ b/src/grid/grid_container_base.F90
@@ -166,7 +166,6 @@ contains
       use constants,        only: xdim, ydim, zdim, LO, HI, I_ONE, I_TWO, BND_MPI, BND_COR, GEO_XYZ, GEO_RPZ, dpi
       use dataio_pub,       only: die, warn
       use domain,           only: dom
-      use func,             only: operator(.equals.)
       use level_essentials, only: level_t
 
       implicit none
@@ -257,7 +256,7 @@ contains
       where (dom%has_dir(:) .and. (my_se(:, HI) == l%off(:) + l%n_d(:) - I_ONE)) this%lh_out(:, HI) = this%lh_out(:, HI) + dom%nb
       !> \todo make sure the above works correctly with refinements
 
-      if (any(this%dl .equals. 0.)) call die("[grid_container_base:init_gc_base] found cell size equal to 0.")
+      if (any(this%dl < tiny(1.0))) call die("[grid_container_base:init_gc_base] found cell size < tiny()")
 
       this%isb = this%ijkseb(xdim, LO)
       this%ieb = this%ijkseb(xdim, HI)
@@ -352,7 +351,7 @@ contains
       use constants,  only: LO, HI, half, one, zero, xdim, ydim, zdim, CENTER, LEFT, RIGHT, INV_CENTER
       use dataio_pub, only: die, warn
       use domain,     only: dom
-      use func,       only: operator(.notequals.), operator(.equals.)
+      use func,       only: operator(.notequals.)
 
       implicit none
 
@@ -376,7 +375,7 @@ contains
          this%coord(LEFT,  d)%r(:) = this%coord(CENTER, d)%r(:) - half*this%dl(d)
          this%coord(RIGHT, d)%r(:) = this%coord(CENTER, d)%r(:) + half*this%dl(d)
 
-         where ( this%coord(CENTER, d)%r(:).notequals.zero )
+         where (this%coord(CENTER, d)%r(:) .notequals. zero)
             this%coord(INV_CENTER, d)%r(:) = one/this%coord(CENTER, d)%r(:)
          elsewhere
             this%coord(INV_CENTER, d)%r(:) = zero
@@ -387,8 +386,8 @@ contains
          ! When the cell size is too small compared to the coordinates, such line cannot be properly calculated
          ! Note that since we force real kind=8, we can use a named constant instead of epsilon
          if (dom%has_dir(d)) then
-            if ( any(this%coord(CENTER, d)%r(:) .equals. this%coord(LEFT,  d)%r(:)) .or. &
-                 any(this%coord(CENTER, d)%r(:) .equals. this%coord(RIGHT, d)%r(:)) ) call die("[grid_container_base:set_coords] cannot distinguish between center and face coordinates of a cell")
+            if ( any(abs(this%coord(CENTER, d)%r(:) - this%coord(LEFT,  d)%r(:)) < tiny(1.0)) .or. &
+                 any(abs(this%coord(CENTER, d)%r(:) - this%coord(RIGHT, d)%r(:)) < tiny(1.0)) ) call die("[grid_container_base:set_coords] cannot distinguish between center and face coordinates of a cell")
             if ( any(abs(this%coord(CENTER, d)%r(:)-this%coord(LEFT,  d)%r(:)) < safety_warn_factor*epsilon(this%coord(CENTER, d)%r(:))*this%coord(CENTER, d)%r(:)) .or. &
                  any(abs(this%coord(CENTER, d)%r(:)-this%coord(RIGHT, d)%r(:)) < safety_warn_factor*epsilon(this%coord(CENTER, d)%r(:))*this%coord(CENTER, d)%r(:))) &
                  call warn("[grid_container_base:set_coords] cell sizes are much smaller than coordinates. Inaccuracies in setting the initial conditions may happen.")

--- a/src/grid/refinement/unified_ref_crit_var.F90
+++ b/src/grid/refinement/unified_ref_crit_var.F90
@@ -290,6 +290,9 @@ contains
 !!
 !! this%aux is the noise filter (epsilon in Loechner's paper)
 !!
+!! Known limitations:
+!! * Extremely small and big cell sizes easily cause FP over- and underflows. Don't go much beyond 1e±70.
+!!
 !! OPT: this routine seems to take way too much CPU! Implement 3D variant without functions?
 !!
 !<

--- a/src/multigrid/multigrid_Laplace4M.F90
+++ b/src/multigrid/multigrid_Laplace4M.F90
@@ -192,12 +192,11 @@ contains
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
-      use constants,          only: xdim, ydim, zdim, ndims, GEO_XYZ, BND_NEGREF, pMAX, zero
+      use constants,          only: xdim, ydim, zdim, ndims, GEO_XYZ, BND_NEGREF, pMAX
       use dataio_pub,         only: die, warn
       use domain,             only: dom
       use global,             only: dirty_debug
       use grid_cont,          only: grid_container
-      use func,               only: operator(.notequals.)
       use mpisetup,           only: piernik_MPI_Allreduce, master
       use multigrid_helpers,  only: set_relax_boundaries, copy_and_max
       use multigridvars,      only: multidim_code_3D, coarsest_tol, nc_growth, dirty_label
@@ -257,7 +256,7 @@ contains
             Ly  = 0. ; if (dom%has_dir(ydim)) Ly = cg%idy2 - 2. * (Lxy + Lyz)
             Lz  = 0. ; if (dom%has_dir(zdim)) Lz = cg%idz2 - 2. * (Lxz + Lyz)
             L0  = 2. * (Lx + Ly + Lz) + 4. * (Lxy + Lxz + Lyz)
-            if (L0.notequals.zero) then
+            if (abs(L0) > tiny(1.0)) then
                iL0 = 1. / L0
                Lx = Lx * iL0
                Ly = Ly * iL0

--- a/src/particles/particle_gravity.F90
+++ b/src/particles/particle_gravity.F90
@@ -530,7 +530,6 @@ contains
 
       use constants,        only: xdim, ydim, zdim, ndims, LO, HI, IM, I0, IP, CENTER, gp1b_n, gpot_n, idm, half, zero
       use domain,           only: dom
-      use func,             only: operator(.equals.)
       use grid_cont,        only: grid_container
       use multipole,        only: moments2pot
       use named_array_list, only: qna
@@ -561,7 +560,7 @@ contains
       do while (associated(pset))
 
          !Delete particles escaping the domain
-         if (pset%pdata%energy .equals. 0.0) then
+         if (abs(pset%pdata%energy) < tiny(1.)) then
             pset2 => pset%nxt
             call cg%pset%remove(pset)
             pset => pset2

--- a/src/particles/particle_timestep.F90
+++ b/src/particles/particle_timestep.F90
@@ -51,16 +51,15 @@ contains
 
       use cg_leaves,      only: leaves
       use cg_list,        only: cg_list_element
-      use constants,      only: big, one, pMIN, two, zero
+      use constants,      only: one, pMIN, two
       use dataio_pub,     only: msg, printinfo
-      use func,           only: operator(.notequals.)
       use global,         only: dt_max
       use grid_cont,      only: grid_container
       use mpisetup,       only: piernik_MPI_Allreduce, master
       use particle_utils, only: max_pacc_3d
       use particle_pub,   only: lf_c, ignore_dt_fluid
 #ifdef DUST_PARTICLES
-      use constants,      only: ndims, xdim, zdim
+      use constants,      only: ndims, xdim, zdim, big
       use particle_utils, only: max_pvel_1d
 #endif /* DUST_PARTICLES */
 
@@ -82,7 +81,7 @@ contains
 
       eps      = 1.0e-1
       factor   = one
-      dt_nbody = big
+      dt_nbody = huge(1.)
 
       cgl => leaves%first
       do while (associated(cgl))
@@ -90,8 +89,7 @@ contains
          eta = minval(cg%dl)   !scale timestep with cell size
 
          call max_pacc_3d(cg, pacc_max)
-
-         if (pacc_max%val .notequals. zero) then
+         if (abs(pacc_max%val) > tiny(1.)) then
             dt_nbody = sqrt(two*eta*eps/pacc_max%val)
 
 #ifdef DUST_PARTICLES
@@ -121,7 +119,7 @@ contains
          dt = dt_nbody      !IGNORE HYDRO TIMESTEP
       else
          !> \todo verify this condition
-         if (dt_nbody .notequals. 0.0) dt = min(dt, dt_nbody)
+         if (abs(dt_nbody) > tiny(1.)) dt = min(dt, dt_nbody)
       endif
 
       write(msg,'(a,3g12.5)') '[particle_timestep:timestep_nbody] dt for hydro, nbody and both: ', dt_hydro, dt_nbody, dt

--- a/src/particles/particle_utils.F90
+++ b/src/particles/particle_utils.F90
@@ -99,7 +99,7 @@ contains
 
    subroutine max_pacc_3d(cg, max_pacc)
 
-      use constants, only: big, CENTER, half, LO, xdim, zdim, zero
+      use constants, only: CENTER, half, LO, xdim, zdim, zero
       use grid_cont, only: grid_container
       use mpisetup,  only: proc
       use types,     only: value
@@ -113,7 +113,7 @@ contains
       real                                       :: acc2, max_acc
       integer(kind=4) :: cdim
 
-      max_pacc%assoc = big
+      max_pacc%assoc = huge(1.)
 
       max_acc  = zero
       pset => cg%pset%first


### PR DESCRIPTION
Remove computational faults when the cell sizes are extremely small or extremely big (like when one sets up a galaxy measured in centimeters).

These faults usually result from use of `small` and `big` values from `constants` module. In principle `small` and `big` should prevent division by zero or numerical overflows in single-precision data output but in many places we may safelyuse full range of double precision and avoid biased calculations.