### PR TITLE
Field names in named_array_list

### DIFF
--- a/bin/qa.py
+++ b/bin/qa.py
@@ -10,8 +10,8 @@ typ1 = np.dtype([('name', 'S50'), ('beg', 'i'), ('end', 'i'), ('type', 'S4')])
 # starts with spaces or spaces and one of { 'end', 'pure', ... }
 # if function it can have a type next goes subroutine or function or type
 test_for_routines = re.compile(r'''
-      ^\s{0,12}(|end|pure|elemental|recursive|((type|real|logical|integer)(|\([^(]*\))))(|\s)
-      (|pure|elemental|recursive|((type|real|logical|integer)(|\([^(]*\))))(|\s)
+      ^\s{0,12}(|end|impure|pure|elemental|recursive|((type|real|logical|integer)(|\([^(]*\))))(|\s)
+      (|impure|pure|elemental|recursive|((type|real|logical|integer)(|\([^(]*\))))(|\s)
       (subroutine|function|type(,|\s))
    ''', re.VERBOSE)
 # starts with spaces or spaces and one of { 'end', 'pure', ... }

--- a/jenkins/gold_configs/mcrtest_CRESP.config
+++ b/jenkins/gold_configs/mcrtest_CRESP.config
@@ -1,7 +1,8 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=aca398c6924df3eb7c01907e2938483242e5ee1c
+GOLD_COMMIT=649dd5c68b7da35b96de30b87244e3aa5fb64a5a
 
+# 649dd5c68b7da35b96de30b87244e3aa5fb64a5a - small change that was causing a 6e-29 discrepancy in gdf_diff
 # aca398c6924df3eb7c01907e2938483242e5ee1c - fixed bug in common_hdf5
 # 6d0b571fef22a8a87bb3ee12a53d771fc63e6d2c – new gold_test.sh script and major change in configuration on Jenkins
 # 74978ace728553380b355791e33d8e7c25586869 – changed arr_dim to speed up this gold test

--- a/problems/fargo_test/initproblem.F90
+++ b/problems/fargo_test/initproblem.F90
@@ -98,7 +98,7 @@ contains
 
       integer(kind=4) :: dim4 !< BEWARE: workaround for gcc-4.6 bug
 
-      dim4 = wna%lst(wna%fi)%dim4
+      dim4 = wna%get_dim4(wna%fi)
       call all_cg%reg_var(inid_n, restart_mode = AT_NO_B, dim4 = dim4)
 
    end subroutine register_user_var

--- a/problems/streaming_global/initproblem.F90
+++ b/problems/streaming_global/initproblem.F90
@@ -100,7 +100,7 @@ contains
 
       integer(kind=4) :: dim4 !< BEWARE: workaround for gcc-4.6 bug
 
-      dim4 = wna%lst(wna%fi)%dim4
+      dim4 = wna%get_dim4(wna%fi)
       call all_cg%reg_var(inid_n, restart_mode = AT_NO_B, dim4 = dim4)
 
    end subroutine register_user_var

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -111,7 +111,6 @@ contains
       use mpisetup,       only: master
 #ifdef COSM_RAYS
       use cr_data,        only: cr_names, cr_spectral
-      use dataio_pub,     only: msg
 #endif /* COSM_RAYS */
 #ifdef CRESP
       use initcosmicrays, only: ncrb
@@ -223,10 +222,8 @@ contains
                enddo
                do k = lbound(vars, 1), ubound(vars, 1)
                   if (vars(k) .eq. 'cree') exit
-                  if (k .eq. ubound(vars, 1)) then
-                     write(msg, '(a)')"[common_hdf5:init_hdf5] CRESP 'cren' field created, but 'cree' not defined: reconstruction of spectrum from hdf files requires both."
-                     call warn(msg)
-                  endif
+                  if (k .eq. ubound(vars, 1)) &
+                     call warn("[common_hdf5:init_hdf5] CRESP 'cren' field created, but 'cree' not defined: reconstruction of spectrum from hdf files requires both.")
                enddo
             case ('cree') !< CRESP energy density fields
                do k = 1, ncrb
@@ -235,10 +232,8 @@ contains
                enddo
                do k = lbound(vars, 1), ubound(vars, 1)
                   if (vars(k) .eq. 'cren') exit
-                  if (k .eq. ubound(vars, 1)) then
-                     write(msg, '(a)')"[common_hdf5:init_hdf5] CRESP 'cree' field created, but 'cren' not defined: reconstruction of spectrum from hdf files requires both."
-                     call warn(msg)
-                  endif
+                  if (k .eq. ubound(vars, 1)) &
+                     call warn("[common_hdf5:init_hdf5] CRESP 'cree' field created, but 'cren' not defined: reconstruction of spectrum from hdf files requires both.")
                enddo
             case ('cref') !< CRESP distribution function
                do k = 1, ncrb+1

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -123,10 +123,21 @@ contains
 
       integer                                              :: i
       character(len=singlechar)                            :: fc, ord
-      character(len=dsetnamelen)                           :: aux
+      character(len=dsetnamelen)                           :: aux, ifmt
 #ifdef COSM_RAYS
       integer                                              :: k, ke
 #endif /* COSM_RAYS */
+
+      i = 10  ! Let the default counter be 2-digit wide
+#ifdef COSM_RAYS
+      i = max(i, size(cr_names))
+#endif /* COSM_RAYS */
+#ifdef CRESP
+      i = max(i, ncrb + 1)
+#endif /* CRESP */
+      write(ifmt, '(i9)') i
+      i = len_trim(adjustl(ifmt))  ! convert max number of components into number of required digits
+      write(ifmt,'("i",i1,".",i1,")")') i, i  ! this would fail when i > 9 but the code would fail for billions of components anyway
 
       if (.not. allocated(hdf_vars)) allocate(hdf_vars(0))
 
@@ -199,26 +210,16 @@ contains
                      call append_var(aux)
                   else
                      ke = k - count(cr_spectral)
