### PR TITLE
Verbosity control

### DIFF
--- a/benchmarking/problem.par.crtest
+++ b/benchmarking/problem.par.crtest
@@ -61,7 +61,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/benchmarking/problem.par.maclaurin
+++ b/benchmarking/problem.par.maclaurin
@@ -57,7 +57,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/problems/2body/1particle/problem.par
+++ b/problems/2body/1particle/problem.par
@@ -87,7 +87,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/2body/1particle/problem.par
+++ b/problems/2body/1particle/problem.par
@@ -87,7 +87,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/2body/3body/problem.par
+++ b/problems/2body/3body/problem.par
@@ -71,7 +71,6 @@
  /
 
  $MULTIGRID_SOLVER
-   mg_stdout = .true.
  /
 
  $INTERACTIONS

--- a/problems/2body/3body/problem.par
+++ b/problems/2body/3body/problem.par
@@ -71,7 +71,7 @@
  /
 
  $MULTIGRID_SOLVER
-   stdout = .true.
+   mg_stdout = .true.
  /
 
  $INTERACTIONS

--- a/problems/crtest/initproblem.F90
+++ b/problems/crtest/initproblem.F90
@@ -399,7 +399,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: pSUM, pMIN, pMAX
+      use constants,        only: pSUM, pMIN, pMAX, V_INFO
       use dataio_pub,       only: msg, die, printinfo
       use func,             only: operator(.notequals.)
       use grid_cont,        only: grid_container
@@ -458,7 +458,7 @@ contains
          else
             write(msg,'(a,2f12.5)')"[initproblem:check_norm] Cannot compute L2 error norm, min and max error = ", dev(1:2)
          endif
-         call printinfo(msg)
+         call printinfo(msg, V_INFO)
       endif
 
    end subroutine check_norm

--- a/problems/crtest/problem.par
+++ b/problems/crtest/problem.par
@@ -64,7 +64,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par
+++ b/problems/crtest/problem.par
@@ -64,7 +64,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.AMR_conservation
+++ b/problems/crtest/problem.par.AMR_conservation
@@ -78,7 +78,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.AMR_conservation
+++ b/problems/crtest/problem.par.AMR_conservation
@@ -78,7 +78,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.build
+++ b/problems/crtest/problem.par.build
@@ -60,7 +60,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/crtest/problem.par.build
+++ b/problems/crtest/problem.par.build
@@ -60,7 +60,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/crtest/problem.par.debug
+++ b/problems/crtest/problem.par.debug
@@ -59,7 +59,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.debug
+++ b/problems/crtest/problem.par.debug
@@ -59,7 +59,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.expanding_domain
+++ b/problems/crtest/problem.par.expanding_domain
@@ -63,7 +63,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.expanding_domain
+++ b/problems/crtest/problem.par.expanding_domain
@@ -63,7 +63,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.refined
+++ b/problems/crtest/problem.par.refined
@@ -65,7 +65,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.refined
+++ b/problems/crtest/problem.par.refined
@@ -65,7 +65,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.refined_diff_restricted
+++ b/problems/crtest/problem.par.refined_diff_restricted
@@ -69,7 +69,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.refined_diff_restricted
+++ b/problems/crtest/problem.par.refined_diff_restricted
@@ -69,7 +69,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.refinements
+++ b/problems/crtest/problem.par.refinements
@@ -65,7 +65,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/crtest/problem.par.refinements
+++ b/problems/crtest/problem.par.refinements
@@ -65,7 +65,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/divvtest/problem.par
+++ b/problems/divvtest/problem.par
@@ -74,7 +74,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .false.
  /
 

--- a/problems/divvtest/problem.par
+++ b/problems/divvtest/problem.par
@@ -74,7 +74,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .false.
  /
 

--- a/problems/jeans/initproblem.F90
+++ b/problems/jeans/initproblem.F90
@@ -243,7 +243,7 @@ contains
 
    subroutine describe_test
 
-      use constants,  only: pi
+      use constants,  only: pi, V_INFO
       use dataio_pub, only: msg, printinfo
       use mpisetup,   only: master
       use units,      only: fpiG, newtong
@@ -251,36 +251,36 @@ contains
       implicit none
 
       if (master) then
+         call printinfo("", V_INFO, .true.)
          write(msg, *) 'Unperturbed adiabatic sound speed = ', cs0
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_INFO, .true.)
          write(msg, *) 'Gravitational constant * 4pi      = ', fpiG
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_INFO, .true.)
          write(msg, *) 'L_critical                        = ', sqrt(pi * fl%gam * p0 / newtong / d0**2)
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_INFO, .true.)
          write(msg, *) 'gamma                             = ', fl%gam
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_INFO, .true.)
          write(msg, *) 'Perturbation wavenumber           = ', kn
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_INFO, .true.)
          write(msg, *) 'Jeans wavenumber                  = ', kJ
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_INFO, .true.)
          if (omg2>0) then
             write(msg, *) 'characteristic frequency          = ', omg
-            call printinfo(msg, .true.)
-            call printinfo("", .true.)
+            call printinfo(msg, V_INFO, .true.)
+            call printinfo("", V_INFO, .true.)
             write(msg, *) 'T(t) = ',Tamp,'*[1 - cos(',omg,'t)]'
-            call printinfo(msg, .true.)
+            call printinfo(msg, V_INFO, .true.)
          else
             write(msg, *) 'characteristic timescale          = ', omg
-            call printinfo(msg, .true.)
+            call printinfo(msg, V_INFO, .true.)
             !write(msg, *) 'Something like T(t) = ',Tamp,'* exp(',omg,'t)]' !BEWARE the formula is not completed
             !call printinfo(msg, .true.)
          endif
-         call printinfo('Divide T(t) for .tsl by L to get proper amplitude !', .true.)
-         call printinfo('', .true.)
-         call printinfo('To verify results, run:', .true.)
+         call printinfo(' Divide T(t) for .tsl by L to get proper amplitude !', V_INFO, .true.)
+         call printinfo('', V_INFO, .true.)
+         call printinfo(' To verify results, run:', V_INFO, .true.)
          write(msg, '(5a)')' % gnuplot ', plot_fname, '; display jeans.png'
-         call printinfo(msg, .true.)
-         call printinfo('', .true.)
+         call printinfo(msg, V_INFO, .true.)
       endif
 
    end subroutine describe_test

--- a/problems/jeans/powerbug/problem.par
+++ b/problems/jeans/powerbug/problem.par
@@ -91,7 +91,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     level_depth = 0       ! Turn off multigrid solve only on base level
  /
 

--- a/problems/jeans/powerbug/problem.par
+++ b/problems/jeans/powerbug/problem.par
@@ -91,7 +91,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     level_depth = 0       ! Turn off multigrid solve only on base level
  /
 

--- a/problems/jeans/problem.par
+++ b/problems/jeans/problem.par
@@ -81,7 +81,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par
+++ b/problems/jeans/problem.par
@@ -81,7 +81,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.3d
+++ b/problems/jeans/problem.par.3d
@@ -81,7 +81,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.3d
+++ b/problems/jeans/problem.par.3d
@@ -81,7 +81,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.big_domain
+++ b/problems/jeans/problem.par.big_domain
@@ -88,7 +88,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.big_domain
+++ b/problems/jeans/problem.par.big_domain
@@ -88,7 +88,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.dirichlet
+++ b/problems/jeans/problem.par.dirichlet
@@ -87,7 +87,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.dirichlet
+++ b/problems/jeans/problem.par.dirichlet
@@ -87,7 +87,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.small_domain
+++ b/problems/jeans/problem.par.small_domain
@@ -87,7 +87,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/jeans/problem.par.small_domain
+++ b/problems/jeans/problem.par.small_domain
@@ -87,7 +87,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -99,7 +99,7 @@ contains
    subroutine read_problem_par
 
       use cg_list_global,        only: all_cg
-      use constants,             only: pi, GEO_XYZ, GEO_RPZ, xdim, ydim, LO, HI, cbuff_len, INVALID
+      use constants,             only: pi, GEO_XYZ, GEO_RPZ, xdim, ydim, LO, HI, cbuff_len, INVALID, V_VERBOSE, V_INFO
       use dataio_pub,            only: die, warn, msg, printinfo, nh
       use domain,                only: dom
       use fluidindex,            only: iarr_all_dn
@@ -253,7 +253,7 @@ contains
          else
             write(msg, '(a)')"[initproblem:problem_initial_conditions] Set up point-like mass"
          endif
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_INFO, .true.)
          if (x0-a1<dom%edge(xdim, LO) .or. x0+a1>dom%edge(xdim, HI)) call warn("[initproblem:problem_initial_conditions] Part of the spheroid is outside the domain in the X-direction.")
          if ( (dom%geometry_type == GEO_XYZ .and. (y0-a1<dom%edge(ydim, LO) .or. y0+a1>dom%edge(ydim, HI))) .or. &
               (dom%geometry_type == GEO_RPZ .and. (atan2(a1,x0) > minval([y0-dom%edge(ydim, LO), dom%edge(ydim, HI)-y0]))) ) & ! will fail when some one adds 2*k*pi to y0
@@ -263,7 +263,7 @@ contains
          else
             write(msg,'(a,g12.5)')   "[initproblem:problem_initial_conditions] Mass = ", d0
          endif
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_VERBOSE, .true.)
       endif
 
       call all_cg%reg_var(apot_n, ord_prolong = ord_prolong)
@@ -291,7 +291,7 @@ contains
       use cg_cost_data,      only: I_IC
       use cg_leaves,         only: leaves
       use cg_list,           only: cg_list_element
-      use constants,         only: GEO_XYZ, GEO_RPZ, xdim, ydim, zdim, LO, HI
+      use constants,         only: GEO_XYZ, GEO_RPZ, xdim, ydim, zdim, LO, HI, V_DEBUG
       use dataio_pub,        only: die, msg, printinfo
       use domain,            only: dom
       use fluidindex,        only: iarr_all_dn, iarr_all_mx, iarr_all_my, iarr_all_mz
@@ -430,11 +430,11 @@ contains
       n_res = leaves%norm_sq(qna%ind(ares_n))
       if (abs(dm) > tiny(1.)) then  ! An FP overflow will occur when n_res > dm/tiny(1.)
          write(msg, '(a,f13.10)')"[initproblem:problem_initial_conditions] Analytical norm residual/source= ", n_res/dm
-         if (master) call printinfo(msg)
+         if (master) call printinfo(msg, V_DEBUG)
       else
          write(msg, '(2(a,g14.6))')"[initproblem:problem_initial_conditions] Analytical norm residual= ", n_res, " point mass= ", d0
          ! Is n_res ~ sqrt(cg%dvol) ?
-         if (master) call printinfo(msg)
+         if (master) call printinfo(msg, V_DEBUG)
       endif
 
    end subroutine problem_initial_conditions
@@ -685,7 +685,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: GEO_RPZ, pSUM, pMIN, pMAX, idlen
+      use constants,        only: GEO_RPZ, pSUM, pMIN, pMAX, idlen, V_ESSENTIAL
       use dataio_pub,       only: msg, printinfo, warn
       use domain,           only: dom
       use grid_cont,        only: grid_container
