### PR TITLE
manage indexes for CR spectral

### DIFF
--- a/src/fluids/cosmicrays/cresp_NR_method.F90
+++ b/src/fluids/cosmicrays/cresp_NR_method.F90
@@ -519,6 +519,7 @@ contains
       integer(kind=4), intent(in) :: bound_case
       real, dimension(:), pointer :: pfp, pff
       real, dimension(1:2)        :: x_vec, prev_solution, prev_solution_1, x_step
+      real, dimension(1:3)        :: ntab3
       integer(kind=4)             :: i, j, is, js, jm
       logical                     :: exit_code, new_line
 #ifdef CRESP_VERBOSED
@@ -559,9 +560,10 @@ contains
             if (exit_code) then
                jm = j - I_TWO
                if (check_dimm(jm, arr_dim_n)) then
+                  ntab3 = n_tab(bound_case, j-I_TWO:j)
                   pfp => p_p(i,jm:j)
                   pff => p_f(i,jm:j)
-                  call step_extr(pfp, pff, n_tab(bound_case, jm:j), exit_code)
+                  call step_extr(pfp, pff, ntab3, exit_code)
                endif
                if (j >= 2) then
                   jm = j - I_ONE

--- a/src/fluids/cosmicrays/cresp_helpers.F90
+++ b/src/fluids/cosmicrays/cresp_helpers.F90
@@ -33,7 +33,7 @@
 module cresp_helpers
 ! pulled by CRESP
 
-   use constants,    only: cbuff_len, LO, HI
+   use constants, only: cbuff_len, LO, HI
 
    implicit none
 

--- a/src/fluids/cosmicrays/initcosmicrays.F90
+++ b/src/fluids/cosmicrays/initcosmicrays.F90
@@ -264,7 +264,7 @@ contains
       nspc = count(cr_spectral, kind=4)
       ncrn = ncrsp - nspc
 
-      ncr2b  = I_TWO * ncrb
+      ncr2b  = I_TWO * ncrb * nspc
       ncrtot = ncr2b + ncrn
 
       if (any([ncrsp, ncrb] > ncr_max) .or. any([ncrsp, ncrb] < 0)) call die("[initcosmicrays:init_cosmicrays] ncr[nes] > ncr_max or ncr[nes] < 0")
@@ -293,7 +293,7 @@ contains
       call my_allocate(iarr_cre, ma1d) ! < iarr_cre will point: (1:ncrb) - cre number per bin, (ncrb+1:2*ncrb) - cre energy per bin
 
 #ifdef CRESP
-      ma1d = [ncrb]
+      ma1d = [ncrb * nspc]
       call my_allocate(iarr_cre_e, ma1d)
       call my_allocate(iarr_cre_n, ma1d)
 #endif /* CRESP */
@@ -345,18 +345,18 @@ contains
       flind%cre%beg = flind%crn%end + I_ONE
       flind%cre%end = flind%all
       flind%crs%end = flind%cre%end
-      if (flind%crn%all  /= 0) flind%components = flind%components + I_ONE
+      if (flind%crn%all /= 0) flind%components = flind%components + I_ONE
       flind%crn%pos = flind%components
-      if (flind%cre%all  /= 0) flind%components = flind%components + I_ONE
+      if (flind%cre%all /= 0) flind%components = flind%components + I_ONE
       flind%cre%pos = flind%components
 
 #ifdef CRESP
       flind%cre%nbeg = flind%crn%end + I_ONE
-      flind%cre%nend = flind%crn%end + ncrb
+      flind%cre%nend = flind%crn%end + ncrb * nspc
       flind%cre%ebeg = flind%cre%nend + I_ONE
-      flind%cre%eend = flind%cre%nend + ncrb
+      flind%cre%eend = flind%cre%nend + ncrb * nspc
 
-      do icr = 1, ncrb
+      do icr = 1, ncrb * nspc
          iarr_cre_n(icr) = flind%cre%nbeg - I_ONE + icr
          iarr_cre_e(icr) = flind%cre%ebeg - I_ONE + icr
       enddo

--- a/src/fluids/cosmicrays/initcosmicrays.F90
+++ b/src/fluids/cosmicrays/initcosmicrays.F90
@@ -369,7 +369,8 @@ contains
 !<
    integer(kind=4) function cri_select(icr) result(nm)
 
-      use cr_data, only: cr_spectral
+      use constants, only: I_ONE
+      use cr_data,   only: cr_spectral
 
       implicit none
 
@@ -383,7 +384,7 @@ contains
       im = 0
       do i = 1, ncrsp
          if (cr_spectral(i) .eqv. spec) then
-            im = im + 1
+            im = im + I_ONE
             if (ic == im) nm = i
          endif
       enddo

--- a/src/fluids/cosmicrays/initcosmicrays.F90
+++ b/src/fluids/cosmicrays/initcosmicrays.F90
@@ -379,7 +379,7 @@ contains
 
       nm = -1
       spec = (icr > ncrn)
-      ic = icr ; if (spec) ic = ceiling(float(icr-ncrn)/float(ncr2b))
+      ic = icr ; if (spec) ic = ceiling(real(icr-ncrn)/real(ncr2b), kind=4)
       im = 0
       do i = 1, ncrsp
          if (cr_spectral(i) .eqv. spec) then
@@ -415,7 +415,7 @@ contains
          cr_v = 2
          crsp = cri_select(icrt)
          if (iecr > fne) then
-            cr_v = ceiling(float(iecr-fne)/float(ncrb))
+            cr_v = ceiling(real(iecr-fne)/real(ncrb), kind=4)
             cr_b = mod(iecr-fne, ncrb)
          endif
       endif

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -174,7 +174,7 @@ contains
       use diagnostics,     only: my_allocate_with_index
       use global,          only: disallow_CRnegatives
       use func,            only: emag
-      use initcosmicrays,  only: ncrb, ncr2b, ncrn, ncrtot, K_cr_paral, K_cr_perp, K_crs_paral, K_crs_perp, use_smallecr
+      use initcosmicrays,  only: ncrb, ncr2b, ncrn, nspc, ncrtot, K_cr_paral, K_cr_perp, K_crs_paral, K_crs_perp, use_smallecr
       use mpisetup,        only: rbuff, ibuff, lbuff, cbuff, master, slave, piernik_MPI_Bcast
       use units,           only: clight, me, sigma_T
 
@@ -417,7 +417,7 @@ contains
       NR_refine_pf     = [NR_refine_pf_lo, NR_refine_pf_up]
 
 ! Input parameters check
-      if (use_cresp .and. ncrb <= I_ZERO)  then
+      if (use_cresp .and. (ncrb <= I_ZERO .or. nspc == I_ZERO))  then
          write (msg,"(A,I4,A)") '[initcrspectrum:init_cresp] ncrb   = ', ncrb, '; CR bins NOT initnialized. Switching CRESP module off.'
          if (master) call warn(msg)
          use_cresp      = .false.


### PR DESCRIPTION
* automatically switch off cresp for no spectral CR species selected
* routines to identify CR species by component number