### PR TITLE
Huge domain

### DIFF
--- a/problems/jeans/initproblem.F90
+++ b/problems/jeans/initproblem.F90
@@ -34,7 +34,6 @@ module initproblem
 
    private
    public :: read_problem_par, problem_initial_conditions, problem_pointers
-   public :: d0, mode
 
    ! Private variables
    real :: kx, ky, kz
@@ -77,13 +76,13 @@ contains
       implicit none
 
       ! namelist default parameter values
-      d0          = 1.0                   !< Average density of the medium (density bias required for correct EOS evaluation)
-      p0          = 1.e-3                 !< Average pressure of the medium (for calculating sound speed ot temperature)
-      ix          = 2                     !< Number of perturbation waves in the x direction
-      iy          = 0                     !< Number of perturbation waves in the y direction
-      iz          = 0                     !< Number of perturbation waves in the z direction
-      amp         = 0.0                   !< Perturbation relative amplitude
-      mode        = 0                     !< Variant of the test. 0: cos(kx *x + ky*y + kz*z), 1: cos(kx *x) * cos(ky*y) * cos(kz*z)
+      d0          = 1.0    !< Average density of the medium (density bias required for correct EOS evaluation)
+      p0          = 1.e-3  !< Average pressure of the medium (for calculating sound speed of temperature)
+      ix          = 2      !< Number of perturbation waves in the x direction
+      iy          = 0      !< Number of perturbation waves in the y direction
+      iz          = 0      !< Number of perturbation waves in the z direction
+      amp         = 0.0    !< Perturbation relative amplitude
+      mode        = 0      !< Variant of the test. 0: cos(kx*x + ky*y + kz*z), 1: cos(kx*x) * cos(ky*y) * cos(kz*z)
 
       if (master) then
 

--- a/problems/jeans/problem.par.big_domain
+++ b/problems/jeans/problem.par.big_domain
@@ -1,0 +1,103 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+50.  All hydrodynamical structures should remain
+# identical.
+# Bigger domains are likely to crash due to floating point overflow in fluxes.
+# Dirty debug is not possible here because it is based on huge(real(1.0,4))
+
+ $BASE_DOMAIN
+    n_d = 64, 64, 1
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   = 0.0
+    xmax   = 1.1446968195470935e+50
+    ymin   = 0.0
+    ymax   = 1.1446968195470935e+50
+    zmin   = 0.0
+    zmax   = 1.1446968195470935e+50
+ /
+
+ $MPI_BLOCKS
+    allow_uneven = .true.
+    allow_noncart = .true.
+    dd_unif_quality = 1.1
+    dd_rect_quality = 1.1
+ /
+
+ $UNITS
+    units_set = "cgs"
+ /
+
+ $RESTART_CONTROL
+    restart  = 'last'
+    res_id   = ''
+    nrestart = 0
+ /
+
+ $END_CONTROL
+    tend   = 1.0
+    nend   = 1000
+ /
+
+ $OUTPUT_CONTROL
+    problem_name ='jeans'
+    run_id =  'ts1'
+    dt_hdf  = 1.0
+    dt_res  = 0.0
+    dt_log  = 0.001
+    dt_tsl  = 0.001
+    vars(1:) = 'ener', 'dens', 'gpot', 'velx', 'vely', 'velz'
+    H5_64bit = .true.
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.67
+    selfgrav = .true.
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.67
+    selfgrav = .false.
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    limiter= 'vanleer'
+ /
+
+ $GRAVITY
+    external_gp = "null"
+ /
+
+ $RESISTIVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.5e7
+    p0     = 1.5e+107
+    amp    = 0.001
+    ix     = 2
+    iy     = 0
+    iz     = 0
+    mode   = 0
+ /
+
+ $MULTIGRID_SOLVER
+    stdout    = .true.
+!    dirty_debug = .true.
+ /
+
+ $MULTIGRID_GRAVITY
+    grav_bnd_str  = "periodic"
+ /
+
+ $INTERACTIONS
+ /
+
+ $AMR
+ /