@@ -741,7 +741,7 @@ contains
          ffmt = "f12"
          if (any(abs(dev) > 1e6) .or. any(abs(dev) < 1e-4)) ffmt = "g14"
          write(msg,'(a,' // ffmt // '.6,a,2' // ffmt // '.6)')"[initproblem:finalize_problem_maclaurin] L2 error norm = ", sqrt(norm(1)/norm(2)), ", min and max error = ", dev(1:2)
-         call printinfo(msg)
+         call printinfo(msg, V_ESSENTIAL)
       endif
 
    end subroutine finalize_problem_maclaurin

--- a/problems/maclaurin/initproblem.F90
+++ b/problems/maclaurin/initproblem.F90
@@ -253,7 +253,7 @@ contains
          else
             write(msg, '(a)')"[initproblem:problem_initial_conditions] Set up point-like mass"
          endif
-         call printinfo(msg, V_INFO, .true.)
+         call printinfo(msg, V_INFO)
          if (x0-a1<dom%edge(xdim, LO) .or. x0+a1>dom%edge(xdim, HI)) call warn("[initproblem:problem_initial_conditions] Part of the spheroid is outside the domain in the X-direction.")
          if ( (dom%geometry_type == GEO_XYZ .and. (y0-a1<dom%edge(ydim, LO) .or. y0+a1>dom%edge(ydim, HI))) .or. &
               (dom%geometry_type == GEO_RPZ .and. (atan2(a1,x0) > minval([y0-dom%edge(ydim, LO), dom%edge(ydim, HI)-y0]))) ) & ! will fail when some one adds 2*k*pi to y0
@@ -263,7 +263,7 @@ contains
          else
             write(msg,'(a,g12.5)')   "[initproblem:problem_initial_conditions] Mass = ", d0
          endif
-         call printinfo(msg, V_VERBOSE, .true.)
+         call printinfo(msg, V_VERBOSE)
       endif
 
       call all_cg%reg_var(apot_n, ord_prolong = ord_prolong)

--- a/problems/maclaurin/mpi_test.par
+++ b/problems/maclaurin/mpi_test.par
@@ -77,7 +77,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/mpi_test.par
+++ b/problems/maclaurin/mpi_test.par
@@ -77,7 +77,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par
+++ b/problems/maclaurin/problem.par
@@ -74,7 +74,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par
+++ b/problems/maclaurin/problem.par
@@ -74,7 +74,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
+++ b/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
@@ -75,7 +75,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
+++ b/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
@@ -75,7 +75,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.big_domain
+++ b/problems/maclaurin/problem.par.big_domain
@@ -79,7 +79,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.big_domain
+++ b/problems/maclaurin/problem.par.big_domain
@@ -79,7 +79,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.cyl
+++ b/problems/maclaurin/problem.par.cyl
@@ -71,7 +71,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.cyl
+++ b/problems/maclaurin/problem.par.cyl
@@ -71,7 +71,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.cyl2
+++ b/problems/maclaurin/problem.par.cyl2
@@ -71,7 +71,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.cyl2
+++ b/problems/maclaurin/problem.par.cyl2
@@ -71,7 +71,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.multipole_3D
+++ b/problems/maclaurin/problem.par.multipole_3D
@@ -76,7 +76,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.multipole_3D
+++ b/problems/maclaurin/problem.par.multipole_3D
@@ -76,7 +76,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.particle
+++ b/problems/maclaurin/problem.par.particle
@@ -72,7 +72,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.particle
+++ b/problems/maclaurin/problem.par.particle
@@ -72,7 +72,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.plummer
+++ b/problems/maclaurin/problem.par.plummer
@@ -77,7 +77,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.plummer
+++ b/problems/maclaurin/problem.par.plummer
@@ -77,7 +77,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.quite_accurate
+++ b/problems/maclaurin/problem.par.quite_accurate
@@ -76,7 +76,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.quite_accurate
+++ b/problems/maclaurin/problem.par.quite_accurate
@@ -76,7 +76,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.refinement_shapes
+++ b/problems/maclaurin/problem.par.refinement_shapes
@@ -76,7 +76,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.refinement_shapes
+++ b/problems/maclaurin/problem.par.refinement_shapes
@@ -76,7 +76,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.small_domain
+++ b/problems/maclaurin/problem.par.small_domain
@@ -80,7 +80,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/maclaurin/problem.par.small_domain
+++ b/problems/maclaurin/problem.par.small_domain
@@ -80,7 +80,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par
+++ b/problems/mcrtest/mcrtest_cresp/problem.par
@@ -94,7 +94,6 @@ $BASE_DOMAIN
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par
+++ b/problems/mcrtest/mcrtest_cresp/problem.par
@@ -94,7 +94,7 @@ $BASE_DOMAIN
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par.cresp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par.cresp
@@ -93,7 +93,7 @@ $BASE_DOMAIN
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par.cresp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par.cresp
@@ -93,7 +93,6 @@ $BASE_DOMAIN
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_adv
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_adv
@@ -99,7 +99,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_adv
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_adv
@@ -99,7 +99,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_comp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_comp
@@ -99,7 +99,7 @@ $BASE_DOMAIN
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_comp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_comp
@@ -99,7 +99,6 @@ $BASE_DOMAIN
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_diff
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_diff
@@ -99,7 +99,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_diff
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_diff
@@ -99,7 +99,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_dsyn
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_dsyn
@@ -99,7 +99,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_dsyn
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_dsyn
@@ -99,7 +99,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_exp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_exp
@@ -99,7 +99,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_exp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_exp
@@ -99,7 +99,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_sta
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_sta
@@ -99,7 +99,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_sta
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_sta
@@ -99,7 +99,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_syn
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_syn
@@ -98,7 +98,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_syn
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_syn
@@ -98,7 +98,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_test
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_test
@@ -85,7 +85,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/mcrtest_cresp/problem.par_test
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_test
@@ -85,7 +85,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/problem.par
+++ b/problems/mcrtest/problem.par
@@ -75,7 +75,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/problem.par
+++ b/problems/mcrtest/problem.par
@@ -75,7 +75,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
     dirty_debug = .true.
  /
 

--- a/problems/mcrtest/problem.par.build
+++ b/problems/mcrtest/problem.par.build
@@ -74,7 +74,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrtest/problem.par.build
+++ b/problems/mcrtest/problem.par.build
@@ -74,7 +74,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrtest/problem.par.gold
+++ b/problems/mcrtest/problem.par.gold
@@ -77,7 +77,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrtest/problem.par.gold
+++ b/problems/mcrtest/problem.par.gold
@@ -77,7 +77,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrtest/problem.par.refined
+++ b/problems/mcrtest/problem.par.refined
@@ -79,7 +79,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrtest/problem.par.refined
+++ b/problems/mcrtest/problem.par.refined
@@ -79,7 +79,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout = .true.
+    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrwind/problem.par.multigrid
+++ b/problems/mcrwind/problem.par.multigrid
@@ -89,7 +89,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrwind/problem.par.multigrid
+++ b/problems/mcrwind/problem.par.multigrid
@@ -89,7 +89,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrwind/problem.par.selfgrav
+++ b/problems/mcrwind/problem.par.selfgrav
@@ -90,7 +90,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout = .true.
+!    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/mcrwind/problem.par.selfgrav
+++ b/problems/mcrwind/problem.par.selfgrav
@@ -90,7 +90,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/problems/selfgrav_clump/problem.par
+++ b/problems/selfgrav_clump/problem.par
@@ -79,7 +79,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout    = .true.
+!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par
+++ b/problems/selfgrav_clump/problem.par
@@ -79,7 +79,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.1D
+++ b/problems/selfgrav_clump/problem.par.1D
@@ -76,7 +76,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.1D
+++ b/problems/selfgrav_clump/problem.par.1D
@@ -76,7 +76,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout    = .true.
+!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.2D
+++ b/problems/selfgrav_clump/problem.par.2D
@@ -79,7 +79,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout    = .true.
+!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.2D
+++ b/problems/selfgrav_clump/problem.par.2D
@@ -79,7 +79,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.AMR
+++ b/problems/selfgrav_clump/problem.par.AMR
@@ -79,7 +79,7 @@
  /
 
  $MULTIGRID_SOLVER
-!    stdout    = .true.
+!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.AMR
+++ b/problems/selfgrav_clump/problem.par.AMR
@@ -79,7 +79,6 @@
  /
 
  $MULTIGRID_SOLVER
-!    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.conservation_test
+++ b/problems/selfgrav_clump/problem.par.conservation_test
@@ -79,7 +79,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.conservation_test
+++ b/problems/selfgrav_clump/problem.par.conservation_test
@@ -79,7 +79,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.cyl
+++ b/problems/selfgrav_clump/problem.par.cyl
@@ -81,7 +81,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.cyl
+++ b/problems/selfgrav_clump/problem.par.cyl
@@ -81,7 +81,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
 !    dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.expanding_domain
+++ b/problems/selfgrav_clump/problem.par.expanding_domain
@@ -80,7 +80,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.expanding_domain
+++ b/problems/selfgrav_clump/problem.par.expanding_domain
@@ -80,7 +80,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.restart_test
+++ b/problems/selfgrav_clump/problem.par.restart_test
@@ -85,7 +85,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/selfgrav_clump/problem.par.restart_test
+++ b/problems/selfgrav_clump/problem.par.restart_test
@@ -85,7 +85,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/streaming_global/problem.par.AMR
+++ b/problems/streaming_global/problem.par.AMR
@@ -108,7 +108,6 @@
  /
 
  $MULTIGRID_SOLVER
-   mg_stdout = .true.
 !   dirty_debug = .false.
  /
 

--- a/problems/streaming_global/problem.par.AMR
+++ b/problems/streaming_global/problem.par.AMR
@@ -108,7 +108,7 @@
  /
 
  $MULTIGRID_SOLVER
-   stdout = .true.
+   mg_stdout = .true.
 !   dirty_debug = .false.
  /
 

--- a/problems/testing_and_debuging/N-body/problem.par
+++ b/problems/testing_and_debuging/N-body/problem.par
@@ -68,7 +68,6 @@
  /
 
  $MULTIGRID_SOLVER
-   mg_stdout = .true.
    ! dirty_debug = .true.
  /
 

--- a/problems/testing_and_debuging/N-body/problem.par
+++ b/problems/testing_and_debuging/N-body/problem.par
@@ -68,7 +68,7 @@
  /
 
  $MULTIGRID_SOLVER
-   stdout = .true.
+   mg_stdout = .true.
    ! dirty_debug = .true.
  /
 

--- a/problems/testing_and_debuging/analytic_periodic_potential/problem.par
+++ b/problems/testing_and_debuging/analytic_periodic_potential/problem.par
@@ -64,7 +64,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/testing_and_debuging/analytic_periodic_potential/problem.par
+++ b/problems/testing_and_debuging/analytic_periodic_potential/problem.par
@@ -64,7 +64,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/testing_and_debuging/analytic_periodic_potential/problem.par.crashing
+++ b/problems/testing_and_debuging/analytic_periodic_potential/problem.par.crashing
@@ -64,7 +64,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/testing_and_debuging/analytic_periodic_potential/problem.par.crashing
+++ b/problems/testing_and_debuging/analytic_periodic_potential/problem.par.crashing
@@ -64,7 +64,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/testing_and_debuging/pr_test/problem.par
+++ b/problems/testing_and_debuging/pr_test/problem.par
@@ -70,7 +70,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout    = .true.
+    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/testing_and_debuging/pr_test/problem.par
+++ b/problems/testing_and_debuging/pr_test/problem.par
@@ -70,7 +70,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout    = .true.
     dirty_debug = .true.
  /
 

--- a/problems/wt4/problem.par
+++ b/problems/wt4/problem.par
@@ -88,7 +88,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout       = .true.
+    mg_stdout       = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/problems/wt4/problem.par
+++ b/problems/wt4/problem.par
@@ -88,7 +88,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout       = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/problems/wt4/problem.par.AMR
+++ b/problems/wt4/problem.par.AMR
@@ -89,7 +89,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout       = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/problems/wt4/problem.par.AMR
+++ b/problems/wt4/problem.par.AMR
@@ -89,7 +89,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout       = .true.
+    mg_stdout       = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/problems/wt4/problem.par.cylindrical
+++ b/problems/wt4/problem.par.cylindrical
@@ -89,7 +89,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout       = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/problems/wt4/problem.par.cylindrical
+++ b/problems/wt4/problem.par.cylindrical
@@ -89,7 +89,7 @@
  /
 
  $MULTIGRID_SOLVER
-    stdout       = .true.
+    mg_stdout       = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -483,6 +483,8 @@ contains
 
       endif
 
+      call set_colors(colormode)
+
       select case (trim(verbosity))
          case ("silent", trim(v_name(V_SILENT)))
             piernik_verbosity = V_SILENT
@@ -501,8 +503,6 @@ contains
             piernik_verbosity = V_INFO
             if (master) call warn("[dataio:dataio_par_io] non recognized verbosity level '" // trim(verbosity) // "', defaulting to '" // trim(v_name(piernik_verbosity)) // "'")
       end select
-
-      call set_colors(colormode)
 
    end subroutine dataio_par_io
 

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -1639,7 +1639,7 @@ contains
       use cg_leaves,          only: leaves
       use cg_list,            only: cg_list_element
       use constants,          only: idlen, small, MAXL, PPP_IO
-      use dataio_pub,         only: printinfo
+      use dataio_pub,         only: printinfo, print_char_line
       use fluidindex,         only: flind
       use fluids_pub,         only: has_dst, has_ion, has_neu
       use func,               only: L2norm
@@ -1959,7 +1959,7 @@ contains
 
       if (master)  then
          if (.not.present(tsl)) then
-            call printinfo('================================================================================================================', .false.)
+            call print_char_line('=')
             if (has_ion) then
                call common_shout(flind%ion%snap,'ION',.true.,.true.,.true.)
 #ifdef MAGNETIC
@@ -2017,7 +2017,7 @@ contains
             id = "PRT"
             call cmnlog_l(fmt_dtloc, 'max(|acc|)  ', id, pacc_max)
 #endif /* NBODY */
-            call printinfo('================================================================================================================', .false.)
+            call print_char_line('=')
          else
 #ifdef MAGNETIC
             tsl%b_min = b_min%val

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -113,14 +113,12 @@ module dataio_pub
 
    logical                     :: multiple_h5files = .false.     !< write one HDF5 file per proc
 
+   !< enum for message types
    ! stdout and logfile messages
-   integer, parameter :: T_PLAIN  = 0, &                         !< enum for message types
-        &                T_ERR    = T_PLAIN  + 1, &
-        &                T_WARN   = T_ERR    + 1, &
-        &                T_INFO   = T_WARN   + 1, &
-        &                T_IO     = T_INFO   + 1, &
-        &                T_IO_NOA = T_IO     + 1, &
-        &                T_SILENT = T_IO_NOA + 1
+   enum, bind(C)
+      enumerator ::  T_PLAIN = 0
+      enumerator :: T_ERR, T_WARN, T_INFO, T_IO, T_IO_NOA, T_SILENT
+   end enum
    character(len=msglen)       :: msg                            !< buffer for messages
    character(len=ansirst)      :: ansi_black
    character(len=ansilen)      :: ansi_red, ansi_green, ansi_yellow, ansi_blue, ansi_magenta, ansi_cyan, ansi_white
@@ -246,7 +244,7 @@ contains
       implicit none
 
       character(len=*),  intent(in) :: nm
-      integer,           intent(in) :: mode
+      integer(kind=4),   intent(in) :: mode
 
       character(len=ansilen)        :: ansicolor
       integer, parameter            :: msg_type_len = len("Warning")

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -415,15 +415,9 @@ contains
       logical :: adv
 
       adv  = .true.
-      if (present(noadvance)) then
-         if (noadvance) adv = .false.
-      endif
+      if (present(noadvance)) adv = .not. noadvance
 
-      if (adv) then
-         call colormessage(nm, T_IO)
-      else
-         call colormessage(nm, T_IO_NOA)
-      endif
+      call colormessage(nm, merge(T_IO, T_IO_NOA, adv))
 
    end subroutine printio
 !-----------------------------------------------------------------------------

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -124,7 +124,7 @@ module dataio_pub
    character(len=ansilen)      :: ansi_red, ansi_green, ansi_yellow, ansi_blue, ansi_magenta, ansi_cyan, ansi_white
    real                        :: thdf                           !< hdf dump wallclock
 
-   integer                     :: piernik_verbosity = V_INFO
+   integer(kind=4)             :: piernik_verbosity = V_INFO
 
    ! Per suggestion of ZEUS sysops:
    ! http://www.fz-juelich.de/ias/jsc/EN/Expertise/Supercomputers/JUROPA/UserInfo/IO_Tuning.htm
@@ -484,6 +484,8 @@ contains
 !-----------------------------------------------------------------------------
    subroutine namelist_errh(ierrh,nm,skip_eof)
 
+      use constants, only: V_VERBOSE
+
       implicit none
 
       integer(kind=4),   intent(in) :: ierrh
@@ -509,7 +511,7 @@ contains
                if (skip_eof) return
             endif
             write(msg,'(3a)') "Namelist: ",trim(nm)," not found in problem.par. Assuming defaults." ! Can happen also when there is no EOL after the namelist in problem.par
-            call printinfo(msg)
+            call printinfo(msg, V_VERBOSE)
          case (239, 5010)
             write(msg,'(3a)') "A problem with one of the variables that belong to the ",trim(nm)," namelist was found in problem.par:"
             call warn(msg)
@@ -528,7 +530,7 @@ contains
 !-----------------------------------------------------------------------------
    subroutine compare_namelist(this)
 
-      use constants, only: PIERNIK_INIT_IO_IC
+      use constants, only: PIERNIK_INIT_IO_IC, V_LOG
       use MPIF,      only: MPI_COMM_WORLD, MPI_Comm_rank
 
       implicit none
@@ -555,7 +557,7 @@ contains
          else
             write(msg,'(a1,a)') ' ',trim(sb)
          endif
-         call printinfo(msg, .false.)
+         call printinfo(msg, V_LOG)
       enddo
       close(lun_aft, status="delete")
       close(lun_bef, status="delete")

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -368,6 +368,26 @@ contains
 
    end subroutine cleanup_text_buffers
 
+   !> \brief Printinfo variant which prints a line of repeated characters
+
+   subroutine print_char_line(c, verbosity)
+
+      use constants, only: I_ONE, rep_len, V_LOG
+
+      implicit none
+
+      character(len=I_ONE),      intent(in) :: c          !< the character to repeat
+      integer(kind=4), optional, intent(in) :: verbosity  !< verbosity level
+
+      integer(kind=4) :: v
+
+      v = V_LOG
+      if (present(verbosity)) v = verbosity
+
+      call printinfo(repeat(c, rep_len), v)
+
+   end subroutine print_char_line
+
    !> \brief Printinfo variant which does not print colored tag (legacy)
 
    subroutine printinfo_legacy(nm, to_stdout)

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -1379,7 +1379,7 @@ contains
    subroutine dump_announce_time
 
       use constants,  only: tmr_hdf
-      use dataio_pub, only: msg, printinfo, thdf
+      use dataio_pub, only: msg, print_plain, thdf
       use mpisetup,   only: master
       use timer,      only: set_timer
 
@@ -1388,7 +1388,7 @@ contains
       thdf = set_timer(tmr_hdf)
       if (master) then
          write(msg,'(a6,f10.2,a2)') ' done ', thdf, ' s'
-         call printinfo(msg, .true.)
+         call print_plain(msg, .false.)
       endif
 
    end subroutine dump_announce_time

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -176,6 +176,14 @@ module constants
       enumerator :: V_HIGHEST = V_WARN
    end enum
 
+   character(len=*), dimension(V_LOWEST:V_HIGHEST), parameter :: v_name = [ &
+        "log      ", &
+        "debug    ", &
+        "verbose  ", &
+        "standard ", &
+        "essential", &
+        "warn     " ]
+
    ! grid geometry type
    enum, bind(C)
       enumerator :: GEO_XYZ, GEO_RPZ                    !! Cartesian (0) or cylindrical (1) grid with uniform cell spacing

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -171,6 +171,9 @@ module constants
       enumerator :: V_LOG     = V_SILENT
       enumerator :: V_NORMAL  = V_INFO
       enumerator :: V_LACONIC = V_ESSENTIAL
+      ! special aliases
+      enumerator :: V_LOWEST = V_SILENT
+      enumerator :: V_HIGHEST = V_WARN
    end enum
 
    ! grid geometry type

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -159,6 +159,20 @@ module constants
       enumerator :: PIERNIK_CLEANUP                      ! finished post-simulation computations and I/O
    end enum
 
+   ! verbosity levels for printinfo
+   enum, bind(C)
+      enumerator :: V_SILENT                 ! messages that are supposed to be only in the log, not on stdout
+      enumerator :: V_DEBUG                  ! debugging information
+      enumerator :: V_VERBOSE                ! extra details
+      enumerator :: V_INFO                   ! printed by default
+      enumerator :: V_ESSENTIAL              ! to make the output very brief
+      enumerator :: V_WARN                   ! redirect to warn()
+      ! aliases
+      enumerator :: V_LOG     = V_SILENT
+      enumerator :: V_NORMAL  = V_INFO
+      enumerator :: V_LACONIC = V_ESSENTIAL
+   end enum
+
    ! grid geometry type
    enum, bind(C)
       enumerator :: GEO_XYZ, GEO_RPZ                    !! Cartesian (0) or cylindrical (1) grid with uniform cell spacing

--- a/src/base/constants.F90
+++ b/src/base/constants.F90
@@ -144,6 +144,8 @@ module constants
    integer(kind=4), parameter :: idlen = 3                  !< COMMENT ME
    integer(kind=4), parameter :: singlechar = 1             !< a single character
 
+   integer(kind=4), parameter :: rep_len = 112              !< default length of "---...", "+++..." and "===..." strings in the log
+
    ! simulation state
    enum, bind(C)
       enumerator :: PIERNIK_START                        ! before initialization

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -178,7 +178,7 @@ contains
 
       use constants,  only: big_float, one, PIERNIK_INIT_DOMAIN, INVALID, DIVB_CT, DIVB_HDC, &
            &                BND_INVALID, BND_ZERO, BND_REF, BND_OUT, I_ZERO, O_INJ, O_LIN, O_I2, INVALID, &
-           &                RTVD_SPLIT, HLLC_SPLIT, RIEMANN_SPLIT, GEO_XYZ
+           &                RTVD_SPLIT, HLLC_SPLIT, RIEMANN_SPLIT, GEO_XYZ, V_INFO, V_DEBUG
       use dataio_pub, only: die, msg, warn, code_progress, printinfo, nh
       use domain,     only: dom
       use mpisetup,   only: cbuff, ibuff, lbuff, rbuff, master, slave, piernik_MPI_Bcast
@@ -485,11 +485,11 @@ contains
       if (master) then
          select case (which_solver)
             case (RTVD_SPLIT)
-               call printinfo("    (M)HD solver: RTVD.")
+               call printinfo("    (M)HD solver: RTVD.", V_INFO)
             case (HLLC_SPLIT)
-               call printinfo("    HD solver: HLLC.")
+               call printinfo("    HD solver: HLLC.", V_INFO)
             case (RIEMANN_SPLIT)
-               call printinfo("    (M)HD solver: Riemann.")
+               call printinfo("    (M)HD solver: Riemann.", V_INFO)
             case default
                call die("[global:init_global] unrecognized hydro solver")
          end select
@@ -499,29 +499,27 @@ contains
       if (master) then
          select case (divB_0_method)
             case (DIVB_HDC)
-               call printinfo("    The div(B) constraint is maintained by Hyperbolic Cleaning (GLM).")
+               call printinfo("    The div(B) constraint is maintained by Hyperbolic Cleaning (GLM).", V_INFO)
             case (DIVB_CT)
-               call printinfo("    The div(B) constraint is maintained by Constrained Transport (2nd order).")
+               call printinfo("    The div(B) constraint is maintained by Constrained Transport (2nd order).", V_INFO)
             case default
                call die("    The div(B) constraint is maintained by Uknown Something.")
          end select
 
          if (cc_mag) then
-            call printinfo("    Magnetic field is cell-centered.")
+            call printinfo("    Magnetic field is cell-centered.", V_INFO)
          else
-            call printinfo("    Magnetic field is face-centered (staggered).")
+            call printinfo("    Magnetic field is face-centered (staggered).", V_INFO)
          endif
       endif
 #endif /* MAGNETIC */
 
-#ifdef DEBUG
       if (master) &
 #  ifdef MPIF08
-           call printinfo("    use mpi_f08 (modern interface)")
+           call printinfo("    use mpi_f08 (modern interface)", V_DEBUG)
 #  else /* !MPIF08 */
-           call printinfo("    use mpi (old interface)")
+           call printinfo("    use mpi (old interface)", V_DEBUG)
 #  endif /* !MPIF08 */
-#endif /* DEBUG */
 
       if (all(ord_fluid_prolong /= [O_INJ, O_LIN])) then
          write(msg, '(a,i3,a)')"[global:init_global] Prolongation order ", ord_fluid_prolong, " is not positive-definite and thus not allowed for density and energy. Degrading to injection (0)"

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -368,7 +368,7 @@ contains
 
       subroutine print_hostnames
 
-         use constants,  only: fmt_len
+         use constants,  only: fmt_len, V_VERBOSE
          use dataio_pub, only: msg, printinfo
          use mpisetup,   only: slave, nproc
          use procnames,  only: pnames
@@ -408,13 +408,13 @@ contains
                   else
                      write(msg, fmt1) trim(header), p%proc(lbound(p%proc, 1))
                   endif
-                  call printinfo(msg)
+                  call printinfo(msg, V_VERBOSE)
 
                else
 
                   do hl = 0, int((ubound(p%proc, 1) - 1)/ mpl)
                      write(msg, fmtl) merge(repeat(" ", len_trim(header)), trim(header), hl>0), p%proc(hl*mpl+1:min((hl+1)*mpl, ubound(p%proc, 1)))
-                     call printinfo(msg)
+                     call printinfo(msg, V_VERBOSE)
                   enddo
 
                endif

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -48,9 +48,9 @@ contains
       use cg_list_global,        only: all_cg
       use constants,             only: PIERNIK_INIT_MPI, PIERNIK_INIT_GLOBAL, PIERNIK_INIT_FLUIDS, PIERNIK_INIT_DOMAIN, &
            &                           PIERNIK_INIT_GRID, PIERNIK_INIT_IO_IC, PIERNIK_POST_IC, &
-           &                           INCEPTIVE, tmr_fu, cbuff_len, PPP_PROB
+           &                           INCEPTIVE, tmr_fu, cbuff_len, PPP_PROB, V_DEBUG, V_LOWEST, V_HIGHEST
       use dataio,                only: init_dataio, init_dataio_parameters, write_data
-      use dataio_pub,            only: nrestart, restarted_sim, wd_rd, par_file, tmp_log_file, msg, printio, printinfo, &
+      use dataio_pub,            only: nrestart, restarted_sim, wd_rd, par_file, tmp_log_file, msg, printio, printinfo, piernik_verbosity, &
            &                           warn, die, require_problem_IC, problem_name, run_id, code_progress, log_wr, set_colors
       use decomposition,         only: init_decomposition
       use domain,                only: init_domain
@@ -156,6 +156,13 @@ contains
       call cg_extptrs%epa_init
 
       call init_dataio_parameters            ! Required very early to call colormessage without side-effects
+
+      if (piernik_verbosity <= V_DEBUG) then
+         do nit= V_LOWEST, V_HIGHEST
+            write(msg, '(a,i1)')"Verbosity level ", nit
+            if (master) call printinfo(msg, int(nit, kind=4))
+         enddo
+      endif
 
       call pnames%init ; call print_hostnames
       call init_load_balance

--- a/src/base/initpiernik.F90
+++ b/src/base/initpiernik.F90
@@ -49,7 +49,7 @@ contains
       use constants,             only: PIERNIK_INIT_MPI, PIERNIK_INIT_GLOBAL, PIERNIK_INIT_FLUIDS, PIERNIK_INIT_DOMAIN, &
            &                           PIERNIK_INIT_GRID, PIERNIK_INIT_IO_IC, PIERNIK_POST_IC, &
            &                           INCEPTIVE, tmr_fu, cbuff_len, PPP_PROB, &
-           &                           v_name, V_DEBUG, V_INFO, V_ESSENTIAL, V_LOWEST, V_HIGHEST
+           &                           v_name, V_LOG, V_DEBUG, V_INFO, V_ESSENTIAL, V_LOWEST, V_HIGHEST
       use dataio,                only: init_dataio, init_dataio_parameters, write_data
       use dataio_pub,            only: nrestart, restarted_sim, wd_rd, par_file, tmp_log_file, msg, printio, printinfo, piernik_verbosity, &
            &                           warn, die, require_problem_IC, problem_name, run_id, code_progress, log_wr, set_colors
@@ -264,7 +264,7 @@ contains
 
       call ppp_main%start(ic_label)
       if (master) then
-         call printinfo("###############     Initial Conditions     ###############", .false.)
+         call printinfo("###############     Initial Conditions     ###############", V_LOG)
          write(msg,'(4a)') "   Starting problem : ",trim(problem_name)," :: ",trim(run_id)
          call printinfo("", V_ESSENTIAL, .true.)
          call printinfo(msg, V_ESSENTIAL, .true.)

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -192,7 +192,7 @@ contains
       call MPI_Comm_size(MPI_COMM_WORLD, nproc, err_mpi)
       call MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, tag_ub, flag, err_mpi)
 
-      LAST = nproc-I_ONE
+      LAST = nproc - I_ONE
       master = (proc == FIRST)
       slave  = .not. master
       have_mpi = (LAST /= FIRST)
@@ -205,11 +205,8 @@ contains
             open(newunit=lun, file=tmp_log_file)
             close(lun, status="delete")
          endif
-#ifdef VERBOSE
-         call printinfo("[mpisetup:init_mpi]: commencing...")
-#endif /* VERBOSE */
-         if (is_spawned) &
-              call printinfo("[mpisetup:init_mpi] Piernik was called via MPI_Spawn. Additional magic will happen!")
+         call printinfo("[mpisetup:init_mpi]: commencing...", V_DEBUG)
+         if (is_spawned) call printinfo("[mpisetup:init_mpi] Piernik was called via MPI_Spawn. Additional magic will happen!", V_INFO)
       endif
 
       if (allocated(cwd_all) .or. allocated(host_all) .or. allocated(pid_all)) &
@@ -222,10 +219,9 @@ contains
       cwd_status  = getcwd(cwd_proc)
 
       if (cwd_status /= 0) call die("[mpisetup:init_mpi] problems accessing current working directory.")
-#ifdef DEBUG
-      write(msg,'(3a,i8,3a)') 'mpisetup: host="',trim(host_proc),'", PID=',pid_proc,' CWD="',trim(cwd_proc),'"'
-      call printinfo(msg)
-#endif /* DEBUG */
+
+!!$      write(msg,'(3a,i8,3a)') 'mpisetup: host="',trim(host_proc),'", PID=',pid_proc,' CWD="',trim(cwd_proc),'"'
+!!$      call printinfo(msg, V_DEBUG)
 
       call MPI_Gather(cwd_proc,  cwdlen, MPI_CHARACTER, cwd_all,  cwdlen, MPI_CHARACTER, FIRST, MPI_COMM_WORLD, err_mpi)
       call MPI_Gather(host_proc, hnlen,  MPI_CHARACTER, host_all, hnlen,  MPI_CHARACTER, FIRST, MPI_COMM_WORLD, err_mpi)
@@ -243,13 +239,13 @@ contains
          call printinfo("PROCESSES:", V_LOG)
          do iproc = FIRST, LAST
             write(msg,"(a,i4,a,i6,4a)") " proc=", iproc, ", pid= ",pid_all(iproc), " @",trim(host_all(iproc)), " cwd=",trim(cwd_all(iproc))
-            call printinfo(msg, .false.)
+            call printinfo(msg, V_LOG)
          enddo
-         call printinfo("", .true.)
+         call printinfo("", V_INFO, .true.)
          write(msg, "(a,i5,a)")'   Start of the PIERNIK code on ', nproc, " processes"
-         call printinfo(msg, .true.)
-         call printinfo("", .true.)
-         call printinfo("###############     Namelist parameters     ###############", .false.)
+         call printinfo(msg, V_INFO, .true.)
+         call printinfo("", V_INFO, .true.)
+         call printinfo("###############     Namelist parameters     ###############", V_LOG)
       endif
 
       deallocate(host_all, pid_all, cwd_all)

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -148,7 +148,7 @@ contains
            &                   MPI_Wtime, MPI_Init, MPI_Comm_get_parent, &
            &                   MPI_Comm_rank, MPI_Comm_size
       use MPIFUN,        only: MPI_Gather, MPI_Comm_get_attr
-      use dataio_pub,    only: die, printinfo, msg, ansi_white, ansi_black, tmp_log_file
+      use dataio_pub,    only: die, printinfo, msg, tmp_log_file
       use dataio_pub,    only: par_file, lun
       use signalhandler, only: SIGINT, register_sighandler
 #if defined(__INTEL_COMPILER)
@@ -247,7 +247,7 @@ contains
             call printinfo(msg, .false.)
          enddo
          call printinfo("", .true.)
-         write(msg,"(5a,i5)") 'Start of the',ansi_white,' PIERNIK ',ansi_black,'code. No. of procs = ', nproc
+         write(msg, "(a,i5,a)")'   Start of the PIERNIK code on ', nproc, " processes"
          call printinfo(msg, .true.)
          call printinfo("", .true.)
          call printinfo("###############     Namelist parameters     ###############", .false.)

--- a/src/base/mpisetup.F90
+++ b/src/base/mpisetup.F90
@@ -142,14 +142,13 @@ contains
 
    subroutine init_mpi
 
-      use constants,     only: cwdlen, I_ONE
+      use constants,     only: cwdlen, I_ONE, V_LOG, V_DEBUG, V_INFO
+      use dataio_pub,    only: die, print_char_line, printinfo, msg, tmp_log_file, par_file, lun
       use MPIF,          only: MPI_COMM_WORLD, MPI_CHARACTER, MPI_INTEGER, MPI_COMM_NULL, &
            &                   MPI_SUM, MPI_MIN, MPI_MAX, MPI_LOR, MPI_LAND, MPI_TAG_UB, &
            &                   MPI_Wtime, MPI_Init, MPI_Comm_get_parent, &
            &                   MPI_Comm_rank, MPI_Comm_size
       use MPIFUN,        only: MPI_Gather, MPI_Comm_get_attr
-      use dataio_pub,    only: die, printinfo, msg, tmp_log_file
-      use dataio_pub,    only: par_file, lun
       use signalhandler, only: SIGINT, register_sighandler
 #if defined(__INTEL_COMPILER)
       use ifport,        only: getpid, getcwd, hostnm
@@ -238,10 +237,10 @@ contains
          inquire(file=par_file, exist=par_file_exist)
          if (.not. par_file_exist) call die('[mpisetup:init_mpi] Cannot find "problem.par" in the working directory',0)
 
-         call printinfo("------------------------------------------------------------------------------------------------------", .false.)
-         call printinfo("###############     Environment     ###############", .false.)
-         call printinfo("", .false.)
-         call printinfo("PROCESSES:", .false.)
+         call print_char_line("-")
+         call printinfo("###############     Environment     ###############", V_LOG)
+         call printinfo("", V_LOG)
+         call printinfo("PROCESSES:", V_LOG)
          do iproc = FIRST, LAST
             write(msg,"(a,i4,a,i6,4a)") " proc=", iproc, ", pid= ",pid_all(iproc), " @",trim(host_all(iproc)), " cwd=",trim(cwd_all(iproc))
             call printinfo(msg, .false.)
@@ -351,7 +350,7 @@ contains
 
    subroutine cleanup_mpi
 
-      use dataio_pub,      only: printinfo, close_logs
+      use dataio_pub,      only: print_char_line, close_logs
       use MPIF,            only: MPI_COMM_WORLD, MPI_Barrier, MPI_Comm_disconnect, MPI_Finalize
       use piernik_mpi_sig, only: sig
 #if defined(__INTEL_COMPILER)
@@ -363,7 +362,7 @@ contains
       if (allocated(req)) deallocate(req)
       if (allocated(req2)) deallocate(req2)
 
-      if (master) call printinfo("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++", .false.)
+      if (master) call print_char_line("+")
       call MPI_Barrier(MPI_COMM_WORLD,err_mpi)
       if (have_mpi) call sleep(1) ! Prevent random SIGSEGVs in openmpi's MPI_Finalize
       if (is_spawned) then

--- a/src/base/named_array_list.F90
+++ b/src/base/named_array_list.F90
@@ -232,18 +232,22 @@ contains
 
 !> \brief Summarize all registered fields and their properties
 
-   subroutine print_vars(this, to_stdout)
+   subroutine print_vars(this, verbosity)
 
-      use constants,  only: INVALID
+      use constants,  only: INVALID, V_LOG
       use dataio_pub, only: printinfo, warn, msg
       use mpisetup,   only: slave
 
       implicit none
 
-      class(na_var_list), intent(in) :: this
-      logical, optional,  intent(in) :: to_stdout
+      class(na_var_list),        intent(in) :: this
+      integer(kind=4), optional, intent(in) :: verbosity  !< verbosity level
 
       integer :: i, d3
+      integer(kind=4) :: v
+
+      v = V_LOG
+      if (present(verbosity)) v = verbosity
 
       if (slave) return
 
@@ -251,11 +255,11 @@ contains
 
       if (d3 /= 0) then
          write(msg,'(a,i2,a)')"[named_array_list:print_vars] Found ",size(this%lst(:))," rank-3 arrays:"
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
       endif
       if (count(this%lst(:)%dim4 /= INVALID) /= 0) then
          write(msg,'(a,i2,a)')"[named_array_list:print_vars] Found ",size(this%lst(:))," rank-4 arrays:"
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
          if (d3 /=0) call warn("[named_array_list:print_vars] Both rank-3 and rank-4 named arrays are present in the same list!")
       endif
 
@@ -278,7 +282,7 @@ contains
                write(msg(len_trim(msg)+1:), '(a,i4,a)') "[ ", size(this%lst(i)%position), " * 0 ]"
             endif
          endif
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
       enddo
 
    end subroutine print_vars

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -35,9 +35,9 @@ program piernik
    use cg_leaves,         only: leaves
    use cg_list_global,    only: all_cg
    use constants,         only: PIERNIK_START, PIERNIK_INITIALIZED, PIERNIK_FINISHED, PIERNIK_CLEANUP, &
-        &                       fplen, stdout, I_ONE, CHK, FINAL_DUMP, cbuff_len, PPP_IO, PPP_MPI, V_INFO
+        &                       fplen, stdout, I_ONE, CHK, FINAL_DUMP, cbuff_len, PPP_IO, PPP_MPI, V_LOG, V_INFO
    use dataio,            only: write_data, user_msg_handler, check_log, check_tsl, dump, cleanup_dataio
-   use dataio_pub,        only: nend, tend, msg, printinfo, warn, die, code_progress, nstep_start
+   use dataio_pub,        only: nend, tend, msg, print_char_line, printinfo, warn, die, code_progress, nstep_start
    use div_B,             only: print_divB_norm
    use finalizepiernik,   only: cleanup_piernik
    use fluidindex,        only: flind
@@ -103,17 +103,15 @@ program piernik
    end_sim = .false.
 
    if (master) then
-      call printinfo("======================================================================================================", .false.)
-      call printinfo("###############     Simulation     ###############", .false.)
-      call printinfo("Named arrays present at start:", to_stdout=.false.)
+      call print_char_line("=")
+      call printinfo("###############     Simulation     ###############", V_LOG)
+      call printinfo("Named arrays present at start:", V_LOG)
       call qna%print_vars(to_stdout=.false.)
       call wna%print_vars(to_stdout=.false.)
       call printinfo("Grid lists present at start:", to_stdout=.false.)
    endif
    call all_lists%print(to_stdout = .false.)  ! needs all procs to participate
-   if (master) then
-      call printinfo("======================================================================================================", .false.)
-   endif
+   if (master) call print_char_line("=")
 
    call print_progress(nstep)
    if (print_divB > 0) call print_divB_norm
@@ -219,8 +217,8 @@ program piernik
       write(nstr, '(i7)') nstep
       tstr = adjustl(tstr)
       nstr = adjustl(nstr)
-      call printinfo("======================================================================================================", .false.)
-      call printinfo("###############     Finishing     ###############", .false.)
+      call print_char_line("=")
+      call printinfo("###############     Finishing     ###############", V_LOG)
       if (t >= tend) then
          write(msg, '(2a)') "Simulation has reached final time t = ",trim(tstr)
          call printinfo(msg, V_INFO)
@@ -244,9 +242,7 @@ program piernik
       call printinfo("Grid lists present at finish:", to_stdout=.false.)
    endif
    call all_lists%print(to_stdout = .false.)  ! needs all procs to participate
-   if (master) then
-      call printinfo("======================================================================================================", .false.)
-   endif
+   if (master) call print_char_line("=")
 
    if (associated(finalize_problem)) call finalize_problem
 

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -106,11 +106,11 @@ program piernik
       call print_char_line("=")
       call printinfo("###############     Simulation     ###############", V_LOG)
       call printinfo("Named arrays present at start:", V_LOG)
-      call qna%print_vars(to_stdout=.false.)
-      call wna%print_vars(to_stdout=.false.)
-      call printinfo("Grid lists present at start:", to_stdout=.false.)
+      call qna%print_vars
+      call wna%print_vars
+      call printinfo("Grid lists present at start:", V_LOG)
    endif
-   call all_lists%print(to_stdout = .false.)  ! needs all procs to participate
+   call all_lists%print  ! needs all procs to participate
    if (master) call print_char_line("=")
 
    call print_progress(nstep)
@@ -236,12 +236,12 @@ program piernik
          call warn(msg)
       endif
 
-      call printinfo("Named arrays present at finish:", to_stdout=.false.)
-      call qna%print_vars(to_stdout=.false.)
-      call wna%print_vars(to_stdout=.false.)
-      call printinfo("Grid lists present at finish:", to_stdout=.false.)
+      call printinfo("Named arrays present at finish:", V_LOG)
+      call qna%print_vars
+      call wna%print_vars
+      call printinfo("Grid lists present at finish:", V_LOG)
    endif
-   call all_lists%print(to_stdout = .false.)  ! needs all procs to participate
+   call all_lists%print  ! needs all procs to participate
    if (master) call print_char_line("=")
 
    if (associated(finalize_problem)) call finalize_problem

--- a/src/base/piernik.F90
+++ b/src/base/piernik.F90
@@ -275,7 +275,7 @@ contains
 
    subroutine print_progress(nstep)
 
-      use constants,  only: tmr_fu
+      use constants,  only: tmr_fu, V_ESSENTIAL
       use dataio_pub, only: printinfo, msg
       use global,     only: dt, t
       use timer,      only: set_timer, get_timestamp
@@ -292,7 +292,7 @@ contains
             first_run = (set_timer(tmr_fu) < 0.0)
          endif
          write(msg, fmt900) nstep, dt, t, set_timer(tmr_fu), get_timestamp()
-         call printinfo(msg, .true.)
+         call printinfo(msg, V_ESSENTIAL, .true.)
       endif
 
    end subroutine print_progress

--- a/src/base/ppp_eventlist.F90
+++ b/src/base/ppp_eventlist.F90
@@ -296,8 +296,8 @@ contains
 
    subroutine publish(this)
 
-      use constants,    only: I_ZERO, I_ONE
-      use dataio_pub,   only: printinfo, msg
+      use constants,    only: I_ZERO, I_ONE, V_INFO
+      use dataio_pub,   only: warn, printinfo, msg
       use MPIF,         only: MPI_STATUS_IGNORE, MPI_STATUSES_IGNORE, MPI_CHARACTER, MPI_INTEGER, MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
       use MPIFUN,       only: MPI_Isend, MPI_Recv, MPI_Waitall
       use mpisetup,     only: proc, master, slave, err_mpi, FIRST, LAST, req, inflate_req, piernik_MPI_Barrier, extra_barriers
@@ -317,7 +317,7 @@ contains
       if (.not. use_profiling) return
 
       if (this%overflown) then
-         call printinfo("[ppp_eventlist:publish] Profile timings have overflown the allowed buffers and thus are partially broken. Skipping.")
+         call warn("[ppp_eventlist:publish] Profile timings have overflown the allowed buffers and thus are partially broken. Skipping.")
          call this%cleanup
          return
       endif
@@ -329,7 +329,7 @@ contains
             msg = "all events categories are enabled"
          endif
 
-         call printinfo("[ppp_eventlist:publish] Profile timings will be written to '" // trim(profile_file) // "' file, " // trim(msg))
+         call printinfo("[ppp_eventlist:publish] Profile timings will be written to '" // trim(profile_file) // "' file, " // trim(msg), V_INFO)
          open(newunit=profile_lun, file=profile_file)
       endif
 

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -241,6 +241,7 @@ contains
 
    subroutine update_profiling
 
+      use constants,     only: V_VERBOSE
       use dataio_pub,    only: printinfo
       use global,        only: nstep
       use mpisetup,      only: master
@@ -252,7 +253,7 @@ contains
 
       if (turn_off <= nstep) then  ! turn off ppp_main profiling
          call ppp_main%publish
-         if (master) call printinfo("[ppprofiling:update_profiling] Stop PPP")
+         if (master) call printinfo("[ppprofiling:update_profiling] Stop PPP", V_VERBOSE)
          use_profiling = .false.
          turn_off = huge(1)
       endif
@@ -267,7 +268,7 @@ contains
       if (.not. use_profiling) then  ! turn on ppp_main profiling
          use_profiling = .true.
          call ppp_main%init("main", xxl)
-         if (master) call printinfo("[ppprofiling:update_profiling] Start PPP")
+         if (master) call printinfo("[ppprofiling:update_profiling] Start PPP", V_VERBOSE)
       endif
 
    end subroutine update_profiling

--- a/src/base/primes.F90
+++ b/src/base/primes.F90
@@ -95,6 +95,7 @@ contains
 
    subroutine print(this)
 
+      use constants,  only: V_DEBUG
       use dataio_pub, only: msg, printinfo
       use mpisetup,   only: master
 
@@ -104,7 +105,7 @@ contains
 
       if (master) then
          write(msg,'(a,i5,a,i9,a)') "There are ", size(this%tab), " prime numbers smaller than", this%max,":"
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
          print "(15i7)", this%tab
       endif
 

--- a/src/base/primes.F90
+++ b/src/base/primes.F90
@@ -95,7 +95,7 @@ contains
 
    subroutine print(this)
 
-      use constants,  only: V_DEBUG
+      use constants,  only: V_DEBUG, fmt_len
       use dataio_pub, only: msg, printinfo
       use mpisetup,   only: master
 
@@ -103,10 +103,12 @@ contains
 
       class(primes_t), intent(inout) :: this !< object invoking type-bound procedure
 
+      character(len=fmt_len) :: fmt
+
       if (master) then
-         write(msg,'(a,i5,a,i9,a)') "There are ", size(this%tab), " prime numbers smaller than", this%max,":"
+         write(fmt, '(a,i0,a)')'(a,i0,a,i0,a,', ubound(this%tab, 1), '(" ",i0))'
+         write(msg, fmt) "There are ", size(this%tab), " prime numbers smaller than ", this%max," :", this%tab
          call printinfo(msg, V_DEBUG)
-         print "(15i7)", this%tab
       endif
 
    end subroutine print

--- a/src/base/timer.F90
+++ b/src/base/timer.F90
@@ -228,6 +228,7 @@ contains
 
    function time_left(this, wall_to_end) result (tf)
 
+      use constants,  only: V_ESSENTIAL
       use dataio_pub, only: msg, printinfo, die
       use mpisetup,   only: slave
 
@@ -280,7 +281,7 @@ contains
             mm = int(ss,kind=8)
             ss = (ss - mm)*60.0
             write(msg,'("Walltime left until ",A,": ",I4,":",I2.2,":",F5.2)') trim(this%description), hh, mm, ss
-            call printinfo(msg)
+            call printinfo(msg, V_ESSENTIAL)
          endif
       endif
 
@@ -294,7 +295,7 @@ contains
 #ifdef PERFMON
    subroutine timer_stop(nstep, total_ncells)
 
-      use constants,  only: I_ONE, half
+      use constants,  only: I_ONE, half, V_VERBOSE
       use dataio_pub, only: msg, printinfo
       use MPIF,       only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD
       use MPIFUN,     only: MPI_Reduce
@@ -331,14 +332,14 @@ contains
 
          zcps  = real(nstep) * real(total_ncells) / cpuallp
 
-         call printinfo("", .true.)
+         call printinfo("", V_VERBOSE)
          write(msg, "('CPU time        = ', f12.2,' s')") cpuallp
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
          write(msg, "('Wall clock time = ', f12.2,' s')") wctot
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
          write(msg, "('Zone-cycles / s = ',en14.5)") zcps
-         call printinfo(msg)
-         call printinfo("", .true.)
+         call printinfo(msg, V_VERBOSE)
+         call printinfo("", V_VERBOSE)
 
       endif
 

--- a/src/base/timestep.F90
+++ b/src/base/timestep.F90
@@ -136,6 +136,7 @@ contains
       use resistivity,        only: timestep_resist
 #endif /* RESISTIVE */
 #ifdef DEBUG
+      use constants,          only: V_DEBUG
       use dataio_pub,         only: printinfo
       use piernikdebug,       only: has_const_dt, constant_dt
 #endif /* DEBUG */
@@ -224,7 +225,7 @@ contains
       if (has_const_dt) then
          dt = constant_dt
          write(msg,*) "[timestep:time_step]: (constant_dt) c_all = ", c_all
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
       endif
 #endif /* DEBUG */
       call compare_array1D([dt])  ! just in case

--- a/src/base/units.F90
+++ b/src/base/units.F90
@@ -178,7 +178,7 @@ contains
 !<
    subroutine init_units
 
-      use constants,  only: pi, fpi, dirtyL, PIERNIK_INIT_MPI, U_TEMP
+      use constants,  only: pi, fpi, dirtyL, PIERNIK_INIT_MPI, U_TEMP, V_VERBOSE, V_INFO
       use dataio_pub, only: warn, printinfo, msg, die, code_progress
       use func,       only: operator(.equals.)
       use mpisetup,   only: master
@@ -186,16 +186,13 @@ contains
       implicit none
 
       logical, save            :: scale_me = .false.
-      logical                  :: to_stdout
+      integer(kind=4) :: v
+
+      v = V_VERBOSE
 
       if (code_progress < PIERNIK_INIT_MPI) call die("[units:init_units] MPI not initialized.")
 
       call units_par_io
-
-      to_stdout = .false.
-#ifdef VERBOSE
-      to_stdout = .true.
-#endif /* VERBOSE */
 
       s_lmtvB(U_ENER) = "complex "
       select case (trim(units_set))
@@ -314,7 +311,7 @@ contains
             if (master) call warn("[units:init_units] PIERNIK will use 'cm', 'sek', 'gram' defined in problem.par")
             if (any([cm.equals.dirtyL, sek.equals.dirtyL, gram.equals.dirtyL])) &
                call die("[units:init_units] units_set=='user', yet one of {'cm','sek','gram'} is not set in problem.par") ! Don't believe in coincidence
-            to_stdout = .true.               ! Force output in case someone is not aware what he/she is doing
+            v = V_INFO               ! Increase verbosity in case someone is not aware what he/she is doing
             if (trim(s_len_u)  == ' undefined') s_len_u   = ' [user unit]'
             if (trim(s_time_u) == ' undefined') s_time_u  = ' [user unit]'
             if (trim(s_mass_u) == ' undefined') s_mass_u  = ' [user unit]'
@@ -337,11 +334,11 @@ contains
 
       if (master .and. .not. scale_me) then
          write(msg,'(a,es14.7,a)') '[units:init_units] cm   = ', cm,   trim(s_len_u)
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
          write(msg,'(a,es14.7,a)') '[units:init_units] sek  = ', sek,  trim(s_time_u)
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
          write(msg,'(a,es14.7,a)') '[units:init_units] gram = ', gram, trim(s_mass_u)
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
       endif
 
 ! length units:
@@ -412,9 +409,9 @@ contains
 
       if (master) then
          write(msg,'(a,es20.13)') '[units:init_units] newtong = ', newtong
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
          write(msg,'(a,es20.13)') '[units:init_units] kboltz  = ', kboltz
-         call printinfo(msg, to_stdout)
+         call printinfo(msg, v)
       endif
 
    end subroutine init_units

--- a/src/fluids/cosmicrays/cr_data.F90
+++ b/src/fluids/cosmicrays/cr_data.F90
@@ -220,6 +220,7 @@ contains
 
    subroutine cr_species_tables(ncrsp, crness)
 
+      use constants,  only: V_INFO
       use dataio_pub, only: msg, printinfo, die
       use mpisetup,   only: master
       use units,      only: me, mp, myr, mbarn
@@ -269,7 +270,7 @@ contains
             cr_gpess(icr)    = eCRSP_ess(i)
             if (master) then
                write(msg,'(a,a,a,l2)') spectral_or_not(cr_spectral(icr)), eCRSP_names(i), 'CR species is present; taken into account for grad_pcr: ', eCRSP_ess(i)
-               call printinfo(msg)
+               call printinfo(msg, V_INFO)
             endif
          endif
       enddo
@@ -278,7 +279,7 @@ contains
          cr_gpess(ncrsp_auto+1:ncrsp) = crness
          do i = ncrsp_auto+1, ncrsp
             write(msg,'(a,a,i2,a,l2)') spectral_or_not(cr_spectral(i)), 'user CR species no: ', i,' is present; taken into account for grad_pcr: ', cr_gpess(i)
-            if (master) call printinfo(msg)
+            if (master) call printinfo(msg, V_INFO)
          enddo
       endif
 
@@ -286,7 +287,7 @@ contains
          write(msg, '(a,i3)') 'Total amount of CR species: ', ncrsp
          if (count(cr_spectral) > 0) write(msg(len_trim(msg)+1:), '(a,i3,a)') ' | ', count(cr_spectral), ' spectral component(s)'
          if (ncrsp - ncrsp_auto > 0) write(msg(len_trim(msg)+1:), '(a,i3,a)') ' | ', ncrsp - ncrsp_auto, ' user component(s).'
-         call printinfo(msg)
+         call printinfo(msg, V_INFO)
       endif
 
       if (eCRSP(icr_C12)) then

--- a/src/fluids/cosmicrays/multigrid_diffusion.F90
+++ b/src/fluids/cosmicrays/multigrid_diffusion.F90
@@ -281,7 +281,7 @@ contains
       use global,         only: dt
       use initcosmicrays, only: use_CRdiff
       use mpisetup,       only: master
-      use multigridvars,  only: stdout
+      use multigridvars,  only: v_mg
 
       implicit none
 
@@ -300,7 +300,7 @@ contains
       else
          if (dt < 0.99999 * diff_dt_crs_orig * diff_tstep_fac .and. .not. halfstep .and. master) then
             write(msg,'(a,f8.3,a)')"[multigrid_diffusion:inworth_mg_diff] Timestep limited somewhere else: dt = ", dt / diff_dt_crs_orig, " of explicit dt_crs."
-            call printinfo(msg, stdout)
+            call printinfo(msg, v_mg)
          endif
          call multigrid_solve_diff
          call all_fluid_boundaries

--- a/src/fluids/cosmicrays/multigrid_diffusion.F90
+++ b/src/fluids/cosmicrays/multigrid_diffusion.F90
@@ -240,7 +240,7 @@ contains
       endif
 
       if (single_base .and. nproc > 1) then
-         call warn("[multigrid_diffusion:multigrid_diff_par] single_base disabled just in case")
+         if (master) call warn("[multigrid_diffusion:multigrid_diff_par] single_base disabled just in case")
          single_base = (nproc == 1)
       endif
 

--- a/src/fluids/fluidtypes.F90
+++ b/src/fluids/fluidtypes.F90
@@ -278,7 +278,7 @@ contains
 !<
    subroutine set_fluid_index(this, flind, is_magnetized, is_selfgrav, has_energy, cs_iso, gamma_, tag)
 
-      use constants,   only: xdim, ydim, zdim, ndims, I_ONE, ION, NEU, DST, cbuff_len
+      use constants,   only: xdim, ydim, zdim, ndims, I_ONE, ION, NEU, DST, cbuff_len, V_VERBOSE
       use dataio_pub,  only: msg, printinfo
       use diagnostics, only: ma1d, ma2d, my_allocate
       use mpisetup,    only: master
@@ -366,7 +366,7 @@ contains
          msg = trim(msg) // aux
       endif
 
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_VERBOSE)
 
    end subroutine set_fluid_index
 

--- a/src/fluids/fluxes.F90
+++ b/src/fluids/fluxes.F90
@@ -179,10 +179,8 @@ contains
 !*/
    subroutine set_limiter(lname)
 
-      use dataio_pub, only: msg, die
-#ifdef VERBOSE
-      use dataio_pub, only: printinfo
-#endif /* VERBOSE */
+      use constants,  only: V_VERBOSE
+      use dataio_pub, only: msg, die, printinfo
 
       implicit none
 
@@ -202,10 +200,8 @@ contains
             write(msg,'(2a)') "[fluxes:set_limiter] unknown limiter ", lname
             call die(msg)
       end select
-#ifdef VERBOSE
       write(msg,'(2a)') "[fluxes:set_limiter] limiter set to ", lname
-      call printinfo(msg)
-#endif /* VERBOSE */
+      call printinfo(msg, V_VERBOSE)
 
    end subroutine set_limiter
 

--- a/src/fluids/fluxes.F90
+++ b/src/fluids/fluxes.F90
@@ -181,6 +181,7 @@ contains
 
       use constants,  only: V_VERBOSE
       use dataio_pub, only: msg, die, printinfo
+      use mpisetup,   only: master
 
       implicit none
 
@@ -201,7 +202,7 @@ contains
             call die(msg)
       end select
       write(msg,'(2a)') "[fluxes:set_limiter] limiter set to ", lname
-      call printinfo(msg, V_VERBOSE)
+      if (master) call printinfo(msg, V_VERBOSE)
 
    end subroutine set_limiter
 

--- a/src/gravity/gravity.F90
+++ b/src/gravity/gravity.F90
@@ -467,7 +467,8 @@ contains
 #ifdef SELF_GRAV
       use cg_leaves,         only: leaves
       use cg_list_dataop,    only: expanded_domain
-      use dataio_pub,        only: warn, die, restarted_sim
+      use constants,         only: V_VERBOSE
+      use dataio_pub,        only: die, printinfo, restarted_sim
       use fluidindex,        only: iarr_all_sg
       use mpisetup,          only: master
       use multigrid_gravity, only: multigrid_solve_grav, recover_sgpm, recover_sgp
@@ -513,7 +514,7 @@ contains
          !> First step in highly dynamical setups will behave as the potential was frozen before first timestep
          !> Solution? Take one step backwards just for calculating old potential? Sounds complicated.
          !> Another solution: don't use extrapolation, exploit rich history instead and call multigrid more often.
-         if (master) call warn("[gravity:source_terms_grav] assigned sgpm = sgp")
+         if (master) call printinfo("[gravity:source_terms_grav] assigned sgpm = sgp", V_VERBOSE)
       endif
 
       call expanded_domain%q_copy(i_sgp, i_sgpm) ! add fake history for selfgravitating potential: pretend that nothing was changing there until domain expanded

--- a/src/gravity/multigrid_gravity.F90
+++ b/src/gravity/multigrid_gravity.F90
@@ -386,7 +386,7 @@ contains
       use cg_level_coarsest,   only: coarsest
       use cg_level_connected,  only: cg_level_connected_t
       use cg_list,             only: cg_list_element
-      use constants,           only: GEO_XYZ, sgp_n, fft_none, fft_dst, fft_rcr, dsetnamelen, pMAX
+      use constants,           only: GEO_XYZ, sgp_n, fft_none, fft_dst, fft_rcr, dsetnamelen, pMAX, V_VERBOSE
       use dataio_pub,          only: die, warn, printinfo, msg
       use domain,              only: dom
       use mpisetup,            only: master, FIRST, LAST, piernik_MPI_Allreduce
@@ -440,12 +440,12 @@ contains
          end select
          if (trim(FFTn) /= "none" .and. master) then
             write(msg,'(a,i3,2a)')"[multigrid_gravity:init_multigrid_grav] Coarsest level (",coarsest%level%l%id,"), FFT solver: ", trim(FFTn)
-            call printinfo(msg)
+            call printinfo(msg, V_VERBOSE)
          endif
       endif
       if (coarsest%level%fft_type == fft_none .and. master) then
          write(msg,'(a,i3,a)')"[multigrid_gravity:init_multigrid_grav] Coarsest level (",coarsest%level%l%id,"), relaxation solver"
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
       endif
 
       require_FFT = .false.
@@ -1009,7 +1009,7 @@ contains
       use mpisetup,                 only: nproc
       use multigrid_gravity_helper, only: fft_solve_level
       use multigrid_old_soln,       only: soln_history
-      use multigridvars,            only: grav_bnd, bnd_givenval, stdout, source, solution
+      use multigridvars,            only: grav_bnd, bnd_givenval, v_mg, source, solution
       use pcg,                      only: mgpcg, use_CG, use_CG_outer
 
       implicit none
@@ -1023,7 +1023,7 @@ contains
       if (nproc == 1 .and. finest%level%fft_type /= fft_none) then
          call all_cg%set_dirty(solution, 0.978*dirtyH1)
          call fft_solve_level(finest%level, source, solution)
-         call printinfo("[multigrid_gravity:poisson_solver] FFT solve on finest level, Skipping V-cycles.", stdout)
+         call printinfo("[multigrid_gravity:poisson_solver] FFT solve on finest level, Skipping V-cycles.", v_mg)
          fft_solved = .true.
       else
          call history%init_solution(vstat%cprefix)
@@ -1061,11 +1061,11 @@ contains
       use cg_level_connected,       only: cg_level_connected_t
       use cg_level_finest,          only: finest
       use cg_list_global,           only: all_cg
-      use constants,                only: cbuff_len, tmr_mg, dirtyH1, PPP_GRAV, PPP_MG
+      use constants,                only: cbuff_len, tmr_mg, dirtyH1, PPP_GRAV, PPP_MG, V_INFO
       use dataio_pub,               only: msg, die, warn, printinfo
       use global,                   only: do_ascii_dump
       use mpisetup,                 only: master
-      use multigridvars,            only: source, solution, correction, defect, verbose_vcycle, stdout, tot_ts, ts, grav_bnd, bnd_periodic
+      use multigridvars,            only: source, solution, correction, defect, verbose_vcycle, tot_ts, ts, grav_bnd, bnd_periodic
       use multigrid_gravity_helper, only: approximate_solution
       use multigrid_Laplace,        only: residual
       use ppp,                      only: ppp_main
@@ -1139,7 +1139,7 @@ contains
                fmt='(3a,i3,a,f12.9,a,es8.2,a,f7.3)'
             endif
             write(msg, fmt)"[multigrid_gravity] ", trim(vstat%cprefix), "Cycle:", v, " norm/rhs= ", norm_lhs/norm_rhs, " reduction factor= ", norm_old/norm_lhs, "   dt_wall= ", ts
-            call printinfo(msg, stdout)
+            call printinfo(msg, V_INFO, .true.)
          endif
 
          vstat%count = v

--- a/src/gravity/multigrid_monopole.F90
+++ b/src/gravity/multigrid_monopole.F90
@@ -137,20 +137,16 @@ contains
 
       use cg_leaves,    only: leaves
       use cg_list,      only: cg_list_element
-      use constants,    only: ndims, xdim, ydim, zdim, LO, HI, GEO_XYZ, pSUM, zero !, GEO_RPZ
-      use dataio_pub,   only: die
+      use constants,    only: ndims, xdim, ydim, zdim, LO, HI, GEO_XYZ, pSUM, zero, V_DEBUG !, GEO_RPZ
+      use dataio_pub,   only: die, msg, printinfo
       use domain,       only: dom
       use func,         only: operator(.notequals.)
       use grid_cont,    only: grid_container
-      use mpisetup,     only: piernik_MPI_Allreduce
+      use mpisetup,     only: piernik_MPI_Allreduce, master
+      use units,        only: fpiG
 #ifdef NBODY
       use particle_types, only: particle
 #endif /* NBODY */
-#ifdef DEBUG
-      use dataio_pub,   only: msg, printinfo
-      use mpisetup,     only: master
-      use units,        only: fpiG
-#endif /* DEBUG */
 
       implicit none
 
@@ -217,12 +213,10 @@ contains
       else
          call die("[multigrid_monopole:find_img_CoM] Total mass == 0")
       endif
-#ifdef DEBUG
       if (master) then
          write(msg, '(a,g14.6,a,3g14.6,a)')"[multigrid_monopole:find_img_CoM] Total mass = ", CoM(imass)/fpiG," at (",CoM(xdim:zdim),")"
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
       endif
-#endif /* DEBUG */
 
    end subroutine find_img_CoM
 

--- a/src/gravity/multipole_array.F90
+++ b/src/gravity/multipole_array.F90
@@ -141,7 +141,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_level_coarsest,  only: coarsest
       use cg_list,            only: cg_list_element
-      use constants,          only: xdim, zdim, GEO_XYZ, GEO_RPZ, HI, pMIN
+      use constants,          only: xdim, zdim, GEO_XYZ, GEO_RPZ, HI, pMIN, V_LOG, V_VERBOSE
       use dataio_pub,         only: die, warn, msg, printinfo
       use domain,             only: dom
       use memory_usage,       only: check_mem_usage
@@ -240,7 +240,7 @@ contains
 
       if (this%pr_log) then
          write(msg, '(a,3g13.5,a)')"[multipole_array:refresh] multipoles centered at ( ", this%center, " ) low edges of bins are at:"
-         if (master) call printinfo(msg, .false.)
+         if (master) call printinfo(msg, V_LOG)
       endif
       prev = 0
       do i = lbound(this%i_r, dim=1), ubound(this%i_r, dim=1)
@@ -253,10 +253,10 @@ contains
                call print_ri(i)
                prev = i
             else if (div2n(i) <= 3) then  ! if the array is long then print only for some values
-               if (prev < i-2 .and. prev == skip_pr .and. master) call printinfo(dots, .false.)
+               if (prev < i-2 .and. prev == skip_pr .and. master) call printinfo(dots, V_LOG)
                if (prev < i-1) call print_ri(i-1)
                call print_ri(i)
-               if (i+1 /= ubound(this%i_r, dim=1) - skip_pr .and. master) call printinfo(dots, .false.)
+               if (i+1 /= ubound(this%i_r, dim=1) - skip_pr .and. master) call printinfo(dots, V_LOG)
                prev = i
             endif
          endif
@@ -264,7 +264,7 @@ contains
       if (this%pr_log .and. ubound(this%i_r, dim=1) > 1 .and. master) then
          write(msg, '(a,3g13.5,2(a,g13.5))')"[multipole_array:refresh] multipoles centered at ( ", this%center, " ) first bin width = ", this%i_r(1), " last bin starts at = ", this%i_r(ubound(this%i_r, dim=1) - 1)
          ! Expect inaccurate potential for sources that fall into last few bins due to large dr/r ratio.
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
       endif
 
    contains
@@ -313,7 +313,7 @@ contains
             write(fmt, '(a,i1,a)')'(a,i',1 + int(log10(real(max(1,i)))),',a,g13.5)'
          endif
          write(msg, fmt)"  r( ",i," ) = ", this%i_r(i)
-         if (master) call printinfo(msg, .false.)
+         if (master) call printinfo(msg, V_LOG)
 
       end subroutine print_ri
 

--- a/src/gravity/old_soln_list.F90
+++ b/src/gravity/old_soln_list.F90
@@ -357,7 +357,7 @@ contains
 
    subroutine print(this)
 
-      use constants,        only: I_ZERO, I_ONE
+      use constants,        only: I_ZERO, I_ONE, V_VERBOSE
       use dataio_pub,       only: msg, printinfo
       use global,           only: t
       use mpisetup,         only: master
@@ -382,7 +382,7 @@ contains
             class default
                write(msg, '(a,i3,a,g14.6,a,i3,2a)') "(Other ?) soln# ", cnt, " time = ", os%time, " qna_index: ", os%i_hist, " qna_name: ", qna%lst(os%i_hist)%name
          end select
-         if (master) call printinfo(msg)
+         if (master) call printinfo(msg, V_VERBOSE)
          os => os%earlier
          if (cnt > too_long) os => null()
       enddo
@@ -393,7 +393,7 @@ contains
             write(msg(len_trim(msg)+1:), '(a,l2)') " is valid? ", this%is_valid()
          class default
       end select
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_VERBOSE)
 
    end subroutine print
 

--- a/src/gravity/pcg.F90
+++ b/src/gravity/pcg.F90
@@ -112,7 +112,7 @@ contains
 
       use cg_leaves,          only: leaves
       use cg_list_dataop,     only: ind_val
-      use constants,          only: tmr_mg
+      use constants,          only: tmr_mg, V_VERBOSE
       use dataio_pub,         only: msg, printinfo
       use mpisetup,           only: master
       use multigrid_Laplace,  only: residual, vT_A_v
@@ -156,7 +156,7 @@ contains
             write(msg,'(a,i3,a,f12.8,a,es10.3,a,f11.7,g14.6,a,f8.3)')"MG-PCG: ", k, " lhs/rhs= ",norm_lhs/norm_rhs, " improvement= ",norm_old/norm_lhs, &
                  &                                                 " a,b= ", alpha, beta, " time=", ts
          endif
-         if (master) call printinfo(msg)
+         if (master) call printinfo(msg, V_VERBOSE)
          if (norm_lhs/norm_rhs <= norm_tol) exit                                                  ! if {r}_{k+1} is sufficiently small then exit loop
          norm_old = norm_lhs
          call precond(defect, correction)                                                         ! {z}_{k+1} := {M}^{-1} {r}_{k+1}
@@ -171,7 +171,7 @@ contains
       tot_ts = tot_ts + ts
       loc_ts = loc_ts + ts
       write(msg, '(a,i4,a,f8.3)')"MG-PCG: ",k," iterations, total time spent =", loc_ts
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_VERBOSE)
 
    end subroutine mgpcg
 

