### PR TITLE
Adding a timeout and some diagnostics to MPI_Waitall wrapper

### DIFF
--- a/src/base/cnt_array.F90
+++ b/src/base/cnt_array.F90
@@ -51,6 +51,7 @@ module cnt_array
       procedure :: add      !< add some value to the selected counter
       procedure :: print    !< print the collected values
       procedure, private :: numdigits !< find minimum required field width
+      procedure :: get_v1   !< get vector of counters
    end type arrcnt
 
    type, extends(arrcnt) :: arrsum  ! array of sumators + array of counters
@@ -332,5 +333,28 @@ contains
       endif
 
    end function numdigits
+
+!>
+!! \brief get vector of counters
+!!
+!! An ad-hoc implementation for log_bins. ToDo: generalize it.
+!<
+
+   function get_v1(this)
+
+      use dataio_pub, only: die
+
+      implicit none
+
+      class(arrcnt), intent(in) :: this   !< an object invoking the type-bound procedure
+
+      integer(LONG), dimension(size(this%c1)) :: get_v1
+
+      if (.not. allocated(this%c1)) call die("[cnt_array:get_v1] not allocated")
+
+      get_v1 = this%c1
+
+   end function get_v1
+
 
 end module cnt_array

--- a/src/base/global.F90
+++ b/src/base/global.F90
@@ -45,7 +45,7 @@ module global
         &    dt, dt_initial, dt_max_grow, dt_shrink, dt_cur_shrink, dt_min, dt_max, dt_old, dt_full, dtm, t, t_saved, nstep, nstep_saved, max_redostep_attempts, &
         &    repetitive_steps, integration_order, limiter, limiter_b, smalld, smallei, smallp, use_smalld, use_smallei, interpol_str, &
         &    relax_time, grace_period_passed, cfr_smooth, skip_sweep, geometry25D, &
-        &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, do_external_corners, prefer_merged_MPI, &
+        &    dirty_debug, do_ascii_dump, show_n_dirtys, no_dirty_checks, sweeps_mgu, use_fargo, print_divB, do_external_corners, prefer_merged_MPI, waitall_timeout, &
         &    divB_0_method, cc_mag, glm_alpha, use_eglm, cfl_glm, ch_grid, w_epsilon, psi_bnd, ord_mag_prolong, ord_fluid_prolong, which_solver
 
    logical         :: dn_negative = .false.
@@ -116,8 +116,9 @@ module global
         &                     use_fargo, divB_0, glm_alpha, use_eglm, cfl_glm, ch_grid, interpol_str, w_epsilon, psi_bnd_str, ord_mag_prolong, ord_fluid_prolong, do_external_corners, solver_str
 
    logical :: prefer_merged_MPI  !< prefer internal_boundaries_MPI_merged over internal_boundaries_MPI_1by1
+   real :: waitall_timeout       !< when > 0. then replace MPI_Waitall with MPI_Test* calls and print some diagnostics it the timeout is reached
 
-   namelist /PARALLEL_SETUP/ extra_barriers, prefer_merged_MPI, MPI_wrapper_stats
+   namelist /PARALLEL_SETUP/ extra_barriers, prefer_merged_MPI, MPI_wrapper_stats, waitall_timeout
 
 contains
 
@@ -172,6 +173,7 @@ contains
 !!   <tr><td>prefer_merged_MPI </td><td>.true.  </td><td>logical </td><td>\copydoc global::prefer_merged_MPI      </td></tr>
 !!   <tr><td>extra_barriers    </td><td>.false. </td><td>logical </td><td>\copydoc mpi_wrapper::extra_barriers    </td></tr>
 !!   <tr><td>MPI_wrapper_stats </td><td>.false. </td><td>logical </td><td>\copydoc mpi_wrapper::MPI_wrapper_stats </td></tr>
+!!   <tr><td>waitall_timeout   </td><td>0.      </td><td>real    </td><td>\copydoc mpi_wrapper::waitall_timeout   </td></tr>
 !! </table>
 !! \n \n
 