--- a/problems/jeans/problem.par.dirichlet
+++ b/problems/jeans/problem.par.dirichlet
@@ -1,3 +1,12 @@
+! This is a 3D variant of the Jeans test.
+
+! Here we use Dirichlet boundary conditions for gravitational potential in
+! a way that should match periodic boundaries.
+
+!  The default Jeans config is quite minimalistic and tests only most
+! essential parts of the multigrid solver.  This config has more extensive
+! coverage of the multigrid and multipole solvers.
+
  $BASE_DOMAIN
     n_d = 64, 64, 64
     bnd_xl = 'per'
@@ -84,7 +93,7 @@
 
  $MULTIGRID_GRAVITY
     grav_bnd_str  = "dirichlet"
-    gb_no_fft = .true.
+    base_no_fft = .true.
  /
 
  $INTERACTIONS

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -384,7 +384,8 @@ contains
          write(msg,'(a,f13.10)')"[initproblem:problem_initial_conditions] Analytical norm residual/source= ",leaves%norm_sq(qna%ind(ares_n))/dm
          if (master) call printinfo(msg)
       else
-         write(msg,'(2(a,f13.10))')"[initproblem:problem_initial_conditions] Analytical norm residual= ",leaves%norm_sq(qna%ind(ares_n)), " point mass= ", d0
+         write(msg, '(2(a,g14.6))')"[initproblem:problem_initial_conditions] Analytical norm residual= ", leaves%norm_sq(qna%ind(ares_n)), " point mass= ", d0
+         ! Is leaves%norm_sq(qna%ind(ares_n)) ~ sqrt(cg%dvol) ?
          if (master) call printinfo(msg)
       endif
 
@@ -560,7 +561,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: GEO_RPZ, pSUM, pMIN, pMAX
+      use constants,        only: GEO_RPZ, pSUM, pMIN, pMAX, idlen
       use dataio_pub,       only: msg, printinfo, warn
       use domain,           only: dom
       use grid_cont,        only: grid_container
@@ -574,6 +575,7 @@ contains
       real                           :: potential, fac
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg
+      character(len=idlen)           :: ffmt
 
       fac = 1.
       norm(:) = 0.
@@ -612,7 +614,9 @@ contains
       call piernik_MPI_Allreduce(dev(2), pMAX)
 
       if (master) then