-                     if (ke <= 99) then
-                        write(aux,'(A2,I2.2)') 'cr', ke
-                        call append_var(aux)
-                     else
-                        write(msg, '(a,i3)')"[common_hdf5:init_hdf5] Cannot create name for CR energy component #", ke
-                        call warn(msg)
-                     endif
+                     write(aux,'(A2,' // ifmt // ')') 'cr', ke
+                     call append_var(aux)
                   endif
                enddo
 #endif /* COSM_RAYS */
 #ifdef CRESP
             case ('cren') !< CRESP number density fields
                do k = 1, ncrb
-                  if (k<=99) then
-                     write(aux,'(A3,a,A1,I2.2)') 'cr_','e-','n', k
-                     call append_var(aux)
-                  else
-                     write(msg, '(a,i3)')"[common_hdf5:init_hdf5] Cannot create name for CRESP number density component #", k
-                     call warn(msg)
-                  endif
+                  write(aux,'(A3,a,A1,' // ifmt // ')') 'cr_','e-','n', k
+                  call append_var(aux)
                enddo
                do k = lbound(vars, 1), ubound(vars, 1)
                   if (vars(k) .eq. 'cree') exit
@@ -229,13 +230,8 @@ contains
                enddo
             case ('cree') !< CRESP energy density fields
                do k = 1, ncrb
-                  if (k<=99) then
-                     write(aux,'(A3,a,A1,I2.2)') 'cr_','e-','e', k
-                     call append_var(aux)
-                  else
-                     write(msg, '(a,i3)')"[common_hdf5:init_hdf5] Cannot create name for CRESP energy density component #", k
-                     call warn(msg)
-                  endif
+                  write(aux,'(A3,a,A1,' // ifmt // ')') 'cr_','e-','e', k
+                  call append_var(aux)
                enddo
                do k = lbound(vars, 1), ubound(vars, 1)
                   if (vars(k) .eq. 'cren') exit
@@ -246,33 +242,18 @@ contains
                enddo
             case ('cref') !< CRESP distribution function
                do k = 1, ncrb+1
-                  if (k<=99) then
-                     write(aux,'(A4,I2.2)') 'cref', k
-                     call append_var(aux)
-                  else
-                     write(msg, '(a,i3)')"[common_hdf5:init_hdf5] Cannot create name for CRESP distribution function component #", k
-                     call warn(msg)
-                  endif
+                  write(aux,'(A4,' // ifmt // ')') 'cref', k
+                  call append_var(aux)
                enddo
             case ('crep') !< CRESP cutoff momenta
                do k = 1, 2
-                  if (k<=99) then
-                     write(aux,'(A4,I2.2)') 'crep', k
-                     call append_var(aux)
-                  else
-                     write(msg, '(a,i3)')"[common_hdf5:init_hdf5] Cannot create name for CRESP cutoff momentum component #", k
-                     call warn(msg)
-                  endif
+                  write(aux,'(A4,' // ifmt // ')') 'crep', k
+                  call append_var(aux)
                enddo
             case ('creq') !< CRESP spectrum index
                do k = 1, ncrb
-                  if (k<=99) then
-                     write(aux,'(A4,I2.2)') 'creq', k
-                     call append_var(aux)
-                  else
-                     write(msg, '(a,i3)')"[common_hdf5:init_hdf5] Cannot create name for CRESP spectrum index component #", k
-                     call warn(msg)
-                  endif
+                  write(aux,'(A4,' // ifmt // ')') 'creq', k
+                  call append_var(aux)
                enddo
 #endif /* CRESP */
             case default

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -117,11 +117,13 @@ contains
          case ("magdir")
             f%fu = "\rm{radians}"
 #ifdef COSM_RAYS
+         ! ToDo: Adopt for wider range
          case ("cr01" : "cr99")
             f%fu = "\rm{erg}/\rm{cm}^3"
             f%f2cgs = 1.0 / (erg/cm**3)
 #endif /* COSM_RAYS */
 #ifdef CRESP
+         ! ToDo: Adopt for wider range
          case ("cr_e-n01" : "cr_e-n99")
             f%fu = "1/\rm{cm}^3"
             f%f2cgs = 1.0 / (1.0/cm**3) ! number density
@@ -338,10 +340,11 @@ contains
 #endif /* MAGNETIC */
 #ifdef CRESP
       use initcrspectrum,   only: dfpq
-      use named_array_list, only: wna
 #endif /* CRESP */
 #ifdef COSM_RAYS
       use cr_data,          only: cr_names, cr_spectral
+      use dataio_pub,       only: die, warn, msg
+      use named_array_list, only: wna, na_var_4d
 #endif /* COSM_RAYS */
 #ifndef ISO
       use units,            only: kboltz, mH
@@ -358,14 +361,14 @@ contains
       integer(kind=4)                                :: i_xyz
       integer                                        :: ii, jj, kk
 #ifdef COSM_RAYS
+      integer(kind=4)                                :: clast
       integer                                        :: i
       integer, parameter                             :: auxlen = dsetnamelen - 1
       character(len=auxlen)                          :: aux
+      character(len=I_TWO)                           :: varn2
 #endif /* COSM_RAYS */
 #ifdef CRESP
-      character(len=I_TWO)                           :: varn2
       integer                                        :: ibin
-      integer(kind=4)                                :: clast
 #endif /* CRESP */
 
       call common_shortcuts(var, fl_dni, i_xyz)
@@ -390,11 +393,33 @@ contains
          case ("cr01" : "cr99")
             read(var,'(A2,I2.2)') aux, i !> \deprecated BEWARE 0 <= i <= 99, no other indices can be dumped to hdf file
             tab(:,:,:) = cg%u(flind%crn%beg+i-1, RNG)
+            select type(l => wna%lst(wna%fi))
+               class is (na_var_4d)
+                  if (trim(var) /= trim(l%compname(flind%crn%beg+i-1))) then
+                     write(msg, '(5a,i3)') "cr_01-99 '", trim(var), "' /= '", trim(l%compname(flind%crn%beg+i-1)), "' ", i
+                     call warn(msg)
+                  endif
+               class default
+                  call die("[datafields_hdf5] 'cr01-99' not a na_var_4d")
+            end select
          case ('cr_A000' : 'cr_zz99')
             do i = 1, size(cr_names)
                if (var == trim('cr_' // cr_names(i))) exit
             enddo
             tab(:,:,:) = cg%u(flind%crn%beg+i-1-count(cr_spectral), RNG)
+            select type(l => wna%lst(wna%fi))
+               class is (na_var_4d)
+                  clast = len(trim(var), kind=4)
+                  varn2 = var(clast - 1:clast)
+                  if (all(var(clast - 2:clast - 2) /= ['e', 'n'])) then
+                     if (trim(var) /= trim(l%compname(flind%crn%beg+i-1-count(cr_spectral)))) then
+                        write(msg, '(5a,i3)') "cr_A-zz '", trim(var), "' /= '", trim(l%compname(flind%crn%beg+i-1)), "' ", i
+                        call warn(msg)
+                     endif
+                  endif
+               class default
+                  call die("[datafields_hdf5] 'cr_A-zz' not a na_var_4d")
+            end select
 #endif /* COSM_RAYS */
 #ifdef CRESP
             clast = len(trim(var), kind=4)
@@ -405,6 +430,15 @@ contains
 
                read (varn2,'(I2.2)') ibin
                tab(:,:,:) = cg%u(flind%cre%ebeg+ibin-1, RNG)
+               select type(l => wna%lst(wna%fi))
+                  class is (na_var_4d)
+                     if (trim(var) /= trim(l%compname(flind%cre%ebeg+ibin-1))) then
+                        write(msg, '(5a,i3)') "cr_e '", trim(var), "' /= '", trim(l%compname(flind%cre%ebeg+ibin-1)), "' ", ibin
+                        call warn(msg)
+                     endif
+                  class default
+                     call die("[datafields_hdf5] 'cr_e' not a na_var_4d")
+               end select
 
             else if (var(clast - 2:clast - 2) == 'n') then
 
@@ -412,6 +446,15 @@ contains
 
                read (varn2,'(I2.2)') ibin
                tab(:,:,:) = cg%u(flind%cre%nbeg+ibin-1, RNG)
+               select type(l => wna%lst(wna%fi))
+                  class is (na_var_4d)
+                     if (trim(var) /= trim(l%compname(flind%cre%nbeg+ibin-1))) then
+                        write(msg, '(5a,i3)') "cr_n '", trim(var), "' /= '", trim(l%compname(flind%cre%nbeg+ibin-1)), "' ", ibin
+                        call warn(msg)
+                     endif
+                  class default
+                     call die("[datafields_hdf5] 'cr_n' not a na_var_4d")
+               end select
             endif
 
          case ("cren01" : "cren99")

--- a/src/IO/hdf5/restart_hdf5_v1.F90
+++ b/src/IO/hdf5/restart_hdf5_v1.F90
@@ -232,7 +232,7 @@ contains
          area_type = qna%lst(ind)%restart_mode
       else
          if (ind < lbound(wna%lst(:), dim=1) .or. ind > ubound(wna%lst(:), dim=1)) call die("[restart_hdf5_v1:write_arr_to_restart] Invalid 4D array")
-         dim1 = wna%lst(ind)%dim4
+         dim1 = wna%get_dim4(ind)
          rank = rank4
          dname = wna%lst(ind)%name
          area_type = wna%lst(ind)%restart_mode
@@ -341,7 +341,7 @@ contains
       implicit none
 
       integer(HID_T),             intent(in) :: file_id            !< File identifier
-      integer,                    intent(in) :: ind                !< index of cg%q(:) or cg%w(:) arrays
+      integer(kind=4),            intent(in) :: ind                !< index of cg%q(:) or cg%w(:) arrays
       logical,                    intent(in) :: tgt3d              !< .true. for 3D arrays, .false. otherwise
       integer(kind=4),  optional, intent(in) :: alt_area_type
       character(len=*), optional, intent(in) :: alt_name           !< used only in galdisk* setups
@@ -373,7 +373,7 @@ contains
          area_type = qna%lst(ind)%restart_mode
       else
          if (ind < lbound(wna%lst(:), dim=1) .or. ind > ubound(wna%lst(:), dim=1)) call die("[restart_hdf5_v1:read_arr_from_restart] Invalid 4D array")
-         dim1 = wna%lst(ind)%dim4
+         dim1 = wna%get_dim4(ind)
          rank = rank4
          cgname = wna%lst(ind)%name
          area_type = wna%lst(ind)%restart_mode
@@ -498,7 +498,7 @@ contains
       implicit none
 
       integer                                  :: nu
-      integer                                  :: i
+      integer(kind=4)                          :: i
       character(len=cwdlen)                    :: filename      !< File name
 
       integer(HID_T)                           :: file_id       !< File identifier

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -146,7 +146,7 @@ contains
       integer(kind=8),               intent(in) :: n_part
       integer(HID_T),                intent(in) :: st_g_id
 
-      integer :: i
+      integer(kind=4) :: i
       integer(HSIZE_T), dimension(:), allocatable :: d_size
       character(len=*), parameter :: wrce_label = "IO_write_empty_dset"
 
@@ -155,7 +155,7 @@ contains
 
       allocate(d_size(size(cg_n_b)))
       if (allocated(qna%lst)) then
-         do i = lbound(qna%lst(:), dim=1), ubound(qna%lst(:), dim=1)
+         do i = lbound(qna%lst(:), dim=1, kind=4), ubound(qna%lst(:), dim=1, kind=4)
             if (qna%lst(i)%restart_mode == AT_OUT_B) then
                d_size = int(cg_n_o, kind=HSIZE_T)
             else
@@ -169,11 +169,11 @@ contains
 
       allocate(d_size(size(cg_n_b)+I_ONE))
       if (allocated(wna%lst)) then
-         do i = lbound(wna%lst(:), dim=1), ubound(wna%lst(:), dim=1)
+         do i = lbound(wna%lst(:), dim=1, kind=4), ubound(wna%lst(:), dim=1, kind=4)
             if (wna%lst(i)%restart_mode == AT_OUT_B) then
-               d_size = int([ wna%lst(i)%dim4, cg_n_o ], kind=HSIZE_T)
+               d_size = int([ wna%get_dim4(i), cg_n_o ], kind=HSIZE_T)
             else
-               d_size = int([ wna%lst(i)%dim4, cg_n_b ], kind=HSIZE_T)
+               d_size = int([ wna%get_dim4(i), cg_n_b ], kind=HSIZE_T)
             endif
             if (wna%lst(i)%restart_mode > AT_IGNORE) &  ! create "/data/grid_%08d/wna%lst(i)%name"
                  call create_empty_cg_dataset(cg_g_id, wna%lst(i)%name, d_size, Z_avail, O_RES)
@@ -190,7 +190,7 @@ contains
       call ppp_main%stop(wrce_label, PPP_IO + PPP_CG)
 
       return
-      if (.false.) i = int(n_part) + int(st_g_id)
+      if (.false.) i = int(n_part, kind=4) + int(st_g_id, kind=4)
 
    end subroutine create_empty_cg_datasets_in_restart
 
@@ -233,7 +233,7 @@ contains
       integer(kind=4)                                       :: ncg, n, i, ntags
       type(grid_container),  pointer                        :: cg
       type(cg_list_element), pointer                        :: cgl
-      integer, allocatable, dimension(:)                    :: qr_lst, wr_lst
+      integer(kind=4), allocatable, dimension(:)            :: qr_lst, wr_lst
       type(cg_output)                                       :: cg_desc
       character(len=dsetnamelen), dimension(:), allocatable :: dsets
       real, target, dimension(0,0,0)                        :: null_r3d
@@ -300,10 +300,10 @@ contains
                      if (cg_desc%cg_src_p(ncg) == proc) then
                         cg => get_nth_cg(cg_desc%cg_src_n(ncg))
                         pa4d => cg%w(wr_lst(i))%span(pick_area(cg, wna%lst(wr_lst(i))%restart_mode))
-                        dims(:) = [ wna%lst(wr_lst(i))%dim4, cg%n_b ]
+                        dims(:) = [ wna%get_dim4(wr_lst(i)), cg%n_b ]
                      else
                         n_b = pick_size(ncg, wna%lst(wr_lst(i))%restart_mode)
-                        allocate(pa4d(wna%lst(wr_lst(i))%dim4, n_b(xdim), n_b(ydim), n_b(zdim)))
+                        allocate(pa4d(wna%get_dim4(wr_lst(i)), n_b(xdim), n_b(ydim), n_b(zdim)))
                         call MPI_Recv(pa4d(:,:,:,:), size(pa4d(:,:,:,:), kind=4), MPI_DOUBLE_PRECISION, cg_desc%cg_src_p(ncg), &
                            ncg + cg_desc%tot_cg_n*(size(qr_lst, kind=4)+i), MPI_COMM_WORLD, MPI_STATUS_IGNORE, err_mpi)
                         dims(:) = shape(pa4d)
@@ -368,7 +368,7 @@ contains
                   do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
                      ic = ic + 1
                      pa4d => cg%w(wr_lst(i))%span(pick_area(cg, wna%lst(wr_lst(i))%restart_mode))
-                     dims(:) = [ wna%lst(wr_lst(i))%dim4, pick_dims(cg, wna%lst(wr_lst(i))%restart_mode) ]
+                     dims(:) = [ wna%get_dim4(wr_lst(i)), pick_dims(cg, wna%lst(wr_lst(i))%restart_mode) ]
                      call h5dwrite_f(cg_desc%dset_id(ncg, ic), H5T_NATIVE_DOUBLE, pa4d, dims, error, xfer_prp = cg_desc%xfer_prp)
                   enddo
                   deallocate(dims)
@@ -995,7 +995,7 @@ contains
       integer(kind=8), dimension(xdim:zdim)        :: own_off_nb, restart_off_nb, o_size_nb   !
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: own_box_ob, restart_box_ob              ! variants for AT_OUT_B
       integer(kind=8), dimension(xdim:zdim)        :: own_off_ob, restart_off_ob, o_size_ob   ! as opposed to AT_NO_B
-      integer, dimension(:), allocatable           :: qr_lst, wr_lst
+      integer(kind=4), dimension(:), allocatable   :: qr_lst, wr_lst
       integer                                      :: i
       real, dimension(:,:,:),   allocatable        :: a3d
       real, dimension(:,:,:,:), allocatable        :: a4d
@@ -1070,7 +1070,7 @@ contains
          allocate(dims(ndims+1), off(ndims+1), cnt(ndims+1))
          do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
             call pick_off_and_size(wna%lst(wr_lst(i))%restart_mode, o_size, restart_off, own_off)
-            dims(:) = [ int(wna%lst(wr_lst(i))%dim4, kind=HSIZE_T), int(o_size(:), kind=HSIZE_T) ]
+            dims(:) = [ int(wna%get_dim4(wr_lst(i)), kind=HSIZE_T), int(o_size(:), kind=HSIZE_T) ]
             call h5dopen_f(cg_g_id, wna%lst(wr_lst(i))%name, dset_id, error)
             call h5dget_space_f(dset_id, filespace, error)
             off(:) = [ 0_HSIZE_T, restart_off(:) ]

--- a/src/base/func.F90
+++ b/src/base/func.F90
@@ -39,7 +39,7 @@ module func
 
    private
    public :: ekin, emag, L2norm, sq_sum3, resample_gauss, piernik_fnum, &
-      & append_int_to_array, operator(.equals.), operator(.notequals.)
+      & append_int_to_array, append_int4_to_array, operator(.equals.), operator(.notequals.)
 
    interface operator (.equals.)
       module procedure float_equals
@@ -198,6 +198,28 @@ contains
       arr(ubound(arr(:))) = i
 
    end subroutine append_int_to_array
+
+!> \brief Expand given integer(kind=4) array by one and store the value i in the last cell
+
+   subroutine append_int4_to_array(arr, i)
+
+      implicit none
+
+      integer(kind=4), dimension(:), allocatable, intent(inout) :: arr
+      integer(kind=4),                            intent(in)    :: i
+
+      integer(kind=4), allocatable, dimension(:) :: tmp
+
+      if (allocated(arr)) then
+         allocate(tmp(lbound(arr(:), dim=1):ubound(arr(:), dim=1) + 1))
+         tmp(:ubound(arr(:), dim=1)) = arr(:)
+         call move_alloc(from=tmp, to=arr)
+      else
+         allocate(arr(1))
+      endif
+      arr(ubound(arr(:))) = i
+
+   end subroutine append_int4_to_array
 
 !>
 !! \brief An operator for avoiding direct comparision with floats (like 0.), because gfortran is complaining about that.

--- a/src/base/named_array_list.F90
+++ b/src/base/named_array_list.F90
@@ -51,6 +51,8 @@ module named_array_list
                                                                   !< AT_OUT_B write with ext. boundaries
       integer(kind=4)                            :: ord_prolong   !< Prolongation order for the variable
       logical                                    :: multigrid     !< .true. for variables that may exist below base level (e.g. work fields for multigrid solver)
+   contains
+      procedure :: copy_base
    end type na_var_base
 
    type, extends(na_var_base) :: na_var
@@ -355,6 +357,21 @@ contains
 
    end subroutine print_vars
 
+   subroutine copy_base(this, other)
+
+      implicit none
+
+      class(na_var_base), intent(out) :: this   !< object to be copied to
+      class(na_var_base), intent(in)  :: other  !< object to be copied from
+
+      this%name = other%name
+      this%vital = other%vital
+      this%restart_mode = other%restart_mode
+      this%ord_prolong = other%ord_prolong
+      this%multigrid = other%multigrid
+
+   end subroutine copy_base
+
    subroutine copy_var(this, other)
 
       implicit none
@@ -362,11 +379,7 @@ contains
       class(na_var), intent(out) :: this   !< object to be copied to
       type(na_var),  intent(in)  :: other  !< object to be copied from
 
-      this%name = other%name
-      this%vital = other%vital
-      this%restart_mode = other%restart_mode
-      this%ord_prolong = other%ord_prolong
-      this%multigrid = other%multigrid
+      call this%copy_base(other)
 
    end subroutine copy_var
 
@@ -381,12 +394,8 @@ contains
 
       integer :: i
 
-      this%name = other%name
-      this%vital = other%vital
-      this%restart_mode = other%restart_mode
-      this%ord_prolong = other%ord_prolong
+      call this%copy_base(other)
       this%dim4 = other%dim4
-      this%multigrid = other%multigrid
 
       if (allocated(this%compname)) deallocate(this%compname)
 

--- a/src/base/named_array_list.F90
+++ b/src/base/named_array_list.F90
@@ -490,6 +490,10 @@ contains
          enddo
       endif
 
+      do i = lbound(this%compname(:), dim=1), ubound(this%compname(:), dim=1)
+         if (trim(compname) == this%compname(i)) &
+            call die("[named_array_list:set_compname] component name collision '" // trim(compname) // "'")
+      enddo
       this%compname(iw) = compname
 
    end subroutine set_compname

--- a/src/base/named_array_list.F90
+++ b/src/base/named_array_list.F90
@@ -443,7 +443,7 @@ contains
       if (iw < 1 .or. iw > this%dim4) &
          call die("[named_array_list:get_compname] Invalid component index")
 
-      write(fmt, '(i2)') this%dim4
+      write(fmt, '(i9)') this%dim4
       num_digits = len_trim(adjustl(fmt))
       write(fmt, '("(a,i",i1,".",i1,")")') num_digits, num_digits
 

--- a/src/fluids/cosmicrays/multigrid_diffusion.F90
+++ b/src/fluids/cosmicrays/multigrid_diffusion.F90
@@ -321,9 +321,11 @@ contains
       use dataio_pub,        only: msg, printinfo, warn
       use fluidindex,        only: flind
       use func,              only: operator(.notequals.)
+      use initcosmicrays,    only: iarr_crs
       use mpisetup,          only: master
       use multigrid_helpers, only: all_dirty
       use multigridvars,     only: ts, tot_ts
+      use named_array_list,  only: wna
       use timer,             only: set_timer
 
       implicit none
@@ -340,7 +342,7 @@ contains
          call init_source(cr_id)
          if (vstat%norm_rhs .notequals. zero) then
             if (norm_was_zero(cr_id) .and. master) then
-               write(msg,'(a,i2.2,a)')"[multigrid_diffusion:multigrid_solve_diff] CR-fluid #", cr_id, " is now available in measurable quantities."
+               write(msg,'(a)')"[multigrid_diffusion:multigrid_solve_diff] CR-fluid '" // trim(wna%get_component_name(wna%fi, iarr_crs(cr_id))) // "' is now available in measurable quantities."
                call printinfo(msg)
             endif
             norm_was_zero(cr_id) = .false.
@@ -351,7 +353,7 @@ contains
             ! enddo
          else
             if (.not. norm_was_zero(cr_id) .and. master) then
-               write(msg,'(a,i2.2,a)')"[multigrid_diffusion:multigrid_solve_diff] Source norm of CR-fluid #", cr_id, " == 0., skipping."
+               write(msg,'(a)')"[multigrid_diffusion:multigrid_solve_diff] Source norm of CR-fluid '" // trim(wna%get_component_name(wna%fi, iarr_crs(cr_id))) // "' == 0., skipping."
                call warn(msg)
             endif
             norm_was_zero(cr_id) = .true.
@@ -545,7 +547,7 @@ contains
          endif
       endif
 
-      write(vstat%cprefix,'("C",i2.2)') cr_id
+      vstat%cprefix = trim(wna%get_component_name(wna%fi, iarr_crs(cr_id))) // "-"
       write(dirty_label, '("md_",i2.2,"_dump")')  cr_id
 
 #ifdef DEBUG

--- a/src/grid/cg_list_bnd.F90
+++ b/src/grid/cg_list_bnd.F90
@@ -378,18 +378,18 @@ contains
                      endif
                   enddo
                else
-                  allocate(slin%buf(slin%total_size*wna%lst(ind)%dim4))
-                  allocate(slout%buf(slout%total_size*wna%lst(ind)%dim4))
+                  allocate(slin%buf(slin%total_size*wna%get_dim4(ind)))
+                  allocate(slout%buf(slout%total_size*wna%get_dim4(ind)))
                   do i = lbound(slout%list, dim=1), slout%cur_last
                      if (dmask( slout%list(i)%dir)) then
                         slout%buf( &
-                            (slout%list(i)%offset - I_ONE) * wna%lst(ind)%dim4 + I_ONE : &
-                             slout%list(i)%off_ceil        * wna%lst(ind)%dim4 ) = reshape( &
-                             slout%list(i)%cg%w(ind)%arr( 1:wna%lst(ind)%dim4, &
+                            (slout%list(i)%offset - I_ONE) * wna%get_dim4(ind) + I_ONE : &
+                             slout%list(i)%off_ceil        * wna%get_dim4(ind) ) = reshape( &
+                             slout%list(i)%cg%w(ind)%arr(  1:wna%get_dim4(ind), &
                              slout%list(i)%se(xdim, LO):slout%list(i)%se(xdim, HI), &
                              slout%list(i)%se(ydim, LO):slout%list(i)%se(ydim, HI), &
                              slout%list(i)%se(zdim, LO):slout%list(i)%se(zdim, HI)), &
-                             [ (slout%list(i)%off_ceil - slout%list(i)%offset + I_ONE) * wna%lst(ind)%dim4 ] )
+                             [ (slout%list(i)%off_ceil - slout%list(i)%offset + I_ONE) * wna%get_dim4(ind) ] )
                      endif
                   enddo
                endif
@@ -426,14 +426,14 @@ contains
                   do i = lbound(slin%list, dim=1), slin%cur_last
                      associate (li => slin%list(i))
                      if (dmask( li%dir)) then
-                        li%cg%w(ind)%arr( 1:wna%lst(ind)%dim4, &
+                        li%cg%w(ind)%arr( 1:wna%get_dim4(ind), &
                              li%se(xdim, LO):li%se(xdim, HI), &
                              li%se(ydim, LO):li%se(ydim, HI), &
                              li%se(zdim, LO):li%se(zdim, HI)) = reshape ( &
                              slin%buf( &
-                            (li%offset - I_ONE) * wna%lst(ind)%dim4 + I_ONE : &
-                             li%off_ceil        * wna%lst(ind)%dim4 ), [ &
-                             int(wna%lst(ind)%dim4, kind=8), &
+                            (li%offset - I_ONE) * wna%get_dim4(ind) + I_ONE : &
+                             li%off_ceil        * wna%get_dim4(ind) ), [ &
+                             int(wna%get_dim4(ind), kind=8), &
                              li%se(xdim, HI) - li%se(xdim, LO) + I_ONE, &
                              li%se(ydim, HI) - li%se(ydim, LO) + I_ONE, &
                              li%se(zdim, HI) - li%se(zdim, LO) + I_ONE ] )
@@ -543,13 +543,13 @@ contains
 
                      else
 
-                        b4su = [ int(wna%lst(ind)%dim4, kind=4), int(i_seg%se(:, HI) - i_seg%se(:, LO) + I_ONE, kind=4) ]
+                        b4su = [ int(wna%get_dim4(ind), kind=4), int(i_seg%se(:, HI) - i_seg%se(:, LO) + I_ONE, kind=4) ]
                         b4st = [ I_ONE, int(i_seg%se(:, LO), kind=4) ] - lbound(cg%w(ind)%arr, kind=4)
                         call MPI_Type_create_subarray(rank4, b4sz, b4su, b4st, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, i_seg%sub_type, err_mpi)
                         call MPI_Type_commit(i_seg%sub_type, err_mpi)
                         call piernik_Irecv(cg%w(ind)%arr(lbound(cg%w(ind)%arr, 1):, lbound(cg%w(ind)%arr, 2):, lbound(cg%w(ind)%arr, 3):, lbound(cg%w(ind)%arr, 4):), I_ONE, i_seg%sub_type, i_seg%proc, i_seg%tag, req)
 
-                        b4su = [ int(wna%lst(ind)%dim4, kind=4), int(o_seg%se(:, HI) - o_seg%se(:, LO) + I_ONE, kind=4) ]
+                        b4su = [ int(wna%get_dim4(ind), kind=4), int(o_seg%se(:, HI) - o_seg%se(:, LO) + I_ONE, kind=4) ]
                         b4st = [ I_ONE, int(o_seg%se(:, LO), kind=4) ] - lbound(cg%w(ind)%arr, kind=4)
                         call MPI_Type_create_subarray(rank4, b4sz, b4su, b4st, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, o_seg%sub_type, err_mpi)
                         call MPI_Type_commit(o_seg%sub_type, err_mpi)

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -776,7 +776,7 @@ contains
       enddo
 
       do iw = lbound(wna%lst, dim=1, kind=4), ubound(wna%lst, dim=1, kind=4)
-         do iv = 1, wna%lst(iw)%dim4
+         do iv = 1, wna%get_dim4(iv)
             call this%check_dirty(iw, label, expand=expand, subfield=iv, warn_only=warn_only)
          enddo
       enddo
@@ -799,7 +799,7 @@ contains
       implicit none
 
       class(cg_list_dataop_t),   intent(inout) :: this      !< level which we are checking
-      integer(kind=4),           intent(in)    :: iv        !< index of variable in cg%q(:) which we want to check
+      integer(kind=4),           intent(in)    :: iv        !< index of variable in cg%q(:) or cg%w(:) which we want to check
       character(len=*),          intent(in)    :: label     !< label to indicate the origin of call
       integer(kind=4), optional, intent(in)    :: expand    !< also check guardcells
       integer(kind=4), optional, intent(in)    :: subfield  !< when present use it to check cg%w array
@@ -812,7 +812,7 @@ contains
 
       if (present(subfield)) then
          if (iv < lbound(wna%lst, dim=1) .or. iv > ubound(wna%lst, dim=1)) call die("[cg_list_dataop:check_dirty] Invalid w-variable index.")
-         if (subfield < 1 .or. subfield > wna%lst(iv)%dim4) call die("[cg_list_dataop:check_dirty] Invalid w-variable component.")
+         if (subfield < 1 .or. subfield > wna%get_dim4(iv)) call die("[cg_list_dataop:check_dirty] Invalid w-variable component.")
       else
          if (iv < lbound(qna%lst, dim=1) .or. iv > ubound(qna%lst, dim=1)) call die("[cg_list_dataop:check_dirty] Invalid q-variable index.")
       endif

--- a/src/grid/cg_list_dataop.F90
+++ b/src/grid/cg_list_dataop.F90
@@ -812,7 +812,8 @@ contains
 
       if (present(subfield)) then
          if (iv < lbound(wna%lst, dim=1) .or. iv > ubound(wna%lst, dim=1)) call die("[cg_list_dataop:check_dirty] Invalid w-variable index.")
-         if (subfield < 1 .or. subfield > wna%get_dim4(iv)) call die("[cg_list_dataop:check_dirty] Invalid w-variable component.")
+         if (subfield < 1) call die("[cg_list_dataop:check_dirty] w-variable component < 1.")
+         if (subfield > wna%get_dim4(iv)) call die("[cg_list_dataop:check_dirty] w-variable component too big.")
       else
          if (iv < lbound(qna%lst, dim=1) .or. iv > ubound(qna%lst, dim=1)) call die("[cg_list_dataop:check_dirty] Invalid q-variable index.")
       endif

--- a/src/grid/cg_list_global.F90
+++ b/src/grid/cg_list_global.F90
@@ -130,7 +130,7 @@ contains
       use dataio_pub,       only: die, warn, msg
       use domain,           only: dom
       use memory_usage,     only: check_mem_usage
-      use named_array_list, only: qna, wna, na_var
+      use named_array_list, only: qna, wna, na_var, na_var_4d
 
       implicit none
 
@@ -187,7 +187,7 @@ contains
       endif
 
       if (present(dim4)) then
-         call wna%add2lst(na_var(name, vit, rm, op, d4, mg))
+         call wna%add2lst(na_var_4d(name, vit, rm, op, d4, mg))
       else
          call qna%add2lst(na_var(name, vit, rm, op, d4, mg))
       endif

--- a/src/grid/cg_list_global.F90
+++ b/src/grid/cg_list_global.F90
@@ -187,9 +187,9 @@ contains
       endif
 
       if (present(dim4)) then
-         call wna%add2lst(na_var(name, vit, rm, op, pos, d4, mg))
+         call wna%add2lst(na_var(name, vit, rm, op, d4, mg))
       else
-         call qna%add2lst(na_var(name, vit, rm, op, pos, d4, mg))
+         call qna%add2lst(na_var(name, vit, rm, op, d4, mg))
       endif
 
       select case (op)

--- a/src/grid/grid_container_na.F90
+++ b/src/grid/grid_container_na.F90
@@ -133,9 +133,10 @@ contains
 
       if (allocated(wna%lst)) then
          do i = lbound(wna%lst(:), dim=1), ubound(wna%lst(:), dim=1)
-            call this%add_na_4d(wna%lst(i)%dim4)
+            call this%add_na_4d(wna%get_dim4(int(i, kind=4)))
          enddo
       endif
+
       call check_mem_usage
 
       ! shortcuts

--- a/src/grid/rebalance.F90
+++ b/src/grid/rebalance.F90
@@ -474,7 +474,7 @@ contains
       cgl => base%level%first
       if (associated(cgl)) then
          do p = lbound(wna%lst, dim=1, kind=4), ubound(wna%lst, dim=1, kind=4)
-            if ((.not. only_vital .or. wna%lst(p)%vital) .and. associated(cgl%cg%w(p)%arr)) totfld = totfld + wna%lst(p)%dim4
+            if ((.not. only_vital .or. wna%lst(p)%vital) .and. associated(cgl%cg%w(p)%arr)) totfld = totfld + wna%get_dim4(p)
          enddo
          do p = lbound(qna%lst, dim=1, kind=4), ubound(qna%lst, dim=1, kind=4)
             if ((.not. only_vital .or. qna%lst(p)%vital) .and. associated(cgl%cg%q(p)%arr)) totfld = totfld + 1
@@ -536,8 +536,8 @@ contains
                         s = lbound(cglepa(i)%tbuf, dim=1)
                         do p = lbound(wna%lst, dim=1, kind=4), ubound(wna%lst, dim=1, kind=4)
                            if ((.not. only_vital .or. wna%lst(p)%vital) .and. associated(cgl%cg%w(p)%arr)) then ! not associated for multigrid coarse levels
-                              cglepa(i)%tbuf(s:s+wna%lst(p)%dim4-1, :, :, :) = cgl%cg%w(p)%arr(:, :, :, :)
-                              s = s + wna%lst(p)%dim4
+                              cglepa(i)%tbuf(s:s+wna%get_dim4(p)-1, :, :, :) = cgl%cg%w(p)%arr(:, :, :, :)
+                              s = s + wna%get_dim4(p)
                            endif
                         enddo
                         do p = lbound(qna%lst, dim=1, kind=4), ubound(qna%lst, dim=1, kind=4)
@@ -639,8 +639,8 @@ contains
                   s = lbound(cglepa(i)%tbuf, dim=1)
                   do p = lbound(wna%lst, dim=1, kind=4), ubound(wna%lst, dim=1, kind=4)
                      if ((.not. only_vital .or. wna%lst(p)%vital) .and. associated(cgl%cg%w(p)%arr)) then
-                        cgl%cg%w(p)%arr(:, :, :, :) = cglepa(i)%tbuf(s:s+wna%lst(p)%dim4-1, :, :, :)
-                        s = s + wna%lst(p)%dim4
+                        cgl%cg%w(p)%arr(:, :, :, :) = cglepa(i)%tbuf(s:s+wna%get_dim4(p)-1, :, :, :)
+                        s = s + wna%get_dim4(p)
                      endif
                   enddo
                   do p = lbound(qna%lst, dim=1, kind=4), ubound(qna%lst, dim=1, kind=4)

--- a/src/multigrid/multigrid_vstats.F90
+++ b/src/multigrid/multigrid_vstats.F90
@@ -32,12 +32,12 @@
 module multigrid_vstats
 ! pulled by MULTIGRID
 
+   use constants, only: dsetnamelen
+
    implicit none
 
    private
    public :: vcycle_stats
-
-   integer, parameter :: prefix_len = 3              !< length of prefix for distinguishing V-cycles in the log
 
    type :: vcycle_stats
       real, allocatable, dimension(:) :: factor      !< norm reduction factor
@@ -45,7 +45,7 @@ module multigrid_vstats
       integer                         :: count       !< number of executed V-cycles
       real                            :: norm_rhs    !< norm of the source
       real                            :: norm_final  !< norm of the defect relative to the source
-      character(len=prefix_len)       :: cprefix     !< prefix for distinguishing V-cycles in the log (e.g inner or outer potential, CR component)
+      character(len=dsetnamelen)      :: cprefix     !< prefix for distinguishing V-cycles in the log (e.g inner or outer potential, CR component)
    contains
       procedure :: init                              !< Initialize vcycle_stats
       procedure :: brief_v_log                       !< Assembles one-line log of V-cycle achievements

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -279,23 +279,23 @@ contains
    subroutine restart_arrays
 
       use cg_list_global,   only: all_cg
-      use constants,        only: AT_BACKUP, AT_IGNORE, dsetnamelen, INVALID, V_VERBOSE
-      use dataio_pub,       only: printinfo, msg
+      use constants,        only: AT_BACKUP, AT_IGNORE, dsetnamelen, V_VERBOSE
+      use dataio_pub,       only: printinfo, msg, die
       use mpisetup,         only: master
-      use named_array_list, only: qna, wna
+      use named_array_list, only: qna, wna, na_var_list_q, na_var_list_w
 
       implicit none
 
-      integer :: i, j
+      integer(kind=4) :: i, j
       character(len=dsetnamelen) :: rname
 
       if (.not. associated(na_lists(1)%p)) na_lists(1)%p => qna
       if (.not. associated(na_lists(2)%p)) na_lists(2)%p => wna
 
-      do j = lbound(na_lists, dim=1), ubound(na_lists, dim=1)
+      do j = lbound(na_lists, dim=1, kind=4), ubound(na_lists, dim=1, kind=4)
          associate (na => na_lists(j)%p)
 
-            do i = lbound(na%lst(:), dim=1), ubound(na%lst(:), dim=1)
+            do i = lbound(na%lst(:), dim=1, kind=4), ubound(na%lst(:), dim=1, kind=4)
                if (na%lst(i)%restart_mode > AT_IGNORE) then
                   rname = get_rname(na%lst(i)%name)
                   if (.not. na%exists(rname)) then
@@ -303,11 +303,14 @@ contains
                         write(msg,'(3a)')"[timestep_retry:restart_arrays] creating backup field '", rname, "'"
                         call printinfo(msg, V_VERBOSE)
                      endif
-                     if (na%lst(i)%dim4 /= INVALID) then
-                        call all_cg%reg_var(rname, dim4=na%lst(i)%dim4, multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
-                     else
-                        call all_cg%reg_var(rname,                      multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
-                     endif
+                     select type(na)
+                        type is (na_var_list_w)
+                           call all_cg%reg_var(rname, dim4=na%get_dim4(i), multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
+                        type is (na_var_list_q)
+                           call all_cg%reg_var(rname,                      multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
+                        class default
+                           call die("[timestep_retry:restart_arrays] unknown named array list type")
+                     end select
                   endif
                endif
             enddo

--- a/src/scheme/timestep_retry.F90
+++ b/src/scheme/timestep_retry.F90
@@ -288,7 +288,6 @@ contains
 
       integer :: i, j
       character(len=dsetnamelen) :: rname
-      integer(kind=4), dimension(:), allocatable, target :: pos_copy
 
       if (.not. associated(na_lists(1)%p)) na_lists(1)%p => qna
       if (.not. associated(na_lists(2)%p)) na_lists(2)%p => wna
@@ -304,14 +303,11 @@ contains
                         write(msg,'(3a)')"[timestep_retry:restart_arrays] creating backup field '", rname, "'"
                         call printinfo(msg, V_VERBOSE)
                      endif
-                     allocate(pos_copy(size(na%lst(i)%position)))
-                     pos_copy = na%lst(i)%position
                      if (na%lst(i)%dim4 /= INVALID) then
-                        call all_cg%reg_var(rname, dim4=na%lst(i)%dim4, position=pos_copy, multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
+                        call all_cg%reg_var(rname, dim4=na%lst(i)%dim4, multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
                      else
-                        call all_cg%reg_var(rname,                      position=pos_copy, multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
+                        call all_cg%reg_var(rname,                      multigrid=na%lst(i)%multigrid, restart_mode = AT_BACKUP)
                      endif
-                     deallocate(pos_copy)
                   endif
                endif
             enddo


### PR DESCRIPTION
The types defined in `named_array_list` can also hold the names of individual fields in case of rank-4 arrays (such as `cg%w`. This should make it easier to handle the multitude of CR species.