### PR TITLE
Crdiffusion and benchmarking fixups

### DIFF
--- a/benchmarking/problem.par.crtest
+++ b/benchmarking/problem.par.crtest
@@ -32,6 +32,7 @@
  /
 
  $OUTPUT_CONTROL
+    verbosity = "verbose"
     problem_name = 'cr'
     run_id = 'ben'
     dt_hdf  = 0.0
@@ -61,7 +62,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
  /
 
  $MULTIGRID_DIFFUSION

--- a/benchmarking/problem.par.maclaurin
+++ b/benchmarking/problem.par.maclaurin
@@ -24,6 +24,7 @@
  /
 
  $OUTPUT_CONTROL
+    verbosity = "verbose"
     problem_name ='maclaurin'
     run_id =  'ben'
     dt_hdf  = 0.0
@@ -57,7 +58,6 @@
  /
 
  $MULTIGRID_SOLVER
-    mg_stdout = .true.
  /
 
  $MULTIGRID_GRAVITY

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -253,7 +253,7 @@ contains
       do_external_corners =.false.
       solver_str = ""
 
-      prefer_merged_MPI = .false.  ! non-merged MPI in internal_boundaries are implemented without buffers, which often is faster
+      prefer_merged_MPI = .true.  ! Non-merged MPI in internal_boundaries are implemented without buffers, which can be faster, especially for bsize(:) larger than 3*16, but in some non-periodic setups internal_boundaries_MPI_1by1 has tag collisions, so merged_MPI is currently safer.
 
       if (master) then
 

--- a/src/fluids/cosmicrays/crdiffusion.F90
+++ b/src/fluids/cosmicrays/crdiffusion.F90
@@ -142,7 +142,7 @@ contains
       use cg_level_connected, only: cg_level_connected_t
       use cg_level_finest,    only: finest
       use cg_list,            only: cg_list_element
-      use constants,          only: ndims, xdim, ydim, zdim, LO, HI, BND_PER, BND_MPI, BND_FC, BND_MPI_FC, I_TWO, I_THREE, wcr_n, PPP_CR
+      use constants,          only: ndims, xdim, ydim, zdim, LO, HI, BND_PER, BND_MPI, BND_FC, BND_MPI_FC, I_TWO, I_THREE, wcr_n, PPP_CR, base_level_id
       use dataio_pub,         only: die
       use domain,             only: dom
       use grid_cont,          only: grid_container
@@ -182,8 +182,9 @@ contains
          ! slightly modified copy of cg_leaves::leaf_arr4d_boundaries
          curl => diffl
          do while (associated(curl))
-            call curl%level_4d_boundaries(wcri)
+            call curl%level_4d_boundaries(wcri) ! Do we need to call it below base level? Or on any level that does not have leaves?
             curl => curl%coarser
+            if (curl%l%id < base_level_id) nullify(curl)
          enddo
       endif
 

--- a/src/grid/cg_list_balance.F90
+++ b/src/grid/cg_list_balance.F90
@@ -31,12 +31,11 @@
 
 module cg_list_balance
 
-   use cg_list_bnd,      only: cg_list_bnd_t
-   use constants,        only: ndims, I_ONE
-   use dot,              only: dot_t
-   use level_essentials, only: level_t
-   use patch_list,       only: patch_list_t
-   use sort_piece_list,  only: grid_piece_list
+   use cg_list_bnd,     only: cg_list_bnd_t
+   use constants,       only: ndims, I_ONE
+   use dot,             only: dot_t
+   use patch_list,      only: patch_list_t
+   use sort_piece_list, only: grid_piece_list
 
    implicit none
 
@@ -55,7 +54,6 @@ module cg_list_balance
       type(patch_list_t)                :: plist             !< list of patches that exist on the current level
       type(dot_t)                       :: dot               !< depiction of topology
       logical                           :: recently_changed  !< .true. when anything was added to or deleted from this level