-         write(msg,'(a,f12.6,a,2f12.6)')"[initproblem:finalize_problem_maclaurin] L2 error norm = ", sqrt(norm(1)/norm(2)), ", min and max error = ", dev(1:2)
+         ffmt = "f12"
+         if (any(abs(dev) > 1e6) .or. any(abs(dev) < 1e-4)) ffmt = "g14"
+         write(msg,'(a,' // ffmt // '.6,a,2' // ffmt // '.6)')"[initproblem:finalize_problem_maclaurin] L2 error norm = ", sqrt(norm(1)/norm(2)), ", min and max error = ", dev(1:2)
          call printinfo(msg)
       endif
 

--- a/problems/maclaurin/problem.par.big_domain
+++ b/problems/maclaurin/problem.par.big_domain
@@ -1,0 +1,98 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+62.  All hydrodynamical structures should remain identical.
+# Bigger domains are likely to crash due to floating point overflow in dataio.
+
+ $BASE_DOMAIN
+    n_d = 3*16
+    bnd_xl = 'out'
+    bnd_xr = 'out'
+    bnd_yl = 'out'
+    bnd_yr = 'out'
+    bnd_zl = 'out'
+    bnd_zr = 'out'
+    xmin   = -2.e+62
+    xmax   =  2.e+62
+    ymin   = -2.e+62
+    ymax   =  2.e+62
+    zmin   = -2.e+62
+    zmax   =  2.e+62
+ /
+
+ $MPI_BLOCKS
+    allow_uneven = .true.
+    allow_noncart = .true.
+    dd_unif_quality = 1.1
+    dd_rect_quality = 1.1
+ /
+
+ $UNITS
+    units_set = "cgs"
+ /
+
+ $RESTART_CONTROL
+    restart  = 'none'
+    res_id   = ''
+    nrestart = 0
+ /
+
+ $END_CONTROL
+    tend   = 0.0
+    nend   = 1 ! we can set here 0 as well, but this would issue a warning
+ /
+
+ $OUTPUT_CONTROL
+    problem_name ='maclaurin'
+    run_id =  'sph'
+    dt_hdf  = 10.0
+    dt_res  = 0.0
+    dt_log  = 0.0
+    dt_tsl  = 0.0
+    vars(1:) = 'dens', 'gpot', 'apot', 'errp', 'relerr', 'level'
+    h5_64bit = .true.
+ /
+
+ $FLUID_DUST
+    selfgrav = .true.
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 1e-50
+    smallei= 1e-50
+    limiter= 'vanleer'
+ /
+
+ $GRAVITY
+ /
+
+ $RESISTIVITY
+ /
+
+ $PROBLEM_CONTROL
+    x0     = 0.
+    y0     = 0.5e+62
+    z0     = 1.e+62
+    d0     = 1.
+    a1     = 0.7e+62
+    e      = 0.
+    nsub   = 3
+ /
+
+ $MULTIGRID_SOLVER
+    stdout    = .true.
+!    dirty_debug = .true.
+ /
+
+ $MULTIGRID_GRAVITY
+    grav_bnd_str  = "isolated"
+    mpole_solver  = "3d"
+    mpole_level   = 0   ! base level evaluation of multipole moments seems to be good enough for maclaurin, even -2 would be sufficient
+ /
+
+ $INTERACTIONS
+ /
+
+ $AMR
+    bsize = 3*8
+    level_max = 3
+ /

--- a/problems/sedov/MHD_blast_wave/problem.par.big_domain
+++ b/problems/sedov/MHD_blast_wave/problem.par.big_domain
@@ -1,0 +1,107 @@
+! 2D MHD blast wave, see
+! http://www.astro.princeton.edu/~jstone/Athena/tests/blast/blast.html
+! or
+! https://academic.oup.com/mnras/article/455/1/51/983632/Accurate-meshless-methods-for-magnetohydrodynamics
+! for more inspiration
+
+! The setup mostly follows the Athena approach except that we have different resolution and square domain.
+!
+! To mimic their setup use
+! n_d = 400, 600, 1
+! ymin = -0.75
+! ymax =  0.75
+! in the BASE_DOMAIN section below and also increase tend from END_CONTROL for full match
+
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+81. All hydrodynamical structures should remain
+# identical.
+# On bigger domains the refinement criteria start to produce different refinements.
+
+ $BASE_DOMAIN
+    n_d = 2*64, 1
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   =-0.5e+81
+    xmax   = 0.5e+81
+    ymin   =-0.5e+81
+    ymax   = 0.5e+81
+    zmin   =-0.5e+81
+    zmax   = 0.5e+81
+ /
+
+ $MPI_BLOCKS
+ /
+
+ $UNITS
+    units_set = 'cgs'
+ /
+
+ $RESTART_CONTROL
+ /
+
+ $END_CONTROL
+    tend   = 0.2e+81
+ /
+
+ $OUTPUT_CONTROL
+    problem_name = 'sedov'
+    run_id =  'tst'
+    dt_hdf  = 0.1e+81
+    dt_res  = 0.0
+    dt_log  = 0.01e+81
+    dt_tsl  = 0.01e+81
+    vars(1:) = 'ener', 'dens', 'magx', 'magy', 'magz', 'velx', 'vely', 'ethr', 'magB', "pres", "divb", "divb4", "psi", "level", "ref_01"
+    H5_64bit = .true.
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.666666666
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.666666666
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    print_divb = 10
+    solver_str = "Riemann"
+ /
+
+ $GRAVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.0
+    p0     = 0.1
+    Eexpl  = 14.85
+    bx0    = 0.7071067811865475
+    by0    = 0.7071067811865475
+    bz0    = 0.0
+    x0     = -0.0
+    y0     = -0.0
+    z0     = -0.0
+    r0     = 0.1e+81
+    smooth = 0.
+ /
+
+ $MULTIGRID_SOLVER
+ /
+
+ $INTERACTIONS
+ /
+
+ $FLUID_TRACER
+ /
+
+ $AMR
+    bsize = 3*16
+    level_max = 2
+    n_updAMR = 3
+ /

--- a/problems/sedov/problem.par.big_domain
+++ b/problems/sedov/problem.par.big_domain
@@ -1,0 +1,87 @@
+# This setup differs from the default one mostly in scaling sizes and times
+# by a factor of 1e+101. All hydrodynamical structures should remain
+# identical.
+# Bigger domains are crashing due to FP overflows in dataio.
+
+ $BASE_DOMAIN
+    n_d = 64, 64, 64
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   =-1.0e+101
+    xmax   = 1.0e+101
+    ymin   =-1.0e+101
+    ymax   = 1.0e+101
+    zmin   =-1.0e+101
+    zmax   = 1.0e+101
+ /
+
+ $MPI_BLOCKS
+ /
+
+ $UNITS
+    units_set = 'cgs'
+ /
+
+ $RESTART_CONTROL
+ /
+
+ $END_CONTROL
+    tend   = 0.002e+101
+ /
+
+ $OUTPUT_CONTROL
+    problem_name = 'sedov'
+    run_id =  'tst'
+    dt_hdf  = 0.001e+101
+    dt_res  = 0.0
+    dt_log  = 0.0001e+101
+    dt_tsl  = 0.0001e+101
+    vars(1:) = 'ener', 'dens', 'velx', 'vely', 'velz'
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.666666666
+ /
+
+ $FLUID_NEUTRAL
+    gamma = 1.666666666
+ /
+
+ $NUMERICAL_SETUP
+    cfl    = 0.7
+    smalld = 0.
+    smallei= 0.
+    solver_str = "Riemann"
+ /
+
+ $GRAVITY
+ /
+
+ $PROBLEM_CONTROL
+    d0     = 1.0
+    p0     = 1.0
+    Eexpl  = 1.e6
+    bx0    = 1.0
+    by0    = 1.0
+    bz0    = 1.0
+    x0     = -0.0
+    y0     = -0.0
+    z0     = -0.0
+    r0     = 0.25e+101
+ /
+
+ $MULTIGRID_SOLVER
+ /
+
+ $INTERACTIONS
+ /
+
+ $FLUID_TRACER
+ /
+
+ $AMR
+ /

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -90,7 +90,8 @@ module constants
    real, parameter :: e          = 2.718281828459045235  !< Napier's constant (base of Natural logarithm)
 
    ! some numerical representation extrema
-   real, parameter :: big        = huge(real(1.0,4))     !< a constant used as the upper limit number
+   real, parameter :: big        = huge(real(1.0,4))     !< a constant used as the upper limit number.
+   !> Warning: this value is causing numerical problems with domains bigger than ~1e42.
    real, parameter :: big_float  = huge(real(1.0,4))     !< replicated temporarily 'big' for compatibility \todo choose one and convert occurrences of the other one
    real, parameter :: dirtyH     = big                   !< If dirty_debug then pollute arrays with this insane value
    real, parameter :: dirtyH1    = 10.**int(log10(big))  !< this "round" dirty value makes it easier to detect which call contaminated the data

--- a/src/fluids/interactions/timestepinteractions.F90
+++ b/src/fluids/interactions/timestepinteractions.F90
@@ -45,7 +45,7 @@ contains
 
       use cg_leaves,    only: leaves
       use cg_list,      only: cg_list_element
-      use constants,    only: big, pMIN, small
+      use constants,    only: pMIN, small
       use fluidindex,   only: flind
       use func,         only: L2norm
       use grid_cont,    only: grid_container
@@ -58,7 +58,7 @@ contains
       type(grid_container),  pointer :: cg
       real                           :: val        !< variable used to store the maximum value of relative momentum
 
-      dt_interact = big
+      dt_interact = huge(1.)
       if (.not.has_interactions) return
       !    dt_interact_proc = 1.0 / (maxval(collfaq)+small) / maxval(cg%u(iarr_all_dn,:,:,:))
 

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -525,7 +525,6 @@ contains
       use constants,          only: fft_none
       use dataio_pub,         only: die
       use find_lev,           only: find_level
-      use func,               only: operator(.notequals.)
       use grid_cont,          only: grid_container
       use multigridvars,      only: overrelax
 #ifndef NO_FFT
@@ -544,14 +543,14 @@ contains
 
       ! this should work correctly also when dom%eff_dim < 3
       cg%mg%r  = overrelax / 2.
-      cg%mg%rx = cg%dvol**2 * cg%idx2
-      cg%mg%ry = cg%dvol**2 * cg%idy2
-      cg%mg%rz = cg%dvol**2 * cg%idz2
+      cg%mg%rx = cg%idx2
+      cg%mg%ry = cg%idy2
+      cg%mg%rz = cg%idz2
       cg%mg%r  = cg%mg%r / (cg%mg%rx + cg%mg%ry + cg%mg%rz)
       cg%mg%rx = cg%mg%r * cg%mg%rx
       cg%mg%ry = cg%mg%r * cg%mg%ry
       cg%mg%rz = cg%mg%r * cg%mg%rz
-      cg%mg%r  = cg%mg%r * cg%dvol**2
+      cg%mg%r  = cg%mg%r
 
       ! FFT solver storage and data
       curl => find_level(cg%l%id)
@@ -627,7 +626,7 @@ contains
          ! compute Green's function for 7-point 3D discrete laplacian
          do i = 1, cg%mg%nxc
             do j = 1, cg%nyb
-               where ((kx(i) + ky(j) + kz(:)).notequals.zero)
+               where (abs(kx(i) + ky(j) + kz(:)) >  tiny(1.))
                   cg%mg%Green3D(i,j,:) = half * cg%mg%fft_norm / (kx(i) + ky(j) + kz(:))
                elsewhere
                   cg%mg%Green3D(i,j,:) = zero

--- a/src/multigrid/multigrid_Laplace4M.F90
+++ b/src/multigrid/multigrid_Laplace4M.F90
@@ -192,12 +192,11 @@ contains
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
-      use constants,          only: xdim, ydim, zdim, ndims, GEO_XYZ, BND_NEGREF, pMAX, zero
+      use constants,          only: xdim, ydim, zdim, ndims, GEO_XYZ, BND_NEGREF, pMAX
       use dataio_pub,         only: die, warn
       use domain,             only: dom
       use global,             only: dirty_debug
       use grid_cont,          only: grid_container
-      use func,               only: operator(.notequals.)
       use mpisetup,           only: piernik_MPI_Allreduce, master
       use multigrid_helpers,  only: set_relax_boundaries, copy_and_max
       use multigridvars,      only: multidim_code_3D, coarsest_tol, nc_growth, dirty_label
@@ -257,7 +256,7 @@ contains
             Ly  = 0. ; if (dom%has_dir(ydim)) Ly = cg%idy2 - 2. * (Lxy + Lyz)
             Lz  = 0. ; if (dom%has_dir(zdim)) Lz = cg%idz2 - 2. * (Lxz + Lyz)
             L0  = 2. * (Lx + Ly + Lz) + 4. * (Lxy + Lxz + Lyz)
-            if (L0.notequals.zero) then
+            if (abs(L0) > tiny(1.0)) then
                iL0 = 1. / L0
                Lx = Lx * iL0
                Ly = Ly * iL0


### PR DESCRIPTION
Remove computational faults when the cell sizes are big or extreme (like when one sets up a galaxy measured in centimeters).

These faults usually result from use of small and big values from constants module. In principle small and big should prevent division by zero or numerical overflows in single-precision data output but in many places we may safely use full range of double precision and avoid biased calculations.