### PR TITLE
Less regular ways for updating refinements

### DIFF
--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -622,6 +622,7 @@ contains
       use mpisetup,     only: master, piernik_MPI_Bcast
       use ppp,          only: umsg_request
       use procnames,    only: pnames
+      use refinement,   only: emergency_fix
       use timer,        only: walltime_end
 #ifdef HDF5
       use data_hdf5,    only: write_hdf5
@@ -703,6 +704,8 @@ contains
             case ('unexclude')
                call pnames%enable_all
                ! manual excluding may be helpful too, but we need to pass a list, like "exclude 2,7-9,32769", and process it safely
+            case ('refine')
+               emergency_fix = .true.
             case ('help')
                if (master) then
                   write(msg,*) "[dataio:user_msg_handler] Recognized messages:", char(10), &
@@ -715,6 +718,7 @@ contains
 #endif /* HDF5 */
                   &"  log       - update logfile", char(10), &
                   &"  tsl       - write a timeslice", char(10), &
+                  &"  refine    - call refinement_update as soon as possible", char(10), &
                   &"  ppp [N]   - start ppp_main profiling for N timesteps (default 1)", char(10), &
                   &"  unexclude - reset thread exclusion mask", char(10), &
                   &"  perf [N]  - print performance data with verbosity N (default V_HOST)", char(10), &

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -36,7 +36,7 @@ program piernik
    use cg_list_global,    only: all_cg
    use constants,         only: PIERNIK_START, PIERNIK_INITIALIZED, PIERNIK_FINISHED, PIERNIK_CLEANUP, fplen, stdout, I_ONE, CHK, FINAL_DUMP, cbuff_len, PPP_IO, PPP_MPI
    use dataio,            only: write_data, user_msg_handler, check_log, check_tsl, dump, cleanup_dataio
-   use dataio_pub,        only: nend, tend, msg, printinfo, warn, die, code_progress
+   use dataio_pub,        only: nend, tend, msg, printinfo, warn, die, code_progress, nstep_start
    use div_B,             only: print_divB_norm
    use finalizepiernik,   only: cleanup_piernik
    use fluidindex,        only: flind
@@ -48,7 +48,7 @@ program piernik
    use mpisetup,          only: master, piernik_MPI_Barrier, piernik_MPI_Bcast, cleanup_mpi
    use named_array_list,  only: qna, wna
    use ppp,               only: cleanup_profiling, update_profiling, ppp_main
-   use refinement,        only: emergency_fix
+   use refinement,        only: emergency_fix, updAMR_after
    use refinement_update, only: update_refinement
    use repeatstep,        only: repeat_step
    use timer,             only: walltime_end
@@ -203,6 +203,7 @@ program piernik
       call update_profiling
       rs = repeat_step()  ! enforce function call
 
+      emergency_fix = any(nstep_start + updAMR_after == nstep)
    enddo ! main loop
 
    if (print_divB > 0) then

--- a/src/grid/refinement.F90
+++ b/src/grid/refinement.F90
@@ -37,7 +37,7 @@ module refinement
    private
    public :: n_updAMR, oop_thr, ref_point, refine_points, ref_auto_param, refine_vars, level_min, level_max, inactive_name, bsize, &
         &    ref_box, refine_boxes, refine_zcyls, init_refinement, emergency_fix, set_n_updAMR, prefer_n_bruteforce, jeans_ref, jeans_plot, &
-        &    nbody_ref
+        &    nbody_ref, updAMR_after
 
    integer(kind=4), protected :: n_updAMR            !< How often to update the refinement structure
    real,            protected :: oop_thr             !< Maximum allowed ratio of Out-of-Place grid pieces (according to current ordering scheme)
@@ -49,6 +49,9 @@ module refinement
 
    ! some refinement primitives
    integer, parameter :: nshapes = 10 !< number of shapes of each kind allowed to be predefined by user in problem.par
+
+   integer, parameter :: n_upd_steps = 10 !< number of entries in updAMR_after
+   integer(kind=4), dimension(n_upd_steps), protected :: updAMR_after
 
    !> \brief Refinement point
    type :: ref_point
@@ -87,7 +90,7 @@ module refinement
 
    logical :: emergency_fix                                                    !< set to .true. if you want to call update_refinement ASAP
 
