### PR TITLE
Don't overwrite self

### DIFF
--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -492,8 +492,8 @@ contains
          end select
       enddo
 
-      if (wd_wr(len_trim(wd_wr):len_trim(wd_wr)) /= '/' ) write(wd_wr,'(a,a1)') trim(wd_wr),'/'
-      if (wd_rd(len_trim(wd_rd):len_trim(wd_rd)) /= '/' ) write(wd_rd,'(a,a1)') trim(wd_rd),'/'
+      if (wd_wr(len_trim(wd_wr):len_trim(wd_wr)) /= '/' ) write(wd_wr(len_trim(wd_wr)+1:),'(a1)') '/'
+      if (wd_rd(len_trim(wd_rd):len_trim(wd_rd)) /= '/' ) write(wd_rd(len_trim(wd_rd)+1:),'(a1)') '/'
 
       ! Print the date and, optionally, the time
       call date_and_time(DATE=date, TIME=time, ZONE=zone)

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -478,7 +478,7 @@ contains
             write(log_wr,'(a)') get_next_arg(i+1, arg)
             skip_next = .true.
          case ('-n', '--namelist')
-            write(cmdl_nml, '(3A)') cmdl_nml(1:len_trim(cmdl_nml)), " ", trim(get_next_arg(i+1, arg))
+            write(cmdl_nml(len_trim(cmdl_nml)+1:), '(2A)') " ", trim(get_next_arg(i+1, arg))
             skip_next = .true.
          case ('-h', '--help')
             call print_help()

--- a/src/base/named_array_list.F90
+++ b/src/base/named_array_list.F90
@@ -270,12 +270,12 @@ contains
             if (any(this%lst(i)%position /= 0)) then
                ! theoretically we can print even about (len(msg) - len_trim(msg))/2 ~= 452 entries for position
                if (size(this%lst(i)%position) <= 400) then  ! hardcoded integer here and in the formats below
-                  write(msg, '(a,400i2)') trim(msg), this%lst(i)%position(:)
+                  write(msg(len_trim(msg)+1:), '(400i2)') this%lst(i)%position(:)
                else
-                  write(msg, '(a,400i2,a)') trim(msg), this%lst(i)%position(:400), " ... ??? ..."
+                  write(msg(len_trim(msg)+1:), '(400i2,a)') this%lst(i)%position(:400), " ... ??? ..."
                endif
             else
-               write(msg, '(2a,i4,a)') trim(msg), "[ ", size(this%lst(i)%position), " * 0 ]"
+               write(msg(len_trim(msg)+1:), '(a,i4,a)') "[ ", size(this%lst(i)%position), " * 0 ]"
             endif
          endif
          call printinfo(msg, to_stdout)

--- a/src/fluids/cosmicrays/cr_data.F90
+++ b/src/fluids/cosmicrays/cr_data.F90
@@ -284,8 +284,8 @@ contains
 
       if (master) then
          write(msg, '(a,i3)') 'Total amount of CR species: ', ncrsp
-         if (count(cr_spectral) > 0) write(msg, '(a,a,i3,a)') trim(msg), ' | ', count(cr_spectral), ' spectral component(s)'
-         if (ncrsp - ncrsp_auto > 0) write(msg, '(a,a,i3,a)') trim(msg), ' | ', ncrsp - ncrsp_auto, ' user component(s).'
+         if (count(cr_spectral) > 0) write(msg(len_trim(msg)+1:), '(a,i3,a)') ' | ', count(cr_spectral), ' spectral component(s)'
+         if (ncrsp - ncrsp_auto > 0) write(msg(len_trim(msg)+1:), '(a,i3,a)') ' | ', ncrsp - ncrsp_auto, ' user component(s).'
          call printinfo(msg)
       endif
 

--- a/src/gravity/old_soln_list.F90
+++ b/src/gravity/old_soln_list.F90
@@ -390,7 +390,7 @@ contains
       write(msg, '(a,g14.6,3a,i3,a)') "[old_soln_list] t= ", t, " name: '", trim(this%label), "' contains ", this%cnt(), " elements"
       select type(this)
          type is (os_list_t)
-            write(msg, '(2a,l2)') trim(msg), " is valid? ", this%is_valid()
+            write(msg(len_trim(msg)+1:), '(a,l2)') " is valid? ", this%is_valid()
          class default
       end select
       if (master) call printinfo(msg)