--- a/src/grid/cg_leaves.F90
+++ b/src/grid/cg_leaves.F90
@@ -86,7 +86,7 @@ contains
       use cg_level_finest,    only: finest
       use cg_level_connected, only: cg_level_connected_t
       use cg_list,            only: cg_list_element
-      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, INVALID, tmr_amr, PPP_AMR
+      use constants,          only: pSUM, pMAX, base_level_id, refinement_factor, INVALID, tmr_amr, PPP_AMR, V_VERBOSE
       use dataio_pub,         only: msg, printinfo
       use domain,             only: dom
       use list_of_cg_lists,   only: all_lists
@@ -100,8 +100,8 @@ contains
 
       implicit none
 
-      class(cg_leaves_t),         intent(inout) :: this  !< object invoking type-bound procedure
-      character(len=*), optional, intent(in)    :: str   !< optional string identifier to show the progress of updating refinement
+      class(cg_leaves_t), intent(inout) :: this  !< object invoking type-bound procedure
+      character(len=*),   intent(in)    :: str   !< optional string identifier to show the progress of updating refinement
 
       type(cg_level_connected_t), pointer :: curl
       type(cg_list_element),      pointer :: cgl
@@ -121,8 +121,7 @@ contains
       call leaves%delete
       call all_lists%register(this, "leaves")
 