-   namelist /AMR/ level_min, level_max, bsize, auto_bsize, n_updAMR, prefer_n_bruteforce, oop_thr, &
+   namelist /AMR/ level_min, level_max, bsize, auto_bsize, n_updAMR, updAMR_after, prefer_n_bruteforce, oop_thr, &
         &         refine_points, refine_boxes, refine_zcyls, refine_vars, jeans_ref, jeans_plot, &
         &         nbody_ref
 
@@ -104,6 +107,7 @@ contains
 !!   <tr><td> level_min           </td><td> 0       </td><td> integer          </td><td> \copydoc refinement::level_min           </td></tr>
 !!   <tr><td> level_max           </td><td> 0       </td><td> integer          </td><td> \copydoc refinement::level_max           </td></tr>
 !!   <tr><td> n_updAMR            </td><td> HUGE    </td><td> integer          </td><td> \copydoc refinement::n_updAMR            </td></tr>
+!!   <tr><td> updAMR_after        </td><td> 0       </td><td> integer(10)      </td><td> \copydoc refinement::updAMR_after        </td></tr>
 !!   <tr><td> oop_thr             </td><td> 0.1     </td><td> real             </td><td> \copydoc refinement::oop_thr             </td></tr>
 !!   <tr><td> refine_points(10)   </td><td> none    </td><td> integer, 3*real  </td><td> \copydoc refinement::refine_points       </td></tr>
 !!   <tr><td> refine_boxes(10)    </td><td> none    </td><td> integer, 6*real  </td><td> \copydoc refinement::refine_boxes        </td></tr>
@@ -146,6 +150,7 @@ contains
       jeans_ref = 0.       !< inactive by default, 4. is the absolute minimum for reasonable use
       jeans_plot = .false.
       nbody_ref = INVALID
+      updAMR_after = I_ZERO
 
       if (2*n_ref_auto_param              > ubound(cbuff, dim=1)) call die("[refinement:init_refinement] increase cbuff size")
       if (10+3*nshapes                    > ubound(ibuff, dim=1)) call die("[refinement:init_refinement] increase ibuff size")
@@ -187,6 +192,7 @@ contains
          ibuff(11          :10+  nshapes) = refine_points(:)%level
          ibuff(11+  nshapes:10+2*nshapes) = refine_boxes (:)%level
          ibuff(11+2*nshapes:10+3*nshapes) = refine_zcyls (:)%level
+         ibuff(11+3*nshapes:10+3*nshapes+n_upd_steps) = updAMR_after
 
          lbuff(1) = jeans_plot
          lbuff(2) = prefer_n_bruteforce
@@ -236,6 +242,7 @@ contains
          refine_points(:)%level = ibuff(11          :10+  nshapes)
          refine_boxes (:)%level = ibuff(11+  nshapes:10+2*nshapes)
          refine_zcyls (:)%level = ibuff(11+2*nshapes:10+3*nshapes)
+         updAMR_after           = ibuff(11+3*nshapes:10+3*nshapes+n_upd_steps)
 
          jeans_plot               = lbuff(1)
          prefer_n_bruteforce      = lbuff(2)

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -557,13 +557,9 @@ contains
       call finest%level%restrict_to_base ! implies update of leafmap
       call ppp_main%stop(rtb_label, PPP_AMR)
 
-      if (n_updAMR <= 0) then
-         ! call print_time("[refinement_update] No refinement update")  ! ToDo: enable only when detailed profiling is required
-         return
-      endif
-      if (mod(nstep, n_updAMR) /= 0 .and. .not. emergency_fix) then
-         ! call print_time("[refinement_update] No refinement update")  ! ToDo: enable only when detailed profiling is required
-         return
+      if (.not. emergency_fix) then
+         if (n_updAMR <= 0) return
+         if (mod(nstep, n_updAMR) /= 0) return
       endif
 
       call ppp_main%start(ruprep_label, PPP_AMR)


### PR DESCRIPTION
* `echo refine > msg` – will do refinement update ASAP.
* `/AMR/ updAMR_after = 1,3,7` – will do refinement update on steps 1, 3 and 7 after start from scratch and after reading restart (e.g. if one restarts from nstep 137, then refinement updates will happen after steps 138, 140 and 144).