### PR TITLE
[IO] change the default value of nproc_io to 1

### DIFF
--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -297,7 +297,7 @@ contains
       tsl_firstcall      = .true.
       use_v2_io          = .true.
       gdf_strict         = .true.
-      nproc_io           = nproc
+      nproc_io           = 1  ! The default was nproc previously but it seems that serial write is often faster, especially on NFS. Use any other value in problem.par to get the parallel write by nproc threads.
       enable_compression = .false.
       gzip_level         = 9
 

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -766,6 +766,9 @@ contains
          enddo
       else ! perform parallel write
          ! This piece will be a generalization of the serial case. It should work correctly also for nproc_io == 1 so it should replace the serial code
+
+         ! It seems that the fastest implementation would use _at most_ single thread per node.
+
          if (can_i_write) then
             ! write own
             n = 0

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -338,6 +338,10 @@ contains
          enddo
       else ! perform parallel write
          ! This piece will be a generalization of the serial case. It should work correctly also for nproc_io == 1 so it should replace the serial code
+
+         ! It seems that the fastest implementation would use _at most_ single thread per node.
+         ! This way the MPI communication would be intra-node only and there would be not too many I/O-active threads.
+
          if (can_i_write) then
             ! write own
             n = 0


### PR DESCRIPTION
[IO] change the default value of nproc_io to 1 as it is usually faster than nproc on NFS.

ToDo: implement general case with the default of 1 thread per node.