-      class(level_t), pointer           :: l                 !< single place to store off, n_d and id
       type(grid_piece_list)             :: gp                !< SFC-sortable structure for collecting cgs for rebalance
       integer(kind=4), allocatable, dimension(:) :: cnt_all  !< block count for all threads (used in rebalance, only on master)
    contains

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -204,6 +204,9 @@ contains
       !
       ! OPT: at what size of cg%w array (number of components, size of block) one approach wins over another?
       ! it seems that at [5, 16, 16, 16] internal_boundaries_MPI_merged and internal_boundaries_MPI_1by1 have similar performance
+      ! On blocks as large as 32×32×32 cells, the 1-by-1 variant seems to be abit faster. On small blocks (like 8×8×8) it can be twice as slow as MPI_merged.
+      !
+      ! In some non-periodic setups internal_boundaries_MPI_1by1 can have tag collisions on refinements at the boundary, so MPI_merged is currently safer.
 
       if (this%ms%valid .and. (prefer_merged_MPI .or. tgt3d) .and. this%l%id >= base_level_id) then
          call ppp_main%start(ibl_label)

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -45,8 +45,9 @@ module cg_list_bnd
 
 ! pulled by ANY
 
-   use cg_list_dataop, only: cg_list_dataop_t
-   use merge_segments, only: merge_segments_t
+   use cg_list_dataop,   only: cg_list_dataop_t
+   use level_essentials, only: level_t
+   use merge_segments,   only: merge_segments_t
 
    implicit none
 
@@ -62,6 +63,7 @@ module cg_list_bnd
 
    type, extends(cg_list_dataop_t), abstract :: cg_list_bnd_t
       type(merge_segments_t) :: ms                         !< merged segments
+      class(level_t), pointer :: l                         !< single place to store off, n_d and id
    contains
       procedure          :: level_3d_boundaries            !< Perform internal boundary exchanges and external boundary extrapolations on 3D named arrays
       procedure          :: level_4d_boundaries            !< Perform internal boundary exchanges and external boundary extrapolations on 4D named arrays
@@ -166,7 +168,7 @@ contains
 
    subroutine internal_boundaries(this, ind, tgt3d, dir, nocorners)
 
-      use constants,  only: xdim, zdim, cor_dim, PPP_AMR
+      use constants,  only: xdim, zdim, cor_dim, PPP_AMR, base_level_id
       use dataio_pub, only: die
       use domain,     only: dom
       use global,     only: prefer_merged_MPI
@@ -203,7 +205,7 @@ contains
       ! OPT: at what size of cg%w array (number of components, size of block) one approach wins over another?
       ! it seems that at [5, 16, 16, 16] internal_boundaries_MPI_merged and internal_boundaries_MPI_1by1 have similar performance
 
-      if (this%ms%valid .and. (prefer_merged_MPI .or. tgt3d)) then
+      if (this%ms%valid .and. (prefer_merged_MPI .or. tgt3d) .and. this%l%id >= base_level_id) then
          call ppp_main%start(ibl_label)
          call internal_boundaries_local(this, ind, tgt3d, dmask)
          call ppp_main%stop(ibl_label)
@@ -324,7 +326,7 @@ contains
 
    subroutine internal_boundaries_MPI_merged(this, ind, tgt3d, dmask)
 
-      use constants,        only: xdim, ydim, zdim, cor_dim, I_ONE, LO, HI
+      use constants,        only: xdim, ydim, zdim, cor_dim, I_ONE, LO, HI, base_level_id
       use dataio_pub,       only: die
       use merge_segments,   only: IN, OUT
       use MPIF,             only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD
@@ -353,6 +355,7 @@ contains
 #endif /* !MPIF08 */
 
       if (.not. this%ms%valid) call die("[cg_list_bnd:internal_boundaries_MPI_merged] this%ms%valid .eqv. .false.")
+      if (this%l%id < base_level_id .and. .not. tgt3d) call die("[cg_list_bnd:internal_boundaries_MPI_merged] some 4D buffers aren't reliably initialized below base level")
 
       call inflate_req(nproc, .true.)
 


### PR DESCRIPTION
Fixed problems with use of `internal_boundaries_MPI_merged` in setups with CR diffusion.

Fixed problem with benchmarking.