-      msg = "[cg_leaves:update] Grids on levels: "
-      if (present(str)) msg(len_trim(msg)+1:) = str
+      msg = "[cg_leaves:update] Grids on levels:" // str
       ih = len_trim(msg) + 1
 
       curl => finest%level
@@ -186,7 +185,8 @@ contains
             write(msg(len_trim(msg)+1:), '(" ",e9.2)') lf
          endif
       endif
-      if (master .and. (msg(ih:is) /= prev_msg(ih:prev_is))) call printinfo(msg)
+      ! Consider a higher verbosity when str == ' ( derefine )'
+      if (master .and. (msg(ih:is) /= prev_msg(ih:prev_is))) call printinfo(msg, V_VERBOSE)
       prev_msg = msg
       prev_is = is
 
@@ -194,7 +194,7 @@ contains
       lb_part = global_balance_particles()
       if (master .and. (lb_part .notequals. prev_lb_part)) then
          write(msg, '(a,f7.4)')"[cg_leaves:update] particles load balance: ", lb_part
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
       endif
       prev_lb_part = lb_part
 #endif /* NBODY */
@@ -215,8 +215,8 @@ contains
 
       implicit none
 
-      class(cg_leaves_t),         intent(inout) :: this  !< object invoking type-bound procedure
-      character(len=*), optional, intent(in)    :: str   !< optional string identifier to show the progress of updating refinement
+      class(cg_leaves_t), intent(inout) :: this  !< object invoking type-bound procedure
+      character(len=*),   intent(in)    :: str   !< optional string identifier to show the progress of updating refinement
 
       type(cg_level_connected_t), pointer :: curl
       character(len=*), parameter :: bu_label = "leaves_balance_and_update"

