### PR TITLE
Chspeed fixup

### DIFF
--- a/jenkins/gold_configs/MHDsedovAMR.config
+++ b/jenkins/gold_configs/MHDsedovAMR.config
@@ -1,8 +1,9 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=27e21790dd1ae3959ddf9d7ad283feae6561b15e
+GOLD_COMMIT=2765c69bd3da054fcd21d6d00355a3ea56cb85cb
 
-# 27e21790dd1ae3959ddf9d7ad283feae6561b15e -  [solve_cg_rieman] care_for_positives should operate with arrays after the update: u1 and b1
+# 2765c69bd3da054fcd21d6d00355a3ea56cb85cb - [hdc] fixed bug that could result in erroneous value of chspeed when some processes got empty leaves list
+# 27e21790dd1ae3959ddf9d7ad283feae6561b15e - [solve_cg_rieman] care_for_positives should operate with arrays after the update: u1 and b1
 # ccbcc225480734a626f1d0abbf1b4acc2b3c0b7f - changed the default method of computing ch_speed
 # 6d0b571fef22a8a87bb3ee12a53d771fc63e6d2c – new gold_test.sh script and major change in configuration on Jenkins
 # f7d819e8779e57651509407436770430e0b1e786 - cheaper 2D MHD AMR gold test

--- a/src/scheme/Riemann_Solver/hdc.F90
+++ b/src/scheme/Riemann_Solver/hdc.F90
@@ -93,7 +93,7 @@ contains
       use cg_cost_data, only: I_MHD
       use cg_leaves,    only: leaves
       use cg_list,      only: cg_list_element
-      use constants,    only: GEO_XYZ, pMAX, small, DIVB_HDC, RIEMANN_SPLIT
+      use constants,    only: GEO_XYZ, pMAX, pMIN, small, DIVB_HDC, RIEMANN_SPLIT
       use dataio_pub,   only: die
       use domain,       only: dom
       use global,       only: use_fargo, cfl_glm, ch_grid, dt, divB_0_method, which_solver
@@ -135,7 +135,7 @@ contains
          cgl => cgl%nxt
       enddo
 
-      call piernik_MPI_Allreduce(chspeed, pMAX)
+      call piernik_MPI_Allreduce(chspeed, merge(pMIN, pMAX, ch_grid))
 
    end subroutine update_chspeed
 


### PR DESCRIPTION
This should fix the problem with `MHDsedovAMR` gold test failing under heavy load.

The problem occured when a single thread got no cg to process after reshuffle and `ch_grid` was .true. (the default value).

Depleting a thread can occur when the code detects a particularly slow thread lagging behind other threads.