@@ -181,7 +183,7 @@ contains
       use bcast,      only: piernik_MPI_Bcast
       use constants,  only: big_float, one, PIERNIK_INIT_DOMAIN, INVALID, DIVB_CT, DIVB_HDC, &
            &                BND_INVALID, BND_ZERO, BND_REF, BND_OUT, I_ZERO, O_INJ, O_LIN, O_I2, INVALID, &
-           &                RTVD_SPLIT, HLLC_SPLIT, RIEMANN_SPLIT, GEO_XYZ, V_INFO, V_DEBUG
+           &                RTVD_SPLIT, HLLC_SPLIT, RIEMANN_SPLIT, GEO_XYZ, V_INFO, V_DEBUG, V_ESSENTIAL
       use dataio_pub, only: die, msg, warn, code_progress, printinfo, nh
       use domain,     only: dom
       use mpisetup,   only: cbuff, ibuff, lbuff, rbuff, master, slave
@@ -257,6 +259,7 @@ contains
 
       prefer_merged_MPI = .true.  ! Non-merged MPI in internal_boundaries are implemented without buffers, which can be faster, especially for bsize(:) larger than 3*16, but in some non-periodic setups internal_boundaries_MPI_1by1 has tag collisions, so merged_MPI is currently safer.
       MPI_wrapper_stats = .false.
+      waitall_timeout   = 0.
 
       if (master) then
 
@@ -337,6 +340,7 @@ contains
          rbuff(14) = cfl_glm
          rbuff(15) = w_epsilon
          rbuff(16) = dt_shrink
+         rbuff(17) = waitall_timeout
 
          lbuff(1)   = use_smalld
          lbuff(2)   = use_smallei
@@ -393,6 +397,7 @@ contains
          cfl_glm               = rbuff(14)
          w_epsilon             = rbuff(15)
          dt_shrink             = rbuff(16)
+         waitall_timeout       = rbuff(17)
 
          limiter               = cbuff(1)
          limiter_b             = cbuff(2)
@@ -538,6 +543,11 @@ contains
 
       tstep_attempt = I_ZERO
       dt_cur_shrink = one
+
+      if (waitall_timeout > 0. .and. master) then
+         write(msg, '(a,g0.2,a)')"[global:init_global] Timeout for MPI_Waitall is ", waitall_timeout, " s."
+         call printinfo(msg, V_ESSENTIAL)
+      endif
 
    end subroutine init_global
 