--- a/src/grid/level_essentials.F90
+++ b/src/grid/level_essentials.F90
@@ -84,9 +84,9 @@ contains
 
       write(msg, '(a,i4,a,3i11,a)')"[level_essentials] Initializing level", this%id, ", size=[", this%n_d, "], "
       if (any(dom%has_dir .and. (this%off /= 0))) then
-         write(msg, '(2a,3i8,a)')trim(msg)," offset=[", this%off, "]"
+         write(msg(len_trim(msg)+1:), '(a,3i8,a)') " offset=[", this%off, "]"
       else
-         write(msg, '(2a)')trim(msg)," no offset"
+         write(msg(len_trim(msg)+1:), '(a)') " no offset"
       endif
       if (master) call printinfo(msg)
 

--- a/src/grid/load_balance.F90
+++ b/src/grid/load_balance.F90
@@ -227,9 +227,9 @@ contains
       if (master) then
          if (any(cost_mask) .and. (balance_cg > 0. .or. balance_host > 0.)) then
             write(msg, '(a)')"[load_balance] Auto-balance enabled: "
-            if (balance_host > 0.) write(msg, '(2a,f5.2,a)') &
-                 trim(msg), " balance_host = ", balance_host, " (" // trim(merge("thread", "host  ", balance_thread)) // "-based)"
-            if (balance_cg > 0.) write(msg, '(2a,f5.2)') trim(msg), " balance_cg = ", balance_cg
+            if (balance_host > 0.) write(msg(len_trim(msg)+1:), '(a,f5.2,a)') &
+                 " balance_host = ", balance_host, " (" // trim(merge("thread", "host  ", balance_thread)) // "-based)"
+            if (balance_cg > 0.) write(msg(len_trim(msg)+1:), '(a,f5.2)') " balance_cg = ", balance_cg
             call printinfo(msg)
          endif
          if (watch_ind /= INVALID .and. enable_exclusion) then

--- a/src/grid/refinement/unified_ref_crit_list.F90
+++ b/src/grid/refinement/unified_ref_crit_list.F90
@@ -286,11 +286,11 @@ contains
                   p%iplot = new_ref_field()
                   write(msg, '(3a)') "[unified_ref_crit_list:create_plotfields] refinement criterion of type '", trim(p%rname), "' for '"
                   if (p%ic /= INVALID) then
-                     write(msg, '(3a,i3,a)') trim(msg), trim(wna%lst(p%iv)%name), "(", p%ic, ")"
+                     write(msg(len_trim(msg)+1:), '(2a,i3,a)') trim(wna%lst(p%iv)%name), "(", p%ic, ")"
                   else
-                     write(msg, '(2a)') trim(msg), trim(qna%lst(p%iv)%name)
+                     write(msg(len_trim(msg)+1:), '(a)') trim(qna%lst(p%iv)%name)
                   endif
-                  write(msg, '(4a)') trim(msg), "' is stored in array '", trim(ref_n), "'"
+                  write(msg(len_trim(msg)+1:), '(3a)') "' is stored in array '", trim(ref_n), "'"
                   if (master) call printinfo(msg)
                endif
             class is (urc_jeans)

--- a/src/magnetic/divB.F90
+++ b/src/magnetic/divB.F90
@@ -100,9 +100,9 @@ contains
       write(msg,'(a)')"[divB:print_divB_norm]"
       do i = I_TWO, I_TWO*min(max_c, dom%nb), I_TWO  ! only even-order norms;  tricky: I_TWO*max_c
          call divB(i)
-         write(msg,'(2a,i1,a,g12.5)')trim(msg), " |divB|_", i, "= ", leaves%norm_sq(idivB) / sqrt(dom%Vol)
+         write(msg(len_trim(msg)+1:), '(a,i1,a,g12.5)') " |divB|_", i, "= ", leaves%norm_sq(idivB) / sqrt(dom%Vol)
       enddo
-      if (qna%exists(psi_n)) write(msg,'(2a,g12.5)') trim(msg), " |psi|= ", leaves%norm_sq(qna%ind(psi_n)) / sqrt(dom%Vol)
+      if (qna%exists(psi_n)) write(msg(len_trim(msg)+1:), '(a,g12.5)') " |psi|= ", leaves%norm_sq(qna%ind(psi_n)) / sqrt(dom%Vol)
       if (master) call printinfo(msg)
 
    end subroutine print_divB_norm


### PR DESCRIPTION
Apparently Intel compilers do not handle well overwriting a string with itself, which caused the `-n` option to fail to pass commandline parameters.

Some other cases of similar code were also rewritten.