### PR TITLE
make gfortran 12.x a little bit happier

### DIFF
--- a/src/grid/domain.F90
+++ b/src/grid/domain.F90
@@ -321,18 +321,10 @@ contains
 
       call dom%init(nb, n_d, [bnd_xl, bnd_xr, bnd_yl, bnd_yr, bnd_zl, bnd_zr], edges, geometry, offset)
 
-      where (dom%has_dir(:))
-         minsize(:) = max(minsize(:), dom%nb)
-      elsewhere
-         minsize(:) = 1
-      endwhere
-
       is_uneven = .false.
       is_mpi_noncart = .false.
       is_refined = .false.
       is_multicg = .false.
-
-      where (.not. dom%has_dir(:)) psize(:) = I_ONE
 
    end subroutine init_domain
 
@@ -586,8 +578,11 @@ contains
 
       where (this%has_dir(:))
          this%n_t(:) = this%n_d(:) + I_TWO * this%nb
+         minsize(:) = max(minsize(:), this%nb)
       elsewhere
          this%n_t(:) = 1
+         minsize(:) = 1
+         psize(:) = I_ONE
       endwhere
 
    end subroutine init

--- a/src/grid/grid_container_prolong.F90
+++ b/src/grid/grid_container_prolong.F90
@@ -75,10 +75,8 @@ contains
 
       ! size of coarsened grid with guardcells
       rn = f2c(int(this%ijkse, kind=8))
-      where (dom%has_dir(:))
-         rn(:, LO) = rn(:, LO) - dom%nb
-         rn(:, HI) = rn(:, HI) + dom%nb
-      endwhere
+      where (dom%has_dir(:)) rn(:, LO) = rn(:, LO) - dom%nb
+      where (dom%has_dir(:)) rn(:, HI) = rn(:, HI) + dom%nb
       allocate(this%prolong_   (      rn(xdim, LO):      rn(xdim, HI),       rn(ydim, LO):      rn(ydim, HI),       rn(zdim, LO):      rn(zdim, HI)), &
            &   this%prolong_x  (this%lhn(xdim, LO):this%lhn(xdim, HI),       rn(ydim, LO):      rn(ydim, HI),       rn(zdim, LO):      rn(zdim, HI)), &
            &   this%prolong_xy (this%lhn(xdim, LO):this%lhn(xdim, HI), this%lhn(ydim, LO):this%lhn(ydim, HI),       rn(zdim, LO):      rn(zdim, HI)), &


### PR DESCRIPTION
It seems that `-Wmaybe-uninitialized` in gfortran 12.x is alittle bit overreacting and throwing false-positives sometimes.

The fixes here are achieved by rearranging the code.