--- a/src/base/log_bins.F90
+++ b/src/base/log_bins.F90
@@ -1,0 +1,171 @@
+!
+! PIERNIK Code Copyright (C) 2006 Michal Hanasz
+!
+!    This file is part of PIERNIK code.
+!
+!    PIERNIK is free software: you can redistribute it and/or modify
+!    it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation, either version 3 of the License, or
+!    (at your option) any later version.
+!
+!    PIERNIK is distributed in the hope that it will be useful,
+!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with PIERNIK.  If not, see <http://www.gnu.org/licenses/>.
+!
+!    Initial implementation of PIERNIK code was based on TVD split MHD code by
+!    Ue-Li Pen
+!        see: Pen, Arras & Wong (2003) for algorithm and
+!             http://www.cita.utoronto.ca/~pen/MHD
+!             for original source code "mhd.f90"
+!
+!    For full list of developers see $PIERNIK_HOME/license/pdt.txt
+!
+#include "piernik.h"
+
+!>
+!! \brief Type for array of logarithmically spaced bins
+!!
+!! \details The logarithmic bins for collecting e.g. Waitall execution time:
+!!
+!! [ < min,                                                   ! first bin
+!!   min .. min * width,                                       ! first regular bin of declared width
+!!   ...,                                                      ! regular bins of declared width
+!!   min * width ** (nbins - 3) .. min * width ** (nbins - 2), ! last regular bin of declared width
+!!   >= min * width ** (nbins - 2) ]                           ! last bin
+!<
+
+module log_bins
+
+   use cnt_array, only: arrcnt
+
+   implicit none
+
+   private
+   public :: lbins
+
+   type :: lbins  ! array of logarithmically spaced bins
+      real, private :: min     !< first bin will contain everything below this value
+      real, private :: lwidth  !< each bin from 2 to (nbins - 1) has this width
+      integer, private :: n    !< remember the size
+      type(arrcnt) :: bins     !< the bins
+      real, dimension(:), allocatable, private :: bnd  !< bin boundaries
+   contains
+      procedure :: init     !< allocate the bins
+      procedure :: cleanup  !< deallocate everything
+      procedure :: put      !< update bin counters according to given value
+      procedure :: print    !< print the bins
+   end type lbins
+
+contains
+
+!> \brief Allocate the array of bins
+
+   recursive subroutine init(this, min, width, n)
+
+      use dataio_pub, only: die
+
+      implicit none
+
+      class(lbins), intent(inout) :: this   !< an object invoking the type-bound procedure
+      real,         intent(in)    :: min    !< set this%min
+      real,         intent(in)    :: width  !< log(width)
+      integer,      intent(in)    :: n      !< the number of bins
+
+      integer :: i
+
+      ! n=2 is an edge case: [ < min, >= min ]
+      if (n < 2) call die("[log_bins:init] nonsense: this is a counter, not bins")
+
+      if (width <= 1.) call die("[log_bins:init] nonsense: width of logarithmic bins has to be > 1.")
+
+      this%min = min
+      this%lwidth = log(width)
+      this%n = n
+      call this%bins%init([n])
+
+      if (allocated(this%bnd)) call die("[log_bins:init] already initialized")
+      allocate(this%bnd(n-1))
+
+      this%bnd = [(this%min * width ** i, i = 0, n - 2)]
+
+   end subroutine init
+
+!> \brief Deallocate everything
+
+   recursive subroutine cleanup(this)
+
+      implicit none
+
+      class(lbins), intent(inout) :: this  !< an object invoking the type-bound procedure
+
+      call this%bins%cleanup
+      if (allocated(this%bnd)) deallocate(this%bnd)
+
+   end subroutine cleanup
+
+!> \brief Add some value to the selected counter
+
+   recursive subroutine put(this, val)
+
+      implicit none
+
+      class(lbins), intent(inout) :: this  !< an object invoking the type-bound procedure
+      real,         intent(in)    :: val   !< value to be used to update bins
+
+      integer :: ind
+
+      ! ToDo: binary search would be faster for large arrays
+      if (val >= this%bnd(ubound(this%bnd, 1))) then
+         ind = this%n
+      else
+         do ind = lbound(this%bnd, 1), ubound(this%bnd, 1)
+            if (val < this%bnd(ind)) exit
+         enddo
+      endif
+
+      call this%bins%incr([ind])
+
+   end subroutine put
+
+!> \brief Print the collected values
+
+   subroutine print(this, title, v)
+
+      use constants,  only: fmt_len, LONG
+      use dataio_pub, only: msg, warn, printinfo
+
+      implicit none
+
+      class(lbins),     intent(in) :: this   !< an object invoking the type-bound procedure
+      character(len=*), intent(in) :: title  !< label for the title
+      integer(kind=4),  intent(in) :: v      !< verbosity level
+
+      integer :: maxn
+      integer(LONG), dimension(this%n) :: bindata
+      character(len=fmt_len) :: fmt  ! for formats like '(a,5(' ',i3,'(',i3,')'))'
+
+      call printinfo(trim(title), v)
+
+      ! Since msg has finite length we may run into errors here for large bin sets.
+      maxn = min(this%n, int(len(msg) / 13.) - 1)  ! 13 is the current width occupied by one entry, with spacing
+      if (maxn < this%n) then
+         write(msg, '(a,2(i0,a))')"[log_bins:print] only first ", maxn, " out of ", this%n, " can be printed"
+         call warn(msg)
+      endif
+
+      write(fmt, '(a,2(i0,a))')"(a,", maxn - 1, "('   ',es8.2))"
+      write(msg, fmt)"    ", this%bnd(1:maxn-1)
+      call printinfo(trim(msg), v)
+
+      write(fmt, '(a,2(i0,a))')"(a,", maxn - 1, "(i8,' | '),i8)"
+      bindata = this%bins%get_v1()
+      write(msg, fmt)"  ", bindata(1:maxn)
+      call printinfo(trim(msg), v)
+
+   end subroutine print
+
+end module log_bins

