### PR TITLE
Fix for CRESP nonconvergence

### DIFF
--- a/jenkins/gold_configs/mcrtest_CRESP.config
+++ b/jenkins/gold_configs/mcrtest_CRESP.config
@@ -1,7 +1,8 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=649dd5c68b7da35b96de30b87244e3aa5fb64a5a
+GOLD_COMMIT=1aefd3395554cb51389944837ba48eafc8ee46a7
 
+# 1aefd3395554cb51389944837ba48eafc8ee46a7 - fix for nonconvergence due to uninitialized variables
 # 649dd5c68b7da35b96de30b87244e3aa5fb64a5a - small change that was causing a 6e-29 discrepancy in gdf_diff
 # aca398c6924df3eb7c01907e2938483242e5ee1c - fixed bug in common_hdf5
 # 6d0b571fef22a8a87bb3ee12a53d771fc63e6d2c – new gold_test.sh script and major change in configuration on Jenkins

--- a/src/fluids/cosmicrays/cresp_NR_method.F90
+++ b/src/fluids/cosmicrays/cresp_NR_method.F90
@@ -769,6 +769,8 @@ contains
       real, dimension(1:2)                :: x_vec_0, x_vec, delta, x_in
       integer(kind=4)                     :: nsubstep = 100, k
 
+      exit_code = .true.  ! Ensure always set
+
       ! alpha and n are set !
 
       if (minval(p3(1:2)) > tiny(zero) .and. p3(3) <= zero) then ! sometimes NaNs and numbers of order e-317 appear; must be looked into
@@ -878,6 +880,8 @@ contains
       real, dimension(1:2), intent(inout) :: prev_solution
       logical,              intent(out)   :: exit_code
       real, dimension(1:2)                :: x_vec
+
+      exit_code = .true.  ! Ensure always set
 
       x_vec = prev_solution
       call NR_algorithm(x_vec, exit_code)

--- a/src/fluids/cosmicrays/cresp_NR_method.F90
+++ b/src/fluids/cosmicrays/cresp_NR_method.F90
@@ -991,6 +991,7 @@ contains
       real,    intent(inout) :: x
       logical, intent(out)   :: exit_code
 
+      exit_code = .false.
       if (abs(x) >= q_big) then
          x = sign(one, x) * q_big
          exit_code = .true.


### PR DESCRIPTION
Some use of uninitialized value were caught and fixed. This explains compiler-dependent behavior and dependence on apparently unrelated compiler flags.