--- a/src/grid/cg_level.F90
+++ b/src/grid/cg_level.F90
@@ -126,6 +126,7 @@ contains
       use dataio_pub, only: printinfo !, msg, warn
       use mpisetup,   only: FIRST, LAST, master!, nproc, proc
 #ifdef VERBOSE
+      use constants,  only: V_DEBUG
       use dataio_pub, only: msg
 #endif /* VERBOSE */
 
@@ -155,7 +156,7 @@ contains
 !!$         cgl => this%first
 !!$         do while (associated(cgl))
 !!$            write(msg,'(2(a,i7),2(a,3i10),a)')" @",proc," #",cgl%cg%grid_id," : [", cgl%cg%my_se(:, LO), "] : [", cgl%cg%my_se(:, HI)," ]"
-!!$            call printinfo(msg)
+!!$            call printinfo(msg, V_DEBUG)
 !!$            cgl => cgl%nxt
 !!$         enddo
 !!$      endif
@@ -188,7 +189,7 @@ contains
             else
                write(msg,'(2a,2(3i18,a),i8,a)') header(:hl), " : [", this%dot%gse(p)%c(i)%se(:, LO), "] : [", this%dot%gse(p)%c(i)%se(:, HI), "] #", ccnt, " cells"
             endif
-            call printinfo(msg)
+            call printinfo(msg, V_DEBUG)
 #endif /* VERBOSE */
          enddo
       enddo
