### PR TITLE
[dataio] don't ignore restart numbers above 999 (bugfix)

### DIFF
--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -940,7 +940,7 @@ contains
       open(newunit=unlink_stat, file='restart_list.tmp', status='unknown')
       close(unlink_stat, status='delete')
 
-      do nres = 999, 0, -1
+      do nres = 9999, 0, -1
          inquire(file = trim(output_fname(RD,'.res', nres)), exist = exist)
          if (exist) then
             restart_number = nres


### PR DESCRIPTION
This could be the oldest bug in Piernik that remained undetected.

Scanning restart files from 999 to 0 was introduced in 46849e1079 – these were really early days of Piernik. It looks like it was correct at that time, because filename format had "i3.3" for the counter. Then, suddenly we adopted HDF5 and unified finenames which resulted in introduction of this bug in 0715d2abdd. The bug was contitional and required relying on HDF format. Somewhat later HDF5 became the only way of writing files and the bug became unconditional, yet it avoided detectionn until now :-)