### PR TITLE
fixups

### DIFF
--- a/problems/testing_and_debuging/chimaera/info
+++ b/problems/testing_and_debuging/chimaera/info
@@ -1,0 +1,1 @@
+Compilation test problem that covers most of the codebase by including nearly all F90 files.

--- a/problems/testing_and_debuging/chimaera/initproblem.F90
+++ b/problems/testing_and_debuging/chimaera/initproblem.F90
@@ -1,0 +1,62 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+#include "piernik.h"
+
+module initproblem
+
+   implicit none
+
+   private
+   public :: read_problem_par, problem_initial_conditions, problem_pointers
+
+contains
+
+!-----------------------------------------------------------------------------
+
+   subroutine problem_pointers
+
+      implicit none
+
+   end subroutine problem_pointers
+
+!-----------------------------------------------------------------------------
+
+   subroutine read_problem_par
+
+      implicit none
+
+   end subroutine read_problem_par
+
+!-----------------------------------------------------------------------------
+
+   subroutine problem_initial_conditions
+
+      implicit none
+
+   end subroutine problem_initial_conditions
+
+end module initproblem

--- a/problems/testing_and_debuging/chimaera/piernik.def
+++ b/problems/testing_and_debuging/chimaera/piernik.def
@@ -1,0 +1,31 @@
+#if !defined LOCAL_FR_SPEED
+#  define GLOBAL_FR_SPEED
+#endif
+
+/* Fluids */
+#define DUST
+#define IONIZED
+/* NEUTRAL is mutually exclusive with IONIZED at this point */
+#undef NEUTRAL
+#define TRACER
+
+/* Big features */
+#define MAGNETIC
+#define CRESP
+#define SELF_GRAV
+#define NBODY
+
+/* Small, single-file features */
+#define SN_SRC
+#define THERM
+#define SHEAR
+#define RESISTIVE
+#define DEBUG
+/* RANDOMIZE is known for unsolved problems when default integer type is forced to 64-bit
+   because there is no appropriate variant of h5ltget_attribute_int_f */
+#undef RANDOMIZE
+
+/* Barely used, abandoned, historical ... */
+#define CORIOLIS
+#undef PGPLOT
+#undef PIERNIK_OPENCL

--- a/problems/testing_and_debuging/chimaera/piernik.def
+++ b/problems/testing_and_debuging/chimaera/piernik.def
@@ -20,10 +20,14 @@
 #define THERM
 #define SHEAR
 #define RESISTIVE
-#define DEBUG
 /* RANDOMIZE is known for unsolved problems when default integer type is forced to 64-bit
    because there is no appropriate variant of h5ltget_attribute_int_f */
 #undef RANDOMIZE
+
+/* Debugging */
+#define DEBUG
+#define VERBOSE
+#define CRESP_VERBOSED
 
 /* Barely used, abandoned, historical ... */
 #define CORIOLIS

--- a/problems/testing_and_debuging/chimaera/problem.par
+++ b/problems/testing_and_debuging/chimaera/problem.par
@@ -1,0 +1,8 @@
+! This problem is not intended to run, so no parameters are set up here.
+
+! This problem is intended to include as many Piernik source files as possible
+! and cover most code lines in a single compilation.
+
+! To check which files aren't included, you may run:
+!     ./setup testing_and_debuging/chimaera -o Chi
+!     for i in $( find src/ -name "*F90" ) ; do ls obj_Chi/$( basename $i ) > /dev/null || ( echo -n $i" " && grep pulled $i ) ; done

--- a/src/IO/hdf5/particles_io.F90
+++ b/src/IO/hdf5/particles_io.F90
@@ -137,7 +137,7 @@ contains
 
       if (proc_ncg == proc) n_part = count_cg_particles(get_nth_cg(cg_src_ncg))
 
-      ptag = ncg + tot_cg_n * (ubound(hdf_vars, 1, kind=4) + 1)
+      ptag = ncg + tot_cg_n * (ubound(hdf_vars, 1, kind=4) + I_ONE)
       if (master) then
          if (proc_ncg /= proc) call MPI_Recv(n_part, I_ONE, MPI_INTEGER, proc_ncg, ptag, MPI_COMM_WORLD, MPI_STATUS_IGNORE, err_mpi)
       else

--- a/src/fluids/cosmicrays/cresp_NR_method.F90
+++ b/src/fluids/cosmicrays/cresp_NR_method.F90
@@ -1416,6 +1416,8 @@ contains
 #ifdef CRESP_VERBOSED
    subroutine save_loc(bound_case, loc1, loc2)
 
+      use cresp_helpers, only: extension
+
       implicit none
 
       integer(kind=4),                 intent(in) :: bound_case