@@ -196,7 +197,7 @@ contains
 !      write(msg, '(a,i3,a,f5.1,a,i5,a,f8.5)')"[cg_level:print_segments] Level ", this%l%id, " filled in ",(100.*sum(maxcnt(:)))/product(real(this%n_d(:))), &
 !           &                                 "%, ",tot_cg," grid(s), load balance : ", sum(maxcnt(:))/(nproc*maxval(maxcnt(:)))
       !> \todo add calculation of total internal boundary surface in cells
-!      call printinfo(msg)
+!      call printinfo(msg, V_DEBUG)
       deallocate(maxcnt)
 
    end subroutine print_segments

--- a/src/grid/cg_list.F90
+++ b/src/grid/cg_list.F90
@@ -181,6 +181,7 @@ contains
 !> \brief print the list and associated cg ID for debugging purposes
    subroutine print_list(this)
 
+      use constants,  only: V_DEBUG
       use dataio_pub, only: warn, printinfo, msg
 
       implicit none
@@ -210,11 +211,11 @@ contains
 
       if (associated(this%first%cg)) then
          write(msg,'(a,i7)')"First element #",this%first%cg%grid_id
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
       endif
       if (associated(this%last%cg)) then
          write(msg,'(a,i7)')"Last element #",this%last%cg%grid_id
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
       endif
 
       cnt = 0
@@ -223,7 +224,7 @@ contains
          cnt = cnt + 1
          if (associated(cur%cg)) then
             write(msg,'(i5,a,i7)')cnt,"-th element #",cur%cg%grid_id
-            call printinfo(msg)
+            call printinfo(msg, V_DEBUG)
          endif
          cur => cur%nxt
       enddo
@@ -237,7 +238,7 @@ contains
       do while (associated(cur))
          if (associated(cur%cg)) then
             write(msg,'(i5,a,i7)')cnt,"-th element #",cur%cg%grid_id
-            call printinfo(msg)
+            call printinfo(msg, V_DEBUG)
          endif
          cnt = cnt - 1
          cur => cur%prv

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -471,6 +471,7 @@ contains
       use grid_cont,        only: grid_container
       use mpisetup,         only: piernik_MPI_Allreduce
 #ifdef DEBUG
+      use constants,        only: V_DEBUG
       use dataio_pub,       only: msg, printinfo
       use mpisetup,         only: master
       use named_array_list, only: qna
@@ -518,7 +519,7 @@ contains
 #ifdef DEBUG
       if (master) then
          write(msg, '(2a,2(a,g15.7))')"[cg_list_dataop:subtract_average] Average of '",qna%lst(iv)%name,"' over volume ",vol," is ",avg
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
       endif
 #endif /* DEBUG */
 

--- a/src/grid/domain.F90
+++ b/src/grid/domain.F90
@@ -426,24 +426,24 @@ contains
 
    subroutine print_me(this)
 
-      use constants,  only: LO, HI
+      use constants,  only: LO, HI, V_DEBUG
       use dataio_pub, only: printinfo, msg
 
       implicit none
 
       class(domain_container), intent(inout) :: this  !< object invoking type-bound procedure
 
-      write(msg,'(a,3(F5.1,1X))') "LO edge: ", this%edge(:,LO)  ; call printinfo(msg)
-      write(msg,'(a,3(F5.1,1X))') "HI edge: ", this%edge(:,HI)  ; call printinfo(msg)
-      write(msg,'(a,3(I4,1X))')   "n_d    : ", this%n_d(:)      ; call printinfo(msg)
-      write(msg,'(a,3(I4,1X))')   "n_t    : ", this%n_t(:)      ; call printinfo(msg)
-      write(msg,'(a,1(I4,1X))')   "nb     : ", this%nb          ; call printinfo(msg)
-      write(msg,'(a,3(I4,1X))')   "LO bnd : ", this%bnd(:,LO)   ; call printinfo(msg)
-      write(msg,'(a,3(I4,1X))')   "HI bnd : ", this%bnd(:,HI)   ; call printinfo(msg)
-      write(msg,'(a,3(F5.1,1X))') "L_     : ", this%L_(:)       ; call printinfo(msg)
-      write(msg,'(a,3(F5.1,1X))') "C_     : ", this%C_(:)       ; call printinfo(msg)
-      write(msg,'(a,1(F5.1,1X))') "Vol    : ", this%Vol         ; call printinfo(msg)
-      write(msg,'(a,3(L1,1X))')   "period : ", this%periodic(:) ; call printinfo(msg)
+      write(msg,'(a,3(F5.1,1X))') "LO edge: ", this%edge(:,LO)  ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(F5.1,1X))') "HI edge: ", this%edge(:,HI)  ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(I4,1X))')   "n_d    : ", this%n_d(:)      ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(I4,1X))')   "n_t    : ", this%n_t(:)      ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,1(I4,1X))')   "nb     : ", this%nb          ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(I4,1X))')   "LO bnd : ", this%bnd(:,LO)   ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(I4,1X))')   "HI bnd : ", this%bnd(:,HI)   ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(F5.1,1X))') "L_     : ", this%L_(:)       ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(F5.1,1X))') "C_     : ", this%C_(:)       ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,1(F5.1,1X))') "Vol    : ", this%Vol         ; call printinfo(msg, V_DEBUG)
+      write(msg,'(a,3(L1,1X))')   "period : ", this%periodic(:) ; call printinfo(msg, V_DEBUG)
 
    end subroutine print_me
 

--- a/src/grid/grid.F90
+++ b/src/grid/grid.F90
@@ -62,7 +62,7 @@ contains
       ts =  set_timer(tmr_amr, .true.)  ! we need it here for call leaves%update()
       if (code_progress < PIERNIK_INIT_DOMAIN) call die("[grid:init_grid] domain not initialized.")
 
-      call printinfo("[grid:init_grid]: commencing...", V_DEBUG)
+      if (master) call printinfo("[grid:init_grid]: commencing...", V_DEBUG)
 
       ! Create the empty main lists.with the base level
 
@@ -78,7 +78,7 @@ contains
 
       call leaves%update(" (base level) ")
 
-      call printinfo("[grid:init_grid]: cg finished. \o/", V_DEBUG)
+      if (master) call printinfo("[grid:init_grid]: cg finished. \o/", V_DEBUG)
 
    end subroutine init_grid
 

--- a/src/grid/grid.F90
+++ b/src/grid/grid.F90
@@ -49,7 +49,7 @@ contains
       use cg_level_base,      only: base
       use cg_level_coarsest,  only: coarsest
       use cg_level_finest,    only: finest
-      use constants,          only: PIERNIK_INIT_DOMAIN, tmr_amr
+      use constants,          only: PIERNIK_INIT_DOMAIN, tmr_amr, V_DEBUG
       use dataio_pub,         only: printinfo, die, code_progress
       use domain,             only: dom
       use mpisetup,           only: master
@@ -62,9 +62,7 @@ contains
       ts =  set_timer(tmr_amr, .true.)  ! we need it here for call leaves%update()
       if (code_progress < PIERNIK_INIT_DOMAIN) call die("[grid:init_grid] domain not initialized.")
 
-#ifdef VERBOSE
-      call printinfo("[grid:init_grid]: commencing...")
-#endif /* VERBOSE */
+      call printinfo("[grid:init_grid]: commencing...", V_DEBUG)
 
       ! Create the empty main lists.with the base level
 
@@ -80,9 +78,7 @@ contains
 
       call leaves%update(" (base level) ")
 
-#ifdef VERBOSE
-      call printinfo("[grid:init_grid]: cg finished. \o/")
-#endif /* VERBOSE */
+      call printinfo("[grid:init_grid]: cg finished. \o/", V_DEBUG)
 
    end subroutine init_grid
 

--- a/src/grid/level_essentials.F90
+++ b/src/grid/level_essentials.F90
@@ -97,7 +97,7 @@ contains
 
    subroutine update(this, id, n_d, off)
 
-      use constants,  only: ndims
+      use constants,  only: ndims, V_VERBOSE
       use dataio_pub, only: msg, printinfo, die
       use mpisetup,   only: master
 
@@ -114,7 +114,7 @@ contains
       call this%write(id, n_d, off)
 
       write(msg, '(a,i4,2(a,3i8),a)')"[level_essentials] Updating level", this%id, ", new size=[", this%n_d, "], new offset=[", this%off, "]"
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_VERBOSE)
 
    end subroutine update
 

--- a/src/grid/level_essentials.F90
+++ b/src/grid/level_essentials.F90
@@ -66,7 +66,7 @@ contains
 
    subroutine init(this, id, n_d, off)
 
-      use constants,  only: ndims, LONG, INT4, V_VERBOSE
+      use constants,  only: base_level_id, ndims, LONG, INT4, V_INFO
       use dataio_pub, only: msg, printinfo, die
       use domain,     only: dom
       use mpisetup,   only: master
@@ -82,13 +82,14 @@ contains
 
       call this%write(id, n_d, off)
 
-      write(msg, '(a,i4,a,3i11,a)')"[level_essentials] Initializing level", this%id, ", size=[", this%n_d, "], "
+      write(msg, '(a,i3,a,3i11,a)')"[level_essentials] Initializing level", this%id, ", size=[", this%n_d, "], "
       if (any(dom%has_dir .and. (this%off /= 0))) then
          write(msg(len_trim(msg)+1:), '(a,3i8,a)') " offset=[", this%off, "]"
       else
          write(msg(len_trim(msg)+1:), '(a)') " no offset"
       endif
-      if (master) call printinfo(msg, V_VERBOSE)
+      if (this%id == base_level_id) write(msg(len_trim(msg)+1:), '(a)') " (base level)"
+      if (master) call printinfo(msg, V_INFO)
 
    end subroutine init
 

--- a/src/grid/level_essentials.F90
+++ b/src/grid/level_essentials.F90
@@ -66,7 +66,7 @@ contains
 
    subroutine init(this, id, n_d, off)
 
-      use constants,  only: ndims, LONG, INT4
+      use constants,  only: ndims, LONG, INT4, V_VERBOSE
       use dataio_pub, only: msg, printinfo, die
       use domain,     only: dom
       use mpisetup,   only: master
@@ -88,7 +88,7 @@ contains
       else
          write(msg(len_trim(msg)+1:), '(a)') " no offset"
       endif
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_VERBOSE)
 
    end subroutine init
 

--- a/src/grid/load_balance.F90
+++ b/src/grid/load_balance.F90
@@ -113,7 +113,7 @@ contains
       balance_thread   = .false.
       cost_to_balance  = "all"
       verbosity        = V_HOST
-      verbosity_nstep  = 0
+      verbosity_nstep  = huge(1_4)
       enable_exclusion = .false.
       watch_cost       = "MHD"
       exclusion_thr    = intolerable_perf
@@ -192,10 +192,7 @@ contains
          exclusion_thr = huge(1.)
       endif
 
-      if (verbosity_nstep <= 0) then
-         if (master) call warn("[load_balance] verbosity_nstep <= 0 (disabling)")
-         verbosity_nstep = huge(1_4)
-      endif
+      if (verbosity_nstep <= 0) verbosity_nstep = huge(1_4)
 
       if (balance_host > 1.) then
          if (balance_host > insane_factor) then

--- a/src/grid/load_balance.F90
+++ b/src/grid/load_balance.F90
@@ -94,7 +94,7 @@ contains
 !<
    subroutine init_load_balance
 
-      use constants,  only: INVALID, cbuff_len
+      use constants,  only: INVALID, cbuff_len, V_VERBOSE
       use dataio_pub, only: nh      ! QA_WARN required for diff_nml
       use dataio_pub, only: msg, printinfo, warn
       use mpisetup,   only: cbuff, ibuff, lbuff, rbuff, master, slave, piernik_MPI_Bcast
@@ -227,11 +227,11 @@ contains
             if (balance_host > 0.) write(msg(len_trim(msg)+1:), '(a,f5.2,a)') &
                  " balance_host = ", balance_host, " (" // trim(merge("thread", "host  ", balance_thread)) // "-based)"
             if (balance_cg > 0.) write(msg(len_trim(msg)+1:), '(a,f5.2)') " balance_cg = ", balance_cg
-            call printinfo(msg)
+            call printinfo(msg, V_VERBOSE)
          endif
          if (watch_ind /= INVALID .and. enable_exclusion) then
             write(msg, '(a,f4.1,a)')"[load_balance] Thread exclusion enabled (threshold = ", exclusion_thr, ")"
-            call printinfo(msg)
+            call printinfo(msg, V_VERBOSE)
          endif
       endif
 

--- a/src/grid/load_balance_helpers.F90
+++ b/src/grid/load_balance_helpers.F90
@@ -195,6 +195,7 @@ contains
       subroutine log_elaborate
 
          use cg_cost_stats, only: I_SUM2
+         use constants,     only: V_INFO
          use dataio_pub,    only: printinfo
          use procnames,     only: pnames
 
@@ -214,7 +215,7 @@ contains
                              write(msg(len_trim(msg)+1:), '(3a,f10.3,3a)') merge(": ", ", ", j == lbound(stat_labels, 1)), &
                              &                                             trim(stat_labels(j)), "= ", mul*stat(j), " ", trim(prefix), "s "
                      enddo
-                     call printinfo(msg)
+                     call printinfo(msg, V_INFO)
                   endif
                enddo
             endif
@@ -225,7 +226,7 @@ contains
       subroutine log_detailed
 
          use cg_cost_stats, only: I_AVG, I_SIGMA
-         use constants,     only: I_ZERO
+         use constants,     only: I_ZERO, V_INFO
          use dataio_pub,    only: printinfo
          use procnames,     only: pnames
 
@@ -240,7 +241,7 @@ contains
             endif
          enddo
          write(msg(len_trim(msg)+1:), '(a)') " (per cg)"
-         call printinfo(msg)
+         call printinfo(msg, V_INFO)
 
          do p = FIRST, LAST
             write(msg, '(2a,i5,a)')"@", pnames%procnames(p)(:max(h_l, pnames%maxnamelen)), p, " :"
@@ -256,7 +257,7 @@ contains
                   endif
                endif
             enddo
-            call printinfo(msg)
+            call printinfo(msg, V_INFO)
          enddo
 
       end subroutine log_detailed
@@ -265,7 +266,7 @@ contains
 
          use cg_cost_data,  only: cg_cost_data_t
          use cg_cost_stats, only: I_AVG, I_SUM, I_SUM2
-         use constants,     only: I_ZERO
+         use constants,     only: I_ZERO, V_INFO
          use dataio_pub,    only: printinfo
          use procnames,     only: pnames
 
@@ -281,7 +282,7 @@ contains
             endif
          enddo
          write(msg(len_trim(msg)+1:), '(a)') " (per cg, on whole host)"
-         call printinfo(msg)
+         call printinfo(msg, V_INFO)
 
          do host = lbound(pnames%proc_on_node, 1), ubound(pnames%proc_on_node, 1)
             ! this is a bit awkward but we need to find moments over a host from already computed moments on threads
@@ -310,7 +311,7 @@ contains
                      endif
                   endif
                enddo
-               call printinfo(msg)
+               call printinfo(msg, V_INFO)
             end associate
          enddo
 
@@ -318,6 +319,7 @@ contains
 
       subroutine log_summary
 
+         use constants,  only: V_INFO
          use dataio_pub, only: printinfo
          use mpisetup,   only: nproc
          use procnames,  only: pnames
@@ -333,7 +335,7 @@ contains
             dt_wall = MPI_Wtime() - prev_time
 
             write(msg, '(a,f11.3,3a,f5.1,a)') "All accumulated cg costs out of ", mul*dt_wall, " ", trim(prefix), "s, ", 100*sum(all_proc_stats(N_STATS, I_ONE, :))/nproc/dt_wall, "% spent on cg (averaged globally)"
-            call printinfo(msg)
+            call printinfo(msg, V_INFO)
 
             do host = lbound(pnames%proc_on_node, 1), ubound(pnames%proc_on_node, 1)
                associate (ph => pnames%proc_on_node(host))
@@ -356,7 +358,7 @@ contains
                            write(msg(len_trim(msg)+1:), '(a7)') "-"
                         endif
                      enddo
-                     call printinfo(msg)
+                     call printinfo(msg, V_INFO)
                   else
                      lines = ceiling(real(size(ph%proc)) / max_per_line)
                      per_line = ceiling(real(size(ph%proc)) / lines)  ! or max_per_line for extremely heterogeneous set of nodes
@@ -371,7 +373,7 @@ contains
                               write(msg(len_trim(msg)+1:), '(a11)') "-"
                            endif
                         enddo
-                        call printinfo(msg)
+                        call printinfo(msg, V_INFO)
                      enddo
                      do l = 1, lines
                         write(msg, '(2a)') repeat(" ", pnames%maxnamelen + 1), " | "
@@ -384,7 +386,7 @@ contains
                               write(msg(len_trim(msg)+1:), '(a11)') "-"
                            endif
                         enddo
-                        call printinfo(msg)
+                        call printinfo(msg, V_INFO)
                      enddo
                   endif
 
@@ -397,7 +399,7 @@ contains
 
       subroutine log_speed
 
-         use constants,  only: fmt_len
+         use constants,  only: fmt_len, V_INFO
          use dataio_pub, only: printinfo, warn
          use procnames,  only: pnames
 
@@ -429,7 +431,7 @@ contains
                      else
                         write(msg, '(3a)') "@", ph%nodename(:pnames%maxnamelen), " <MHD speed> = N/A"
                      endif