--- a/src/base/mpi/ppp_mpi.F90
+++ b/src/base/mpi/ppp_mpi.F90
@@ -76,7 +76,7 @@ contains
          if (present(x_mask)) mask = mask + x_mask
          call ppp_main%start(mpiw // ppp_label, mask)
 
-         call this%waitall_wrapper(C_REQA)
+         call this%waitall_wrapper(C_REQA, ppp_label)
 
          call ppp_main%stop(mpiw // ppp_label, mask)
       endif

--- a/src/base/mpi/ppp_mpi.F90
+++ b/src/base/mpi/ppp_mpi.F90
@@ -57,13 +57,10 @@ contains
 
    subroutine waitall_ppp(this, ppp_label, x_mask)
 
-      use barrier,      only: piernik_MPI_Barrier
-      use constants,    only: PPP_MPI, LONG
-      use mpisetup,     only: err_mpi
-      use MPIF,         only: MPI_STATUSES_IGNORE
-      use MPIFUN,       only: MPI_Waitall
-      use ppp,          only: ppp_main
-      use req_array,    only: req_wall, C_REQA
+      use barrier,   only: piernik_MPI_Barrier
+      use constants, only: PPP_MPI
+      use ppp,       only: ppp_main
+      use req_array, only: C_REQA
 
       implicit none
 
@@ -79,10 +76,7 @@ contains
          if (present(x_mask)) mask = mask + x_mask
          call ppp_main%start(mpiw // ppp_label, mask)
 
-         call req_wall%add(int([C_REQA]), int(this%n, kind=LONG))
-
-         call MPI_Waitall(this%n, this%r(:this%n), MPI_STATUSES_IGNORE, err_mpi)
-         this%n = 0
+         call this%waitall_wrapper(C_REQA)
 
          call ppp_main%stop(mpiw // ppp_label, mask)
       endif

--- a/src/base/mpi/req_array.F90
+++ b/src/base/mpi/req_array.F90
@@ -76,6 +76,8 @@ module req_array
       enumerator :: C_REQA = 1, C_REQS  ! for both req% waitall methods
    end enum
 
+   real :: longest_wall  ! find the extreme Waital completion time
+
    integer(kind=4) :: err_mpi  !< error status
 
 contains
@@ -93,6 +95,8 @@ contains
       integer :: nbins
       real :: mx_b
 
+      longest_wall = 0.
+
       call req_wall%init(int([C_REQS]))
 
       ! assume sane values of min_bin, def_max_bin, binwidth and waitall_timeout
@@ -106,15 +110,24 @@ contains
 
    subroutine cleanup_wall
 
-      use constants,    only: V_DEBUG
+      use constants,    only: V_DEBUG, I_ONE
+      use dataio_pub,   only: printinfo, msg
       use mpi_wrappers, only: MPI_wrapper_stats
       use mpisetup,     only: master
+      use MPIF,         only: MPI_IN_PLACE, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD
+      use MPIFUN,       only: MPI_Allreduce
 
       implicit none
 
-      if (master .and. MPI_wrapper_stats) then
-         call req_wall%print("Waitall requests(calls). Columns: req_all%, req_some%.", V_DEBUG)
-         call tbins_wall%print("Waitall execution times (bin boundaries in seconds)", V_DEBUG)
+      if (MPI_wrapper_stats) then
+         call MPI_Allreduce(MPI_IN_PLACE, longest_wall, I_ONE, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, err_mpi)
+
+         if (master) then
+            call req_wall%print("Waitall requests(calls). Columns: req_all%, req_some%.", V_DEBUG)
+            call tbins_wall%print("Waitall execution times (bin boundaries in seconds)", V_DEBUG)
+            write(msg, '(a,g0.2,a)')"Longest completion of MPI_Waitall took ", longest_wall, " s (max over all processes)"
+            call printinfo(msg, V_DEBUG)
+         endif
       endif
 
       call req_wall%cleanup
@@ -189,19 +202,27 @@ contains
 
       class(req_arr), intent(inout) :: this  !< an object invoking the type-bound procedure
 
-      call this%waitall_wrapper(C_REQS, "???")
+      call this%waitall_wrapper(C_REQS, "_" // trim(this%tags%label) // "_")
       call this%cleanup
 
    end subroutine waitall_on_some
 
-!> \brief Code common for waitall_on_some and req_ppp::waitall_ppp
+!>
+!! \brief Code common for waitall_on_some and req_ppp::waitall_ppp
+!!
+!! \details Use positive waitall_timeout if you experienced deadlocks in your runs.
+!! With waitall_timeout > 0. this routine won't call MPI_Waitall, which is blocking
+!! but will use nonblocking MPI_Test* calls instead. Chances are that some useful hints
+!! will be printed on the stdout instead of going into silent deadlock.
+!<
 
    subroutine waitall_wrapper(this, ind, label)
 
-      use constants, only: LONG
-      use global,    only: waitall_timeout
-      use MPIF,      only: MPI_STATUSES_IGNORE, MPI_Wtime
-      use MPIFUN,    only: MPI_Waitall
+      use constants,  only: LONG, I_ONE, V_ESSENTIAL
+      use dataio_pub, only: warn, msg, die, printinfo
+      use global,     only: waitall_timeout
+      use MPIF,       only: MPI_STATUSES_IGNORE, MPI_STATUS_IGNORE, MPI_INTEGER_KIND, MPI_UNDEFINED, MPI_Wtime
+      use MPIFUN,     only: MPI_Waitall, MPI_Testsome, MPI_Test
 
       implicit none
 
@@ -211,7 +232,13 @@ contains
 
       logical, save :: firstcall = .true.
       real :: t0, dtw
+      integer(kind=MPI_INTEGER_KIND), dimension(:), allocatable :: inds
+      integer(kind=MPI_INTEGER_KIND) :: tcnt, cnt_prev
+      integer(kind=4) :: i
+      logical(kind=4) :: flag, warn10, fs, fr
+      logical, allocatable, dimension(:) :: tflag
 
+      ! The initialization had to be delayed because waitall_timeout is initialized in module global, which is a bit late.
       if (firstcall) then
          call init_wall
          firstcall = .false.
@@ -219,16 +246,165 @@ contains
 
       if (this%n > 0) then
 
+         warn10 = .false.
          call req_wall%add(int([ind]), int(this%n, kind=LONG))
-         if (waitall_timeout > 0.) then
-         endif
          t0 = MPI_Wtime()
-         call MPI_Waitall(this%n, this%r(:this%n), MPI_STATUSES_IGNORE, err_mpi)
+         if (waitall_timeout > 0.) then  ! complete requests in a non-blocking way, print somediagnostics if completion is slow
+            allocate(inds(this%n))
+            inds(:) = -1
+
+            ! First quickly check if there are already completed requests
+            tcnt = 0
+            do i = 1, this%n
+               call MPI_Test(this%r(i), flag, MPI_STATUS_IGNORE, err_mpi)
+               if (flag) then
+                  tcnt = tcnt + I_ONE
+                  inds(tcnt) = i
+               endif
+            enddo
+
+            ! Look for remaining requests
+            do while (tcnt < this%n)
+
+               if (tcnt /= MPI_UNDEFINED) cnt_prev = tcnt
+               tcnt = MPI_UNDEFINED
+
+               ! If we're exceeding 0.1 * waitall_timeout then is starts to be fishy: either too short waitall_timeout was set or we're going to to get a deadlock
+               dtw = MPI_Wtime() - t0
+               if (dtw > 0.1 * waitall_timeout .and. .not. warn10) then
+                  write(msg, '(2(a,i0),a)')"[req_array:waitall_wrapper] MPI_Testsome progress at 1/10 timeout: ", cnt_prev, " out of ", this%n, " '" // trim(label) // "'"
+                  call printinfo(msg, V_ESSENTIAL)
+                  warn10 = .true.
+               endif
+
+               ! Test remaining requests
+               call MPI_Testsome(this%n, this%r(:this%n), tcnt, inds(cnt_prev+1:), MPI_STATUSES_IGNORE, err_mpi)
+               if ((tcnt < 0 .and. tcnt /= MPI_UNDEFINED) .or. cnt_prev < 0. .or. err_mpi /= 0) then
+                  write(msg, '(a,4(" ",i0),a)')"[req_array:waitall_wrapper] MPI_Testsome failing?", tcnt, cnt_prev, this%n, err_mpi, " '" // trim(label) // "'"
+                  call die(msg)
+               endif
+
+               if (tcnt /= MPI_UNDEFINED) tcnt = cnt_prev + tcnt
+
+               ! If waitall_timeout was exceeded then die with some meaningful messages
+               if ((tcnt == MPI_UNDEFINED .or. tcnt < this%n) .and. dtw > waitall_timeout) then
+                  call set_tflag
+                  call sleep(1)
+                  fs = one_more_test(this%tags%ts)
+                  fr = one_more_test(this%tags%tr) ! make sure that both are executed
+                  if (fs .or. fr) then
+                     ! waitall_timeout was set too short
+                     write(msg, '(a,f0.3,a)')"[req_array:waitall_wrapper] Late completions detected. Increase waitall to at least ", max(1. + waitall_timeout, 2. * waitall_timeout), " s"
+                     call warn(msg)
+                  endif
+                  deallocate(tflag)
+
+                  if ((tcnt == MPI_UNDEFINED .or. tcnt < this%n) .and. dtw > waitall_timeout) then
+                     call set_tflag
+                     call print_details(this%tags%ts, "ISend ")
+                     call print_details(this%tags%tr, "IRecv ")
+                     deallocate(tflag)
+                     write(msg, '(2(a,i0),a,g0.2,a)')"[req_array:waitall_wrapper] only ", merge(tcnt, cnt_prev, tcnt /= MPI_UNDEFINED), " out of ", this%n, &
+                          " requests completed in ", dtw, "s (timeout, '" // trim(label) // "')"
+                     call sleep(3)  ! give the other processes a chance to print their state
+                     call die(msg)
+                  endif
+               endif
+
+            enddo
+            deallocate(inds)
+         else
+            ! This is perhaps faster but gives no clue when deadlock occur
+            call MPI_Waitall(this%n, this%r(:this%n), MPI_STATUSES_IGNORE, err_mpi)
+         endif
          dtw = MPI_Wtime() - t0
          call tbins_wall%put(dtw)
+         if (dtw > longest_wall) longest_wall = dtw
+
          this%n = 0
 
       endif
+
+   contains
+
+      subroutine set_tflag
+
+         implicit none
+
+         allocate(tflag(this%n))
+         tflag = .false.
+         do i = 1, this%n
+            if (inds(i) > -1) then
+               if (inds(i) >= lbound(tflag, 1) .and. inds(i) <= ubound(tflag, 1)) &
+                    tflag(inds(i)) = .true.
+            endif
+         enddo
+
+      end subroutine set_tflag
+
+      subroutine print_details(ta, l)
+
+         use tag_array, only: tag_arr
+
+         implicit none
+
+         type(tag_arr),    intent(in) :: ta
+         character(len=*), intent(in) :: l
+
+         integer :: p, i
+
+         if (allocated(ta%t)) then
+            write(msg, '(2a,2(i0,a))') trim(l) // " '" // trim(this%tags%label), "', procs: [ ", lbound(ta%t), " : ", ubound(ta%t), " ] "
+            call printinfo(msg, V_ESSENTIAL)
+            do p = lbound(ta%t, 1), ubound(ta%t, 1)
+               if (allocated(ta%t(p)%list)) then
+                  write(msg, '(a,3(a,i0))') trim(l) // " '" // trim(this%tags%label), "', checking requests [ ", ta%t(p)%l_bound(), " : ", ta%t(p)%u_bound(), " ] for proc# ", p
+                  call printinfo(msg, V_ESSENTIAL)
+                  do i = ta%t(p)%l_bound(), ta%t(p)%u_bound()
+
+                     ! Print the unfinished requests
+                     if (.not. tflag(ta%t(p)%list(i)%ir)) then
+                        write(msg, '(2a,4(i0,a))') trim(l) // " '" // trim(this%tags%label), "', unfinished with proc ", p, " request ", i, " : ( tag: ", ta%t(p)%list(i)%tag, " , req# ", ta%t(p)%list(i)%ir, " )"
+                        call printinfo(msg, V_ESSENTIAL)
+                     endif
+
+                  enddo
+               endif
+            enddo
+         endif
+
+      end subroutine print_details
+
+      logical function one_more_test(ta)
+
+         use tag_array, only: tag_arr
+
+         implicit none
+
+         type(tag_arr),    intent(in) :: ta
+
+         integer :: p, i
+
+         one_more_test = .false.
+
+         if (allocated(ta%t)) then
+            do p = lbound(ta%t, 1), ubound(ta%t, 1)
+               if (allocated(ta%t(p)%list)) then
+                  do i = ta%t(p)%l_bound(), ta%t(p)%u_bound()
+                     ! Do one more test, just in case
+                     call MPI_Test(this%r(ta%t(p)%list(i)%ir), flag, MPI_STATUS_IGNORE, err_mpi)
+                     if (flag .neqv. tflag(ta%t(p)%list(i)%ir)) then
+                        one_more_test = .true.
+                        tcnt = tcnt + I_ONE
+                        inds(tcnt) = ta%t(p)%list(i)%ir
+                        ! we can return here, but let's go through remaining MPI_Test calls, just in case
+                     endif
+                  enddo
+               endif
+            enddo
+         endif
+
+      end function one_more_test
 
    end subroutine waitall_wrapper
 

--- a/src/base/mpi/req_array.F90
+++ b/src/base/mpi/req_array.F90
@@ -178,6 +178,7 @@ contains
    subroutine waitall_wrapper(this, ind)
 
       use constants, only: LONG
+      use global,    only: waitall_timeout
       use MPIF,      only: MPI_STATUSES_IGNORE
       use MPIFUN,    only: MPI_Waitall
 
@@ -189,6 +190,8 @@ contains
       if (this%n > 0) then
 
          call req_wall%add(int([ind]), int(this%n, kind=LONG))
+         if (waitall_timeout > 0.) then
+         endif
          call MPI_Waitall(this%n, this%r(:this%n), MPI_STATUSES_IGNORE, err_mpi)
          this%n = 0
 

--- a/src/base/mpi/wrapper_stats.F90
+++ b/src/base/mpi/wrapper_stats.F90
@@ -45,14 +45,14 @@ contains
       use barrier,      only: init_bar
       use bcast,        only: init_bcast
       use isend_irecv,  only: init_sr
-      use req_array,    only: init_wall
+!      use req_array,    only: init_wall
 
       implicit none
 
       call init_allreduce
       call init_bcast
       call init_sr
-      call init_wall
+      ! call init_wall  ! will be auto-initialized when necessary
       call init_bar
 
    end subroutine init_wstats
@@ -65,7 +65,7 @@ contains
       use barrier,      only: cleanup_bar
       use bcast,        only: cleanup_bcast
       use constants,    only: stdout, V_DEBUG
-      use dataio_pub,   only: piernik_verbosity
+      use dataio_pub,   only: piernik_verbosity, printinfo
       use isend_irecv,  only: cleanup_sr
       use mpisetup,     only: master
       use req_array,    only: cleanup_wall
@@ -75,6 +75,7 @@ contains
       ! Be nice to the stream of finalization dots on stdout
       if (master .and. (piernik_verbosity <= V_DEBUG)) write(stdout,'()')
 
+      if (master) call printinfo("Collected conters (for master only):", V_DEBUG)
       call cleanup_allreduce
       call cleanup_bcast
       call cleanup_sr


### PR DESCRIPTION
Implemented `waitall_timeout` parameter. If it is set to positive amount of seconds, then Piernik will call MPI_Test* routines instead of MPI_Waitall and after the time expires will print unfinished transactions and Abort execution.

Can be useful for debugging deadlicks.