--- a/src/fluids/thermal/thermal.F90
+++ b/src/fluids/thermal/thermal.F90
@@ -395,6 +395,7 @@ contains
       class(component_fluid), pointer     :: pfl
 
       if (.not. thermal_active) return
+      hfunc = huge(1.)  ! suppress spurious compiler warning triggered by -Wmaybe-uninitialized
 
       cgl => leaves%first
       do while (associated(cgl))

--- a/src/particles/particle_utils.F90
+++ b/src/particles/particle_utils.F90
@@ -176,7 +176,7 @@ contains
       integer(kind=8), dimension(ndims, LO:HI), intent(in) :: se
       integer(kind=8), dimension(ndims),        intent(in) :: off
       real,            dimension(ndims),        intent(in) :: dl
-      integer,                                  intent(in) :: nexp
+      integer(kind=4),                          intent(in) :: nexp
       real,            dimension(ndims, LO:HI)             :: fbnd
 
       fbnd(:, LO)  = dom%edge(:, LO) + dl(:) * (se(:, LO)         - off(:) - nexp)
@@ -188,7 +188,7 @@ contains
 
       use cg_level_base,      only: base
       use cg_level_connected, only: cg_level_connected_t
-      use constants,          only: LO, HI, ndims, xdim, zdim
+      use constants,          only: LO, HI, ndims, xdim, zdim, I_ZERO
       use domain,             only: dom
       use mpisetup,           only: proc
       use particle_func,      only: particle_in_area
@@ -196,10 +196,12 @@ contains
 
       implicit none
 
-      type(particle), pointer, intent(in) :: pset
-      integer,                 intent(in) :: j
-      integer, dimension(:,:), intent(in) :: se
-      integer                             :: b, cdim
+      type(particle), pointer,         intent(in) :: pset
+      integer,                         intent(in) :: j
+      integer(kind=4), dimension(:,:), intent(in) :: se
+
+      integer                             :: b
+      integer(kind=4)                     :: cdim
       real,    dimension(ndims)           :: ldl
       logical, dimension(ndims, LO:HI)    :: ext_bnd
       type(cg_level_connected_t), pointer :: ll
@@ -217,7 +219,7 @@ contains
                ext_bnd(cdim, LO) = ll%l%is_ext_bnd(ll%dot%gse(j)%c(b)%se, cdim, LO)
                ext_bnd(cdim, HI) = ll%l%is_ext_bnd(ll%dot%gse(j)%c(b)%se, cdim, HI)
             enddo
-            if (outdom_part_in_cg(pset%pdata%pos, fbnd_npb(ll%dot%gse(j)%c(b)%se, ll%l%off, ldl, 0), ext_bnd)) to_send = .true.
+            if (outdom_part_in_cg(pset%pdata%pos, fbnd_npb(ll%dot%gse(j)%c(b)%se, ll%l%off, ldl, I_ZERO), ext_bnd)) to_send = .true.
          endif
 #ifdef NBODY_CHECK_PID
          if (to_send) then
@@ -417,6 +419,7 @@ contains
 
    integer(kind=4) function count_cg_particles(cg) result(n_part)
 
+      use constants,      only: I_ONE
       use grid_cont,      only: grid_container
       use particle_types, only: particle
 
@@ -428,7 +431,7 @@ contains
       n_part = 0
       pset => cg%pset%first
       do while (associated(pset))
-         if (pset%pdata%phy) n_part = n_part + 1
+         if (pset%pdata%phy) n_part = n_part + I_ONE
       pset => pset%nxt
       enddo
 

--- a/src/supernovae/snsources.F90
+++ b/src/supernovae/snsources.F90
@@ -330,14 +330,14 @@ contains
 
 !  outer boundary
       jremap = jsn - delj
-      jremap = mod(mod(jremap, cg%nyb)+cg%nyb, cg%nyb)
+      jremap = mod(mod(jremap, int(cg%nyb))+cg%nyb, int(cg%nyb))
       if (jremap <= (cg%lh1(ydim,LO))) jremap = jremap + cg%nyb
 
       ysnoi(1) = cg%y(jremap) + epso + dysn
 
 !  inner boundary
       jremap = jsn + delj
-      jremap = mod(jremap, cg%nyb)+cg%nyb
+      jremap = mod(jremap, int(cg%nyb))+cg%nyb
       if (jremap >= (cg%lh1(ydim,HI))) jremap = jremap - cg%nyb
 
       ysnoi(3) = cg%y(jremap) + epsi + dysn


### PR DESCRIPTION
Corrected integer kind.

Current Jenkins tests for proper int32/int64 declarations rely on compiling `crtest`. Perhaps it is time to change this to something that has better code coverage. 