-                     call printinfo(msg)
+                     call printinfo(msg, V_INFO)
 
                   end associate
                enddo

--- a/src/grid/mergeboxes/box_list.F90
+++ b/src/grid/mergeboxes/box_list.F90
@@ -94,6 +94,7 @@ contains
 
    subroutine print(this)
 
+      use constants,  only: V_DEBUG
       use dataio_pub, only: msg, printinfo
 
       implicit none
@@ -104,7 +105,7 @@ contains
 
       do i = lbound(this%blist, dim=1), ubound(this%blist, dim=1)
          write(msg,*)"[box_list:print] #",i," [ ",this%blist(i)%b(:, LO),"]..[",this%blist(i)%b(:, HI),"]",product(this%blist(i)%b(:, HI)-this%blist(i)%b(:, LO)+1)," cells"
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
       enddo
 
    end subroutine print

--- a/src/grid/mergeboxes/corner_list.F90
+++ b/src/grid/mergeboxes/corner_list.F90
@@ -72,6 +72,7 @@ contains
 
    subroutine print(this)
 
+      use constants,  only: V_DEBUG
       use dataio_pub, only: warn, printinfo, msg
 
       implicit none
@@ -91,7 +92,7 @@ contains
 
       do i = lbound(this%clist, dim=1), ubound(this%clist, dim=1)
          write(msg,*)"[corner_list:print] #",i," @ ",this%clist(i)%pos," -> ",this%clist(i)%ivec, " dist(CoM) ", this%clist(i)%dist
-         call printinfo(msg)
+         call printinfo(msg, V_DEBUG)
       enddo
 
    end subroutine print

--- a/src/grid/mergeboxes/mergeboxes.F90
+++ b/src/grid/mergeboxes/mergeboxes.F90
@@ -144,6 +144,7 @@ contains
 
    subroutine print(this)
 
+      use constants,  only: V_DEBUG
       use dataio_pub, only: msg, printinfo
 
       implicit none
@@ -159,7 +160,7 @@ contains
                a = 0.
                if (this%map(i,j,k)) a = 1.
                write(msg,'(a,3i3,f5.2)')"[mergeboxes:print] ",i,j,k,a
-               call printinfo(msg)
+               call printinfo(msg, V_DEBUG)
             enddo
          enddo
       enddo

--- a/src/grid/rebalance.F90
+++ b/src/grid/rebalance.F90
@@ -214,7 +214,7 @@ contains
 
          use cg_level_base,     only: base
          use cg_level_coarsest, only: coarsest
-         use constants,         only: fmt_len, INVALID, I_ONE, base_level_id
+         use constants,         only: fmt_len, INVALID, I_ONE, base_level_id, V_VERBOSE
          use dataio_pub,        only: printinfo, die
          use load_balance,      only: balance_cg, balance_levels
          use mpisetup,          only: slave
@@ -309,7 +309,7 @@ contains
                  &                      size(cnt_gp), "i", int(log10(real(maxval([cnt_gp, 1]))))+3, ",2a)"
             write(msg, fmt)"Rebalance: ^", lbound(cnt_gp, 1), " .. ", ubound(cnt_gp, 1), " OutOfPlace grids = [", cnt_mv, " ] / [ ", cnt_gp, " ] ", &
                  trim(merge("(reshuffling)       ", "(skipping reshuffle)", rebalance_necessary))
-            call printinfo(msg)
+            call printinfo(msg, V_VERBOSE)
          endif
 
          if (.not. rebalance_necessary) s = 0.

--- a/src/grid/refinement.F90
+++ b/src/grid/refinement.F90
@@ -122,7 +122,7 @@ contains
 !<
    subroutine init_refinement
 
-      use constants,  only: base_level_id, PIERNIK_INIT_DOMAIN, xdim, ydim, zdim, I_ZERO, I_ONE, LO, HI, cbuff_len, refinement_factor, INVALID
+      use constants,  only: base_level_id, PIERNIK_INIT_DOMAIN, xdim, ydim, zdim, I_ZERO, I_ONE, LO, HI, cbuff_len, refinement_factor, INVALID, V_VERBOSE
       use dataio_pub, only: die, code_progress, warn, msg, printinfo, nh
       use domain,     only: dom
       use mpisetup,   only: cbuff, ibuff, lbuff, rbuff, master, slave, piernik_MPI_Bcast
@@ -349,7 +349,7 @@ contains
          level_max = base_level_id
          n_updAMR  = huge(I_ONE)
       endif
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_VERBOSE)
 
       if ((n_updAMR == 0) .and. (level_max > base_level_id)) then
          if (master) call warn("[refinement:init_refinement] refinements disabled (n_updAMR = 0)")

--- a/src/grid/refinement/URC_list.F90
+++ b/src/grid/refinement/URC_list.F90
@@ -310,7 +310,7 @@ contains
                if (p%plotfield .and. p%iplot == INVALID) then
                   p%iplot = new_ref_field("nJ")
                   write(msg, '(3a)') "[URC_list:create_plotfields] Jeans refinement criterion is stored in array '", trim(ref_n), "'"
-                  if (master) call printinfo(msg)
+                  if (master) call printinfo(msg, V_VERBOSE)
                endif
             class is (urc_nbody)
                ! unused at the moment of implementation

--- a/src/grid/refinement/URC_list.F90
+++ b/src/grid/refinement/URC_list.F90
@@ -191,6 +191,7 @@ contains
 
    subroutine summary(this)
 
+      use constants,  only: V_VERBOSE
       use dataio_pub, only: msg, printinfo
       use mpisetup,   only: master
 
@@ -204,9 +205,9 @@ contains
       if (master) then
          if (this%cnt() /= 0) then  ! unfortunately this%cnt() can not be pure due to pointer assignment
             if (first_run) then
-               call printinfo(msg)
+               call printinfo(msg, V_VERBOSE)
             else
-               call printinfo(trim(msg) // " (update)")
+               call printinfo(trim(msg) // " (update)", V_VERBOSE)
             endif
          endif
       endif
@@ -271,7 +272,7 @@ contains
 
    subroutine create_plotfields(this)
 
-      use constants,              only: INVALID, dsetnamelen
+      use constants,              only: INVALID, dsetnamelen, V_VERBOSE
       use dataio_pub,             only: printinfo, msg, warn
       use named_array_list,       only: qna, wna
       use mpisetup,               only: master
@@ -303,7 +304,7 @@ contains
                      write(msg(len_trim(msg)+1:), '(a)') trim(qna%lst(p%iv)%name)
                   endif
                   write(msg(len_trim(msg)+1:), '(3a)') "' is stored in array '", trim(ref_n), "'"
-                  if (master) call printinfo(msg)
+                  if (master) call printinfo(msg, V_VERBOSE)
                endif
             class is (urc_jeans)
                if (p%plotfield .and. p%iplot == INVALID) then
@@ -316,13 +317,13 @@ contains
                if (p%plotfield .and. p%iplot == INVALID) then
                   p%iplot = new_ref_field("nparticles")
                   write(msg, '(3a)') "[URC_list:create_plotfields] particle count criterion is stored in array '", trim(ref_n), "'"
-                  if (master) call printinfo(msg)
+                  if (master) call printinfo(msg, V_VERBOSE)
                endif
             class is (urc_user)
                if (p%plotfield .and. p%iplot == INVALID) then
                   p%iplot = new_ref_field()
                   write(msg, '(3a)') "[URC_list:create_plotfields] user-provided refinement criterion is stored in array '", trim(ref_n), "'"
-                  if (master) call printinfo(msg)
+                  if (master) call printinfo(msg, V_VERBOSE)
                endif
             class default
                if (p%iplot /= INVALID) then

--- a/src/grid/refinement/URC_user.F90
+++ b/src/grid/refinement/URC_user.F90
@@ -102,8 +102,9 @@ contains
 
    function init(user_mark, plotfield) result(this)
 
-      use dataio_pub,       only: printinfo, msg
-      use mpisetup,         only: master
+      use constants,  only: V_INFO
+      use dataio_pub, only: printinfo, msg
+      use mpisetup,   only: master
 
       implicit none
 
@@ -118,7 +119,7 @@ contains
       if (master) then
          write(msg, '(5a,2g13.5,a)')"[URC user]  Initializing user-provided criteria"
          if (plotfield)  write(msg(len_trim(msg)+1:), '(a)') ", with plotfield"
-         call printinfo(msg)
+         call printinfo(msg, V_INFO)
       endif
 
    end function init

--- a/src/grid/refinement/URC_var.F90
+++ b/src/grid/refinement/URC_var.F90
@@ -198,6 +198,7 @@ contains
 
    function init(rf, iv, ic) result(this)
 
+      use constants,        only: V_VERBOSE
       use dataio_pub,       only: printinfo, msg, die, warn
       use func,             only: operator(.notequals.)
       use mpisetup,         only: master
@@ -221,7 +222,7 @@ contains
          else
             write(msg(len_trim(msg)+1:), '(a, i3)') ", qna index: ", iv
          endif
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
          if (present(ic)) then
             if (.not. wna%lst(iv)%vital) call warn("[URC_var:init] 4D field '" // trim(wna%lst(iv)%name) // "' is not vital. Please make sure that the guardcells are properly updater for refinement update.")
          else

--- a/src/grid/refinement/URCgeom_box.F90
+++ b/src/grid/refinement/URCgeom_box.F90
@@ -62,7 +62,7 @@ contains
 
    function init(rp) result(this)
 
-      use constants,  only: base_level_id, ndims, LO, HI
+      use constants,  only: base_level_id, ndims, LO, HI, V_VERBOSE
       use dataio_pub, only: printinfo, msg
       use mpisetup,   only: master
       use refinement, only: ref_box
@@ -82,7 +82,7 @@ contains
       this%ijk_hi = uninit
       if (master) then
          write(msg, '(a,3g13.5,a,3g13.5,a,i3)')"[URC box]   Initializing refinement at box: [ ", this%coords(:, LO), " ]..[ ", this%coords(:, HI), " ] at level ", this%level
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
       endif
 
    end function init

--- a/src/grid/refinement/URCgeom_point.F90
+++ b/src/grid/refinement/URCgeom_point.F90
@@ -61,7 +61,7 @@ contains
 
    function init(rp) result(this)
 
-      use constants,  only: base_level_id, ndims
+      use constants,  only: base_level_id, ndims, V_VERBOSE
       use dataio_pub, only: printinfo, msg
       use mpisetup,   only: master
       use refinement, only: ref_point
@@ -79,7 +79,7 @@ contains
       this%ijk = uninit
       if (master) then
          write(msg, '(a,3g13.5,a,i3)')"[URC point] Initializing refinement at point: [ ", this%coords, " ] at level ", this%level
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
       endif
 
    end function init

--- a/src/grid/refinement/URCgeom_zcyl.F90
+++ b/src/grid/refinement/URCgeom_zcyl.F90
@@ -69,7 +69,7 @@ contains
 
    function init(rp) result(this)
 
-      use constants,  only: base_level_id, ndims, LO, HI
+      use constants,  only: base_level_id, ndims, LO, HI, V_VERBOSE
       use dataio_pub, only: printinfo, msg
       use domain,     only: dom
       use mpisetup,   only: master
@@ -100,7 +100,7 @@ contains
       this%ijk_c  = uninit
       if (master) then
          write(msg, '(a,3g13.5,a,3g13.5,a,i3)')"[URC zcyl]  Initializing cylindrical refinement in a box: [ ", this%coords(:, LO), " ]..[ ", this%coords(:, HI), " ] at level ", this%level
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
       endif
 
    end function init

--- a/src/grid/refinement_update.F90
+++ b/src/grid/refinement_update.F90
@@ -45,7 +45,7 @@ contains
       use cg_cost_data,          only: I_REFINE
       use cg_leaves,             only: leaves
       use cg_list,               only: cg_list_element
-      use constants,             only: I_ONE, pSUM, PPP_AMR, PPP_PROB
+      use constants,             only: I_ONE, pSUM, PPP_AMR, PPP_PROB, V_VERBOSE
       use dataio_pub,            only: msg, printinfo
       use mpisetup,              only: master, piernik_MPI_Allreduce
       use ppp,                   only: ppp_main
@@ -105,7 +105,7 @@ contains
          if (cnt(ubound(cnt, dim=1)) > 0) then
             write(msg,'(a,2i6,a)')"[refinement_update:scan_for_refinements] User routine and URC marked ", &
                  &                cnt(PROBLEM), cnt(PROBLEM+I_ONE:URC)-cnt(PROBLEM:URC-I_ONE), " block(s) for refinement, respectively."
-            if (master) call printinfo(msg)
+            if (master) call printinfo(msg, V_VERBOSE)
          endif
       endif
 
@@ -740,7 +740,7 @@ contains
 
       subroutine print_time(str)
 
-         use constants,  only: tmr_amr
+         use constants,  only: tmr_amr, V_VERBOSE
          use dataio_pub, only: msg, printinfo
          use mpisetup,   only: master
          use timer,      only: set_timer
@@ -750,7 +750,7 @@ contains
          character(len=*), intent(in) :: str
 
          write(msg, '(2a,f7.3)') str, ", dt_wall= ", set_timer(tmr_amr)
-         if (master) call printinfo(msg)
+         if (master) call printinfo(msg, V_VERBOSE)
 
       end subroutine print_time
 
@@ -758,7 +758,7 @@ contains
 
       subroutine log_req
 
-         use constants,  only: pMAX
+         use constants,  only: pMAX, V_DEBUG
          use dataio_pub, only: printinfo, msg
          use mpisetup,   only: master, req, req2, piernik_MPI_Allreduce
 
@@ -775,7 +775,7 @@ contains
          if (cursize > oldsize) then
             if (master) then
                write(msg, *) cursize
-               call printinfo("[refinement_update] Total number of simultaneous nonblocking MPI requests increased to " // trim(adjustl(msg)))
+               call printinfo("[refinement_update] Total number of simultaneous nonblocking MPI requests increased to " // trim(adjustl(msg)), V_DEBUG)
             endif
             oldsize = cursize
          endif

--- a/src/magnetic/divB.F90
+++ b/src/magnetic/divB.F90
@@ -83,7 +83,7 @@ contains
    subroutine print_divB_norm
 
       use cg_leaves,        only: leaves
-      use constants,        only: I_TWO, psi_n
+      use constants,        only: I_TWO, psi_n, V_INFO
       use dataio_pub,       only: printinfo, msg
       use domain,           only: dom
       use mpisetup,         only: master
@@ -103,7 +103,7 @@ contains
          write(msg(len_trim(msg)+1:), '(a,i1,a,g12.5)') " |divB|_", i, "= ", leaves%norm_sq(idivB) / sqrt(dom%Vol)
       enddo
       if (qna%exists(psi_n)) write(msg(len_trim(msg)+1:), '(a,g12.5)') " |psi|= ", leaves%norm_sq(qna%ind(psi_n)) / sqrt(dom%Vol)
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_INFO)
 
    end subroutine print_divB_norm
 

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -63,7 +63,6 @@ contains
 !! <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
 !! <tr><td>level_depth          </td><td>1      </td><td>integer value </td><td>\copydoc multigrid::init_multigrid::level_depth</td></tr>
 !! <tr><td>ord_prolong          </td><td>0      </td><td>integer value </td><td>\copydoc multigridvars::ord_prolong          </td></tr>
-!! <tr><td>mg_stdout            </td><td>.false.</td><td>logical       </td><td>\copydoc multigridvars::mg_stdout            </td></tr>
 !! <tr><td>verbose_vcycle       </td><td>.false.</td><td>logical       </td><td>\copydoc multigridvars::verbose_vcycle       </td></tr>
 !! <tr><td>do_ascii_dump        </td><td>.false.</td><td>logical       </td><td>\copydoc global::do_ascii_dump               </td></tr>
 !! <tr><td>dirty_debug          </td><td>.false.</td><td>logical       </td><td>\copydoc global::dirty_debug                 </td></tr>
@@ -74,12 +73,12 @@ contains
    subroutine multigrid_par
 
       use cg_list_global,      only: all_cg
-      use constants,           only: PIERNIK_INIT_DOMAIN, O_LIN, O_D3, I_ZERO, V_VERBOSE
-      use dataio_pub,          only: warn, die, code_progress, nh, piernik_verbosity
+      use constants,           only: PIERNIK_INIT_DOMAIN, O_LIN, O_D3, I_ZERO
+      use dataio_pub,          only: warn, die, code_progress, nh
       use domain,              only: dom
       use global,              only: dirty_debug, do_ascii_dump, show_n_dirtys !< \warning: alien variables go to local namelist
       use mpisetup,            only: master, slave, nproc, ibuff, lbuff, piernik_MPI_Bcast
-      use multigridvars,       only: single_base, ord_prolong, mg_stdout, verbose_vcycle, tot_ts, v_mg, &
+      use multigridvars,       only: single_base, ord_prolong, verbose_vcycle, tot_ts, &
            &                         source_n, solution_n, defect_n, correction_n, source, solution, defect, correction
       use named_array_list,    only: qna
 #ifdef SELF_GRAV
@@ -93,7 +92,7 @@ contains
 
       logical, save         :: frun = .true.          !< First run flag
 
-      namelist /MULTIGRID_SOLVER/ level_depth, ord_prolong, mg_stdout, verbose_vcycle, do_ascii_dump, dirty_debug, show_n_dirtys
+      namelist /MULTIGRID_SOLVER/ level_depth, ord_prolong, verbose_vcycle, do_ascii_dump, dirty_debug, show_n_dirtys
 
       if (code_progress < PIERNIK_INIT_DOMAIN) call die("[multigrid:multigrid_par] grid, geometry, constants or arrays not initialized")
       ! This check is too weak (geometry), arrays are required only for multigrid_gravity
@@ -106,7 +105,6 @@ contains
       ord_prolong           = O_D3
       show_n_dirtys         = 16
       ! May all the logical parameters be .false. by default
-      mg_stdout             = .false.
       verbose_vcycle        = .false.
       do_ascii_dump         = .false.
       dirty_debug           = .false.
@@ -133,10 +131,9 @@ contains
          ibuff(2) = ord_prolong
          ibuff(3) = show_n_dirtys
 
-         lbuff(1) = mg_stdout
-         lbuff(2) = verbose_vcycle
-         lbuff(3) = do_ascii_dump
-         lbuff(4) = dirty_debug
+         lbuff(1) = verbose_vcycle
+         lbuff(2) = do_ascii_dump
+         lbuff(3) = dirty_debug
 
       endif
 
@@ -145,19 +142,15 @@ contains
 
       if (slave) then
 
-         level_depth           = ibuff(1)
-         ord_prolong           = int(ibuff(2), kind=4)
-         show_n_dirtys         = ibuff(3)
+         level_depth    = ibuff(1)
+         ord_prolong    = int(ibuff(2), kind=4)
+         show_n_dirtys  = ibuff(3)
 
-         mg_stdout        = lbuff(1)
-         verbose_vcycle   = lbuff(2)
-         do_ascii_dump    = lbuff(3)
-         dirty_debug      = lbuff(4)
+         verbose_vcycle = lbuff(1)
+         do_ascii_dump  = lbuff(2)
+         dirty_debug    = lbuff(3)
 
       endif
-
-      v_mg = V_VERBOSE
-      if (mg_stdout) v_mg = max(v_mg, piernik_verbosity)
 
       single_base = (nproc == 1)
 

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -74,12 +74,12 @@ contains
    subroutine multigrid_par
 
       use cg_list_global,      only: all_cg
-      use constants,           only: PIERNIK_INIT_DOMAIN, O_LIN, O_D3, I_ZERO
-      use dataio_pub,          only: warn, die, code_progress, nh
+      use constants,           only: PIERNIK_INIT_DOMAIN, O_LIN, O_D3, I_ZERO, V_VERBOSE
+      use dataio_pub,          only: warn, die, code_progress, nh, piernik_verbosity
       use domain,              only: dom
       use global,              only: dirty_debug, do_ascii_dump, show_n_dirtys !< \warning: alien variables go to local namelist
       use mpisetup,            only: master, slave, nproc, ibuff, lbuff, piernik_MPI_Bcast
-      use multigridvars,       only: single_base, ord_prolong, stdout, verbose_vcycle, tot_ts, &
+      use multigridvars,       only: single_base, ord_prolong, stdout, verbose_vcycle, tot_ts, v_mg, &
            &                         source_n, solution_n, defect_n, correction_n, source, solution, defect, correction
       use named_array_list,    only: qna
 #ifdef SELF_GRAV
@@ -156,11 +156,15 @@ contains
 
       endif
 
+      v_mg = merge(piernik_verbosity, V_VERBOSE, stdout)
+
       stdout = stdout .and. master
 
       single_base = (nproc == 1)
 
+#ifndef DEBUG
       if (dirty_debug .and. master) call warn("[multigrid:multigrid_par] dirty_debug is supposed to be set only in debugging runs. Remember to disable it in production runs")
+#endif /* !DEBUG */
       if (dom%eff_dim < 0 .or. dom%eff_dim > 3) call die("[multigrid:multigrid_par] Unsupported number of dimensions.")
 
 !! \todo Make an array of subroutine pointers
@@ -195,7 +199,7 @@ contains
       use cg_level_coarsest,  only: coarsest
       use cg_level_connected, only: cg_level_connected_t
       use cg_level_finest,    only: finest
-      use constants,          only: PIERNIK_INIT_GRID, I_ONE, refinement_factor
+      use constants,          only: PIERNIK_INIT_GRID, I_ONE, refinement_factor, V_VERBOSE
       use dataio_pub,         only: printinfo, warn, die, code_progress, msg
       use domain,             only: dom, minsize
       use grid_cont,          only: grid_container
@@ -229,7 +233,7 @@ contains
          if (master) then
             if (level_depth /= level_incredible) call warn("[multigrid:init_multigrid] level_depth is too big,")
             write(msg,'(a,i3)')"[multigrid:init_multigrid] Automatically set level_depth = ",j
-            call printinfo(msg)
+            call printinfo(msg, V_VERBOSE)
          endif
          level_depth = j
       endif
@@ -280,7 +284,7 @@ contains
       if (master) then
          write(msg, '(a,i2,a,3i4,a)')"[multigrid:init_multigrid] Initialized ", finest%level%l%id - coarsest%level%l%id, &
               &                      " coarse levels, coarsest level resolution [ ", coarsest%level%l%n_d(:)," ]"
-         call printinfo(msg)
+         call printinfo(msg, V_VERBOSE)
       endif
 
    end subroutine init_multigrid
@@ -353,7 +357,7 @@ contains
 
    subroutine cleanup_multigrid
 
-      use constants,           only: I_ONE
+      use constants,           only: I_ONE, V_LOG
       use dataio_pub,          only: msg, printinfo
       use MPIF,                only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
       use MPIFUN,              only: MPI_Gather
@@ -384,7 +388,7 @@ contains
 
       if (master) then
          write(msg, '(a,3(g11.4,a))')"[multigrid] Spent ", sum(all_ts)/nproc, " seconds in multigrid_solve_* (min= ",minval(all_ts)," max= ",maxval(all_ts),")."
-         call printinfo(msg, .false.)
+         call printinfo(msg, V_LOG)
       endif
 
       if (allocated(all_ts)) deallocate(all_ts)

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -156,7 +156,8 @@ contains
 
       endif
 
-      v_mg = merge(piernik_verbosity, V_VERBOSE, stdout)
+      v_mg = V_VERBOSE
+      if (stdout) v_mg = max(v_mg, piernik_verbosity)
 
       stdout = stdout .and. master
 

--- a/src/multigrid/multigrid.F90
+++ b/src/multigrid/multigrid.F90
@@ -63,7 +63,7 @@ contains
 !! <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
 !! <tr><td>level_depth          </td><td>1      </td><td>integer value </td><td>\copydoc multigrid::init_multigrid::level_depth</td></tr>
 !! <tr><td>ord_prolong          </td><td>0      </td><td>integer value </td><td>\copydoc multigridvars::ord_prolong          </td></tr>
-!! <tr><td>stdout               </td><td>.false.</td><td>logical       </td><td>\copydoc multigridvars::stdout               </td></tr>
+!! <tr><td>mg_stdout            </td><td>.false.</td><td>logical       </td><td>\copydoc multigridvars::mg_stdout            </td></tr>
 !! <tr><td>verbose_vcycle       </td><td>.false.</td><td>logical       </td><td>\copydoc multigridvars::verbose_vcycle       </td></tr>
 !! <tr><td>do_ascii_dump        </td><td>.false.</td><td>logical       </td><td>\copydoc global::do_ascii_dump               </td></tr>
 !! <tr><td>dirty_debug          </td><td>.false.</td><td>logical       </td><td>\copydoc global::dirty_debug                 </td></tr>
@@ -79,7 +79,7 @@ contains
       use domain,              only: dom
       use global,              only: dirty_debug, do_ascii_dump, show_n_dirtys !< \warning: alien variables go to local namelist
       use mpisetup,            only: master, slave, nproc, ibuff, lbuff, piernik_MPI_Bcast
-      use multigridvars,       only: single_base, ord_prolong, stdout, verbose_vcycle, tot_ts, v_mg, &
+      use multigridvars,       only: single_base, ord_prolong, mg_stdout, verbose_vcycle, tot_ts, v_mg, &
            &                         source_n, solution_n, defect_n, correction_n, source, solution, defect, correction
       use named_array_list,    only: qna
 #ifdef SELF_GRAV
@@ -93,7 +93,7 @@ contains
 
       logical, save         :: frun = .true.          !< First run flag
 
-      namelist /MULTIGRID_SOLVER/ level_depth, ord_prolong, stdout, verbose_vcycle, do_ascii_dump, dirty_debug, show_n_dirtys
+      namelist /MULTIGRID_SOLVER/ level_depth, ord_prolong, mg_stdout, verbose_vcycle, do_ascii_dump, dirty_debug, show_n_dirtys
 
       if (code_progress < PIERNIK_INIT_DOMAIN) call die("[multigrid:multigrid_par] grid, geometry, constants or arrays not initialized")
       ! This check is too weak (geometry), arrays are required only for multigrid_gravity
@@ -106,7 +106,7 @@ contains
       ord_prolong           = O_D3
       show_n_dirtys         = 16
       ! May all the logical parameters be .false. by default
-      stdout                = .false.
+      mg_stdout             = .false.
       verbose_vcycle        = .false.
       do_ascii_dump         = .false.
       dirty_debug           = .false.
@@ -133,7 +133,7 @@ contains
          ibuff(2) = ord_prolong
          ibuff(3) = show_n_dirtys
 
-         lbuff(1) = stdout
+         lbuff(1) = mg_stdout
          lbuff(2) = verbose_vcycle
          lbuff(3) = do_ascii_dump
          lbuff(4) = dirty_debug
@@ -149,7 +149,7 @@ contains
          ord_prolong           = int(ibuff(2), kind=4)
          show_n_dirtys         = ibuff(3)
 
-         stdout           = lbuff(1)
+         mg_stdout        = lbuff(1)
          verbose_vcycle   = lbuff(2)
          do_ascii_dump    = lbuff(3)
          dirty_debug      = lbuff(4)
@@ -157,9 +157,7 @@ contains
       endif
 
       v_mg = V_VERBOSE
-      if (stdout) v_mg = max(v_mg, piernik_verbosity)
-
-      stdout = stdout .and. master
+      if (mg_stdout) v_mg = max(v_mg, piernik_verbosity)
 
       single_base = (nproc == 1)
 

--- a/src/multigrid/multigrid_vstats.F90
+++ b/src/multigrid/multigrid_vstats.F90
@@ -101,7 +101,7 @@ contains
       use constants,     only: fplen, fmt_len
       use mpisetup,      only: slave
       use dataio_pub,    only: msg, warn, printinfo
-      use multigridvars, only: stdout
+      use multigridvars, only: v_mg
 
       implicit none
 
@@ -134,7 +134,7 @@ contains
          if (len(msg) >= lm + 9) msg(lm+2:lm+9) = normred(1:8)
       enddo
 
-      call printinfo(msg, stdout)
+      call printinfo(msg, v_mg, .true.)
 
    end subroutine brief_v_log
 

--- a/src/multigrid/multigridvars.F90
+++ b/src/multigrid/multigridvars.F90
@@ -38,7 +38,7 @@
 module multigridvars
 ! pulled by MULTIGRID
 
-   use constants, only: dsetnamelen
+   use constants, only: dsetnamelen, V_VERBOSE
 
    implicit none
 
@@ -54,10 +54,9 @@ module multigridvars
    integer(kind=4) :: source, solution, defect, correction !< indices to the fields described above
 
    ! namelist parameters
-   integer(kind=4)  :: ord_prolong     !< Prolongation operator order; allowed values are -4 -2, 0 (default), 2 and 4; -2 is often fast
-   logical          :: mg_stdout       !< print verbose messages to stdout by increasing their verbosity level to piernik_verbosity
-   logical          :: verbose_vcycle  !< Print one line of log per V-cycle, summary otherwise
-   integer(kind=4)  :: v_mg            !< Multigrid verbosity
+   integer(kind=4)  :: ord_prolong       !< Prolongation operator order; allowed values are -4 -2, 0 (default), 2 and 4; -2 is often fast
+   logical          :: verbose_vcycle    !< Print one line of log per V-cycle, summary otherwise
+   integer(kind=4)  :: v_mg = V_VERBOSE  !< Multigrid verbosity
 
    ! miscellaneous
    real             :: ts                !< time for runtime profiling

--- a/src/multigrid/multigridvars.F90
+++ b/src/multigrid/multigridvars.F90
@@ -55,7 +55,7 @@ module multigridvars
 
    ! namelist parameters
    integer(kind=4)  :: ord_prolong     !< Prolongation operator order; allowed values are -4 -2, 0 (default), 2 and 4; -2 is often fast
-   logical          :: stdout          !< print verbose messages to stdout
+   logical          :: mg_stdout       !< print verbose messages to stdout by increasing their verbosity level to piernik_verbosity
    logical          :: verbose_vcycle  !< Print one line of log per V-cycle, summary otherwise
    integer(kind=4)  :: v_mg            !< Multigrid verbosity
 

--- a/src/multigrid/multigridvars.F90
+++ b/src/multigrid/multigridvars.F90
@@ -57,6 +57,7 @@ module multigridvars
    integer(kind=4)  :: ord_prolong     !< Prolongation operator order; allowed values are -4 -2, 0 (default), 2 and 4; -2 is often fast
    logical          :: stdout          !< print verbose messages to stdout
    logical          :: verbose_vcycle  !< Print one line of log per V-cycle, summary otherwise
+   integer(kind=4)  :: v_mg            !< Multigrid verbosity
 
    ! miscellaneous
    real             :: ts                !< time for runtime profiling

--- a/src/particles/particle_pub.F90
+++ b/src/particles/particle_pub.F90
@@ -58,7 +58,7 @@ contains
 !> \brief Read namelist of particle parameters
    subroutine init_particles
 
-      use constants,     only: I_NGP, I_CIC, I_TSC
+      use constants,     only: I_NGP, I_CIC, I_TSC, V_INFO
       use dataio_pub,    only: msg, die, printinfo, nh
       use mpisetup,      only: master, slave, cbuff, ibuff, lbuff, rbuff, piernik_mpi_bcast
       use particle_func, only: check_ord
@@ -169,7 +169,7 @@ contains
             is_setacc_tsc = .true.
             msg = "[particle_pub:init_particles] Acceleration interpolation method: TSC"
       end select
-      if (master) call printinfo(trim(msg))
+      if (master) call printinfo(trim(msg), V_INFO)
 
    end subroutine init_particles
 

--- a/src/particles/particle_timestep.F90
+++ b/src/particles/particle_timestep.F90
@@ -167,7 +167,7 @@ contains
 
       use cg_leaves,    only: leaves
       use cg_list,      only: cg_list_element
-      use constants,    only: zero, one, two, pMIN
+      use constants,    only: zero, one, two, pMIN, V_VERBOSE
       use dataio_pub,   only: msg, printinfo
       use grid_cont,    only: grid_container
       use mpisetup,     only: piernik_MPI_Allreduce, master
@@ -223,7 +223,7 @@ contains
       endif
 
       write(msg,'(a,3g12.5)') '[particle_timestep:timestep_nbody] dt for hydro, nbody and both: ', dt_hydro, dt_nbody, dt
-      if (master) call printinfo(msg)
+      if (master) call printinfo(msg, V_VERBOSE)
 
 #ifdef VERBOSE
       call printinfo('[particle_timestep:timestep_nbody] Finish timestep_nbody')

--- a/src/particles/particle_utils.F90
+++ b/src/particles/particle_utils.F90
@@ -523,7 +523,7 @@ contains
 
    integer(kind=8) function global_count_all_particles(message) result(gpcount)
 
-      use constants,  only: pSUM, fmt_len
+      use constants,  only: pSUM, fmt_len, V_INFO
       use dataio_pub, only: printinfo, msg
       use mpisetup,   only: piernik_MPI_Allreduce, master
 
@@ -545,7 +545,7 @@ contains
                   fmt = '(2a,i20)'
             end select
             write(msg, fmt) trim(message), " Total number of particles is ", gpcount
-            call printinfo(msg)
+            call printinfo(msg, V_INFO)
          endif
       endif
 

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -234,7 +234,7 @@ contains
    subroutine restart_arrays
 
       use cg_list_global,   only: all_cg
-      use constants,        only: AT_BACKUP, AT_IGNORE, dsetnamelen, INVALID
+      use constants,        only: AT_BACKUP, AT_IGNORE, dsetnamelen, INVALID, V_VERBOSE
       use dataio_pub,       only: printinfo, msg
       use mpisetup,         only: master
       use named_array_list, only: qna, wna
@@ -257,7 +257,7 @@ contains
                   if (.not. na%exists(rname)) then
                      if (master) then
                         write(msg,'(3a)')"[timestep_retry:restart_arrays] creating backup field '", rname, "'"
-                        call printinfo(msg)
+                        call printinfo(msg, V_VERBOSE)
                      endif
                      allocate(pos_copy(size(na%lst(i)%position)))
                      pos_copy = na%lst(i)%position


### PR DESCRIPTION
Reimplementation of printinfo that allows for specifying various stdout verbosity levels.

Default verbosity is reduced, to control the amount of emitted information, use `/OUTPUT_CONTROL/ verbose` parameter. Valid thresholds are: "log", "debug", "verbose", "normal", "essential" and "warning".

Since 7e03ada it is also possible to increase or decrease verbosity level step by step via `msg` file by sending "v+" or "v-" messages.