### PR TITLE
[dataio] bugfix: don't ignore nrestart when restart/='last'

### DIFF
--- a/benchmarking/problem.par.crtest
+++ b/benchmarking/problem.par.crtest
@@ -23,7 +23,6 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/2D_RIEMANN/powerbug/problem.par
+++ b/problems/2D_RIEMANN/powerbug/problem.par
@@ -43,7 +43,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/2D_RIEMANN/problem.par
+++ b/problems/2D_RIEMANN/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/2body/1particle/problem.par
+++ b/problems/2body/1particle/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/2body/3body/problem.par
+++ b/problems/2body/3body/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/2body/problem.par
+++ b/problems/2body/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/3body_orig/problem.par
+++ b/problems/3body_orig/problem.par
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/magnetized_advection_test/divB_blob/problem.par
+++ b/problems/advection_test/magnetized_advection_test/divB_blob/problem.par
@@ -39,7 +39,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/magnetized_advection_test/divB_blob/problem.par.AMR
+++ b/problems/advection_test/magnetized_advection_test/divB_blob/problem.par.AMR
@@ -39,7 +39,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/magnetized_advection_test/problem.par
+++ b/problems/advection_test/magnetized_advection_test/problem.par
@@ -39,7 +39,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/magnetized_advection_test/problem.par.AMR
+++ b/problems/advection_test/magnetized_advection_test/problem.par.AMR
@@ -40,7 +40,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/magnetized_advection_test/problem.par.constB
+++ b/problems/advection_test/magnetized_advection_test/problem.par.constB
@@ -39,7 +39,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/noninertial/problem.par
+++ b/problems/advection_test/noninertial/problem.par
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par
+++ b/problems/advection_test/problem.par
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par.conservation_test
+++ b/problems/advection_test/problem.par.conservation_test
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par.cylindrical
+++ b/problems/advection_test/problem.par.cylindrical
@@ -33,7 +33,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par.cylindrical.conservation_test
+++ b/problems/advection_test/problem.par.cylindrical.conservation_test
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par.explodes_unphysically
+++ b/problems/advection_test/problem.par.explodes_unphysically
@@ -33,7 +33,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par.refined
+++ b/problems/advection_test/problem.par.refined
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par.restart_test
+++ b/problems/advection_test/problem.par.restart_test
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/advection_test/problem.par.restart_test_v2
+++ b/problems/advection_test/problem.par.restart_test_v2
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/blob/problem.par
+++ b/problems/blob/problem.par
@@ -31,7 +31,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/blob/problem.par.AMR
+++ b/problems/blob/problem.par.AMR
@@ -31,7 +31,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/blob/problem.par.wt3_hi
+++ b/problems/blob/problem.par.wt3_hi
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/blob/problem.par.wt3_med
+++ b/problems/blob/problem.par.wt3_med
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par
+++ b/problems/crtest/problem.par
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par.AMR_conservation
+++ b/problems/crtest/problem.par.AMR_conservation
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par.build
+++ b/problems/crtest/problem.par.build
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par.debug
+++ b/problems/crtest/problem.par.debug
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par.expanding_domain
+++ b/problems/crtest/problem.par.expanding_domain
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par.refined
+++ b/problems/crtest/problem.par.refined
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par.refined_diff_restricted
+++ b/problems/crtest/problem.par.refined_diff_restricted
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/crtest/problem.par.refinements
+++ b/problems/crtest/problem.par.refinements
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/divvtest/problem.par
+++ b/problems/divvtest/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/dustblob/problem.par
+++ b/problems/dustblob/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/dustblob/problem.par.AMR
+++ b/problems/dustblob/problem.par.AMR
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/dustwave/problem.par
+++ b/problems/dustwave/problem.par
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/dustybox/problem.par
+++ b/problems/dustybox/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/fargo_test/problem.par
+++ b/problems/fargo_test/problem.par
@@ -29,7 +29,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = 'foo'
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/field_loop_mhd/problem.par
+++ b/problems/field_loop_mhd/problem.par
@@ -24,7 +24,6 @@ $UNITS
 $RESTART_CONTROL
    restart  = 'last'
    res_id   = ''
-   nrestart = 0
 /
 
 $END_CONTROL

--- a/problems/field_loop_mhd/problem.par.CT
+++ b/problems/field_loop_mhd/problem.par.CT
@@ -24,7 +24,6 @@ $UNITS
 $RESTART_CONTROL
    restart  = 'last'
    res_id   = ''
-   nrestart = 0
 /
 
 $END_CONTROL

--- a/problems/jeans/powerbug/problem.par
+++ b/problems/jeans/powerbug/problem.par
@@ -38,7 +38,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/jeans/problem.par
+++ b/problems/jeans/problem.par
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/jeans/problem.par.3d
+++ b/problems/jeans/problem.par.3d
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/jeans/problem.par.AMR.unstable
+++ b/problems/jeans/problem.par.AMR.unstable
@@ -27,7 +27,6 @@
 
  $RESTART_CONTROL
     restart  = 'last'
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/jeans/problem.par.big_domain
+++ b/problems/jeans/problem.par.big_domain
@@ -34,7 +34,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/jeans/problem.par.dirichlet
+++ b/problems/jeans/problem.par.dirichlet
@@ -34,7 +34,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/jeans/problem.par.small_domain
+++ b/problems/jeans/problem.par.small_domain
@@ -34,7 +34,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/kepler/problem.par
+++ b/problems/kepler/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/kepler/problem.par.2d
+++ b/problems/kepler/problem.par.2d
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/kepler/problem.par.build
+++ b/problems/kepler/problem.par.build
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/kepler/problem.par.kep
+++ b/problems/kepler/problem.par.kep
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/khi/problem.par
+++ b/problems/khi/problem.par
@@ -19,7 +19,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/lingrav/problem.par
+++ b/problems/lingrav/problem.par
@@ -23,7 +23,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/maclaurin/mpi_test.par
+++ b/problems/maclaurin/mpi_test.par
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par
+++ b/problems/maclaurin/problem.par
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
+++ b/problems/maclaurin/problem.par.__INACCURATE_REFINEMENT__
@@ -29,7 +29,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.big_domain
+++ b/problems/maclaurin/problem.par.big_domain
@@ -32,7 +32,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.cyl
+++ b/problems/maclaurin/problem.par.cyl
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.cyl2
+++ b/problems/maclaurin/problem.par.cyl2
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.multipole_3D
+++ b/problems/maclaurin/problem.par.multipole_3D
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.particle
+++ b/problems/maclaurin/problem.par.particle
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.plummer
+++ b/problems/maclaurin/problem.par.plummer
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.quite_accurate
+++ b/problems/maclaurin/problem.par.quite_accurate
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.refinement_shapes
+++ b/problems/maclaurin/problem.par.refinement_shapes
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/maclaurin/problem.par.small_domain
+++ b/problems/maclaurin/problem.par.small_domain
@@ -33,7 +33,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/magnetic_rotor/problem.par
+++ b/problems/magnetic_rotor/problem.par
@@ -24,7 +24,6 @@ $UNITS
 $RESTART_CONTROL
    restart  = 'last'
    res_id   = ''
-   nrestart = 0
 /
 
 $END_CONTROL

--- a/problems/magnetic_rotor/problem.par.CT
+++ b/problems/magnetic_rotor/problem.par.CT
@@ -24,7 +24,6 @@ $UNITS
 $RESTART_CONTROL
    restart  = 'last'
    res_id   = ''
-   nrestart = 0
 /
 
 $END_CONTROL

--- a/problems/mandelbrot/problem.par
+++ b/problems/mandelbrot/problem.par
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.polar
+++ b/problems/mandelbrot/problem.par.polar
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.polar.1-2-3-4-5-6
+++ b/problems/mandelbrot/problem.par.polar.1-2-3-4-5-6
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.polar.3-3-3-3-3-3
+++ b/problems/mandelbrot/problem.par.polar.3-3-3-3-3-3
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.polar.3x3x3x3x3x3
+++ b/problems/mandelbrot/problem.par.polar.3x3x3x3x3x3
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.polar.FM
+++ b/problems/mandelbrot/problem.par.polar.FM
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.zoom_1
+++ b/problems/mandelbrot/problem.par.zoom_1
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.zoom_2
+++ b/problems/mandelbrot/problem.par.zoom_2
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.zoom_3
+++ b/problems/mandelbrot/problem.par.zoom_3
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mandelbrot/problem.par.zoom_4
+++ b/problems/mandelbrot/problem.par.zoom_4
@@ -20,7 +20,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par
+++ b/problems/mcrtest/mcrtest_cresp/problem.par
@@ -26,7 +26,6 @@ $BASE_DOMAIN
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par.cresp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par.cresp
@@ -26,7 +26,6 @@ $BASE_DOMAIN
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par.gold
+++ b/problems/mcrtest/mcrtest_cresp/problem.par.gold
@@ -26,7 +26,6 @@ $BASE_DOMAIN
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_adv
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_adv
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_comp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_comp
@@ -26,7 +26,6 @@ $BASE_DOMAIN
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_diff
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_diff
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_dsyn
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_dsyn
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_exp
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_exp
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_sta
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_sta
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_syn
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_syn
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/mcrtest_cresp/problem.par_test
+++ b/problems/mcrtest/mcrtest_cresp/problem.par_test
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     new_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/problem.par
+++ b/problems/mcrtest/problem.par
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/problem.par.build
+++ b/problems/mcrtest/problem.par.build
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/problem.par.gold
+++ b/problems/mcrtest/problem.par.gold
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrtest/problem.par.refined
+++ b/problems/mcrtest/problem.par.refined
@@ -26,7 +26,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/mcrwind/mcrwind_cresp/problem.par
+++ b/problems/mcrwind/mcrwind_cresp/problem.par
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par
+++ b/problems/mcrwind/problem.par
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.gold
+++ b/problems/mcrwind/problem.par.gold
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.highres
+++ b/problems/mcrwind/problem.par.highres
@@ -25,7 +25,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.lowres
+++ b/problems/mcrwind/problem.par.lowres
@@ -25,7 +25,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.multigrid
+++ b/problems/mcrwind/problem.par.multigrid
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.multisn_wind
+++ b/problems/mcrwind/problem.par.multisn_wind
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.selfgrav
+++ b/problems/mcrwind/problem.par.selfgrav
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.singlesn_test
+++ b/problems/mcrwind/problem.par.singlesn_test
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/mcrwind/problem.par.smalltest
+++ b/problems/mcrwind/problem.par.smalltest
@@ -24,7 +24,6 @@
 
  $RESTART_CONTROL
     restart      = 'last'
-    nrestart     = 0
     res_id       = ''
  /
 

--- a/problems/otvortex/problem.par.build
+++ b/problems/otvortex/problem.par.build
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/particle_map_test/problem.par
+++ b/problems/particle_map_test/problem.par
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/roche/problem.par
+++ b/problems/roche/problem.par
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/sedov/problem.par.AMR
+++ b/problems/sedov/problem.par.AMR
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/sedov/problem.par.AMR.threshold_ref
+++ b/problems/sedov/problem.par.AMR.threshold_ref
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/sedov/problem.par.autorebalance_example
+++ b/problems/sedov/problem.par.autorebalance_example
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/sedov/problem.par.build
+++ b/problems/sedov/problem.par.build
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/sedov/problem.par.build-outflow
+++ b/problems/sedov/problem.par.build-outflow
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/sedov/problem.par.expanding_domain
+++ b/problems/sedov/problem.par.expanding_domain
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par
+++ b/problems/selfgrav_clump/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par.1D
+++ b/problems/selfgrav_clump/problem.par.1D
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par.2D
+++ b/problems/selfgrav_clump/problem.par.2D
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par.AMR
+++ b/problems/selfgrav_clump/problem.par.AMR
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par.conservation_test
+++ b/problems/selfgrav_clump/problem.par.conservation_test
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par.cyl
+++ b/problems/selfgrav_clump/problem.par.cyl
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par.expanding_domain
+++ b/problems/selfgrav_clump/problem.par.expanding_domain
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/selfgrav_clump/problem.par.restart_test
+++ b/problems/selfgrav_clump/problem.par.restart_test
@@ -29,7 +29,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj1a
+++ b/problems/shock1d_rj/problem.par.rj1a
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj1b
+++ b/problems/shock1d_rj/problem.par.rj1b
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj2a
+++ b/problems/shock1d_rj/problem.par.rj2a
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj2b
+++ b/problems/shock1d_rj/problem.par.rj2b
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj3a
+++ b/problems/shock1d_rj/problem.par.rj3a
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj3b
+++ b/problems/shock1d_rj/problem.par.rj3b
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj4a
+++ b/problems/shock1d_rj/problem.par.rj4a
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj4b
+++ b/problems/shock1d_rj/problem.par.rj4b
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj4c
+++ b/problems/shock1d_rj/problem.par.rj4c
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/problem.par.rj4d
+++ b/problems/shock1d_rj/problem.par.rj4d
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/shock1d_rj/sod/problem.par
+++ b/problems/shock1d_rj/sod/problem.par
@@ -24,7 +24,6 @@ $UNITS
 $RESTART_CONTROL
    restart  = 'last'
    res_id   = ''
-   nrestart = 0
 /
 
 $END_CONTROL

--- a/problems/slab/problem.par
+++ b/problems/slab/problem.par
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/slab/problem.par.2d
+++ b/problems/slab/problem.par.2d
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/stream/problem_BA.par
+++ b/problems/stream/problem_BA.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/stream/problem_lin.par
+++ b/problems/stream/problem_lin.par
@@ -30,7 +30,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/stream3D/problem.par
+++ b/problems/stream3D/problem.par
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/streaming_global/problem.par
+++ b/problems/streaming_global/problem.par
@@ -29,7 +29,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = 'foo'
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/streaming_global/problem.par.gold
+++ b/problems/streaming_global/problem.par.gold
@@ -29,7 +29,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = 'foo'
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/tearing/problem.par.gold
+++ b/problems/tearing/problem.par.gold
@@ -23,7 +23,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = 'new'
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/N-body/problem.par
+++ b/problems/testing_and_debuging/N-body/problem.par
@@ -17,7 +17,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/analytic_periodic_potential/problem.par
+++ b/problems/testing_and_debuging/analytic_periodic_potential/problem.par
@@ -28,7 +28,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/conservation_test/problem.par
+++ b/problems/testing_and_debuging/conservation_test/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/conservation_test/problem.par.cylindrical
+++ b/problems/testing_and_debuging/conservation_test/problem.par.cylindrical
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/conservation_test/problem.par.cylindrical.AMR
+++ b/problems/testing_and_debuging/conservation_test/problem.par.cylindrical.AMR
@@ -27,7 +27,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/conservation_test/problem.par.uniform
+++ b/problems/testing_and_debuging/conservation_test/problem.par.uniform
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/cresp_1cell/problem.par
+++ b/problems/testing_and_debuging/cresp_1cell/problem.par
@@ -21,7 +21,6 @@ $BASE_DOMAIN
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/int_bnd_test/problem.par
+++ b/problems/testing_and_debuging/int_bnd_test/problem.par
@@ -29,7 +29,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/pr_test/problem.par
+++ b/problems/testing_and_debuging/pr_test/problem.par
@@ -30,7 +30,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/refinement_stress/problem.par
+++ b/problems/testing_and_debuging/refinement_stress/problem.par
@@ -30,7 +30,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/yt_test/problem.par
+++ b/problems/testing_and_debuging/yt_test/problem.par
@@ -18,7 +18,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/testing_and_debuging/yt_test/problem.par.yt_fails
+++ b/problems/testing_and_debuging/yt_test/problem.par.yt_fails
@@ -18,7 +18,6 @@
  $RESTART_CONTROL
     restart  = 'none'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/turbulence/problem.par
+++ b/problems/turbulence/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/wind/problem.par
+++ b/problems/wind/problem.par
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/wt4/problem.par
+++ b/problems/wt4/problem.par
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/wt4/problem.par.AMR
+++ b/problems/wt4/problem.par.AMR
@@ -24,7 +24,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/problems/wt4/problem.par.cylindrical
+++ b/problems/wt4/problem.par.cylindrical
@@ -25,7 +25,6 @@
  $RESTART_CONTROL
     restart  = 'last'
     res_id   = ''
-    nrestart = 0
  /
 
  $END_CONTROL

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -236,6 +236,7 @@ contains
 #endif /* HDF5 */
       call piernik_MPI_Barrier
       call piernik_MPI_Bcast(nrestart)
+      restarted_sim = (nrestart > INVALID)
       call piernik_MPI_Bcast(restarted_sim)
 
       if (master) then
@@ -258,7 +259,7 @@ contains
    subroutine dataio_par_io
 
       use bcast,      only: piernik_MPI_Bcast
-      use constants,  only: idlen, cbuff_len, INT4, V_SILENT, V_DEBUG, V_VERBOSE, V_INFO, V_ESSENTIAL, V_WARN, v_name
+      use constants,  only: idlen, cbuff_len, INT4, V_SILENT, V_DEBUG, V_VERBOSE, V_INFO, V_ESSENTIAL, V_WARN, v_name, INVALID
       use dataio_pub, only: nres, nrestart, warn, nhdf, wd_rd, multiple_h5files, warn, h5_64bit, nh, set_colors, piernik_verbosity
       use mpisetup,   only: lbuff, ibuff, rbuff, cbuff, master, slave, nproc
 
@@ -269,7 +270,7 @@ contains
       restart       = 'last'   ! 'last': automatic choice of the last restart file regardless of "nrestart" value;
                               ! if something else is set: "nrestart" value is fixing
       res_id        = ''
-      nrestart      = 3
+      nrestart      = INVALID
 
       dt_hdf        = 0.0
       dt_res        = 0.0
@@ -924,7 +925,7 @@ contains
    subroutine find_last_restart(restart_number)
 
       use common_hdf5, only: output_fname
-      use constants,   only: RD
+      use constants,   only: RD, INVALID
       use dataio_pub,  only: restarted_sim
 
       implicit none
@@ -935,7 +936,7 @@ contains
       integer                      :: unlink_stat
       logical                      :: exist
 
-      restart_number = 0
+      restart_number = INVALID
 
       open(newunit=unlink_stat, file='restart_list.tmp', status='unknown')
       close(unlink_stat, status='delete')

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -166,7 +166,7 @@ contains
 
       use barrier,      only: piernik_MPI_Barrier
       use bcast,        only: piernik_MPI_Bcast
-      use constants,    only: cwdlen, PIERNIK_INIT_MPI, INVALID, V_DEBUG
+      use constants,    only: cwdlen, PIERNIK_INIT_MPI, INVALID, V_DEBUG, I_ZERO
       use dataio_pub,   only: nrestart, last_hdf_time, last_res_time, last_tsl_time, last_log_time, log_file_initialized, &
            &                  tmp_log_file, printinfo, printio, warn, msg, die, code_progress, log_wr, restarted_sim, &
            &                  move_file, parfile, parfilelines, log_file, maxparlen, maxparfilelines, can_i_write, ierrh, par_file
@@ -239,7 +239,7 @@ contains
       call piernik_MPI_Bcast(restarted_sim)
 
       if (master) then
-         write(log_file,'(6a,i3.3,a)') trim(log_wr),'/',trim(problem_name),'_',trim(run_id),'_',max(0, nrestart),'.log'
+         write(log_file,'(6a,i3.3,a)') trim(log_wr),'/',trim(problem_name),'_',trim(run_id),'_',max(I_ZERO, nrestart),'.log'
 !> \todo if the simulation is restarted then save previous log_file (if exists) under a different, unique name
          system_status = move_file(trim(tmp_log_file), trim(log_file))
          if (system_status /= 0) then
@@ -511,7 +511,7 @@ contains
 
    subroutine init_dataio
 
-      use constants,    only: PIERNIK_INIT_IO_IC, V_DEBUG, V_LOG
+      use constants,    only: PIERNIK_INIT_IO_IC, V_DEBUG, V_LOG, I_ZERO
       use dataio_pub,   only: code_progress, die, maxenvlen, nres, nrestart, printinfo, restarted_sim, warn
       use domain,       only: dom
       use mpisetup,     only: master
@@ -584,7 +584,7 @@ contains
 
       if (associated(user_vars_arr_in_restart)) call user_vars_arr_in_restart
 
-      nres = max(0, nrestart)
+      nres = max(I_ZERO, nrestart)
 
       if (restarted_sim) then
 #ifdef HDF5
@@ -960,7 +960,7 @@ contains
       use cg_cost_data,     only: I_OTHER
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: xdim, DST, pSUM, GEO_XYZ, GEO_RPZ, ndims, LO, HI, I_ONE, INVALID, PPP_IO
+      use constants,        only: xdim, DST, pSUM, GEO_XYZ, GEO_RPZ, ndims, LO, HI, I_ONE, INVALID, PPP_IO, I_ZERO
       use dataio_pub,       only: log_wr, tsl_file, tsl_lun
 #if defined(__INTEL_COMPILER)
       use dataio_pub,       only: io_blocksize, io_buffered, io_buffno
@@ -1049,7 +1049,7 @@ contains
       endif
 
       if (master) then
-         write(tsl_file,'(a,a1,a,a1,a3,a1,i3.3,a4)') trim(log_wr),'/',trim(problem_name),'_', run_id,'_',max(0, nrestart),'.tsl'
+         write(tsl_file,'(a,a1,a,a1,a3,a1,i3.3,a4)') trim(log_wr),'/',trim(problem_name),'_', run_id,'_',max(I_ZERO, nrestart),'.tsl'
 
          if (tsl_firstcall) then
             call pop_vector(tsl_names, field_len, ["nstep   ", "time    ", "timestep", "mass    "])

--- a/src/IO/dataio.F90
+++ b/src/IO/dataio.F90
@@ -60,7 +60,6 @@ module dataio
    character(len=dsetnamelen), dimension(nvarsmx) :: pvars !< array of 4-character strings standing for variables to dump in particle hdf files
 #ifdef HDF5
    integer                  :: nhdf_start            !< number of hdf file for the first hdf dump in simulation run
-   integer                  :: nres_start            !< number of restart file for the first restart dump in simulation run
    real                     :: t_start               !< time in simulation of start simulation run
 #endif /* HDF5 */
    logical                  :: tsl_firstcall         !< logical value to start a new timeslice file
@@ -240,7 +239,7 @@ contains
       call piernik_MPI_Bcast(restarted_sim)
 
       if (master) then
-         write(log_file,'(6a,i3.3,a)') trim(log_wr),'/',trim(problem_name),'_',trim(run_id),'_',nrestart,'.log'
+         write(log_file,'(6a,i3.3,a)') trim(log_wr),'/',trim(problem_name),'_',trim(run_id),'_',max(0, nrestart),'.log'
 !> \todo if the simulation is restarted then save previous log_file (if exists) under a different, unique name
          system_status = move_file(trim(tmp_log_file), trim(log_file))
          if (system_status /= 0) then
@@ -585,7 +584,7 @@ contains
 
       if (associated(user_vars_arr_in_restart)) call user_vars_arr_in_restart
 
-      nres = nrestart
+      nres = max(0, nrestart)
 
       if (restarted_sim) then
 #ifdef HDF5
@@ -593,8 +592,7 @@ contains
          call read_restart_hdf5
          nstep_start = nstep
          t_start     = t
-         nres_start  = nrestart
-         nhdf_start  = nhdf-1
+         nhdf_start  = nhdf - 1
 #else /* !HDF5 */
          call die("[dataio:init_dataio] cannot use restart without HDF5")
 #endif /* !HDF5 */
@@ -1051,7 +1049,7 @@ contains
       endif
 
       if (master) then
-         write(tsl_file,'(a,a1,a,a1,a3,a1,i3.3,a4)') trim(log_wr),'/',trim(problem_name),'_', run_id,'_',nrestart,'.tsl'
+         write(tsl_file,'(a,a1,a,a1,a3,a1,i3.3,a4)') trim(log_wr),'/',trim(problem_name),'_', run_id,'_',max(0, nrestart),'.tsl'
 
          if (tsl_firstcall) then
             call pop_vector(tsl_names, field_len, ["nstep   ", "time    ", "timestep", "mass    "])

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -232,7 +232,7 @@ contains
       if (.not. watch_debug    ) disable_mask = disable_mask + PPP_DEBUG
       if (.not. watch_aux      ) disable_mask = disable_mask + PPP_AUX
 
-      write(profile_file, '(6a,i3.3,a)') trim(log_wr), '/', trim(problem_name), '_', trim(run_id), '_', nrestart, '.ppprofile.ascii'
+      write(profile_file, '(6a,i3.3,a)') trim(log_wr), '/', trim(problem_name), '_', trim(run_id), '_', max(0, nrestart), '.ppprofile.ascii'
 
       call ppp_main%init("main", xxl)
 

--- a/src/base/ppprofiling.F90
+++ b/src/base/ppprofiling.F90
@@ -135,7 +135,7 @@ contains
 
       use bcast,         only: piernik_MPI_Bcast
       use constants,     only: PPP_IO, PPP_MG, PPP_GRAV, PPP_CR, PPP_PART, PPP_MPI, &
-           &                   PPP_AMR, PPP_CG, PPP_MAG, PPP_PROB, PPP_DEBUG, PPP_AUX
+           &                   PPP_AMR, PPP_CG, PPP_MAG, PPP_PROB, PPP_DEBUG, PPP_AUX, I_ZERO
       use dataio_pub,    only: nh, log_wr, problem_name, run_id, nrestart
       use mpisetup,      only: lbuff, master, slave
       use ppp_eventlist, only: use_profiling, disable_mask, profile_file
@@ -232,7 +232,7 @@ contains
       if (.not. watch_debug    ) disable_mask = disable_mask + PPP_DEBUG
       if (.not. watch_aux      ) disable_mask = disable_mask + PPP_AUX
 
-      write(profile_file, '(6a,i3.3,a)') trim(log_wr), '/', trim(problem_name), '_', trim(run_id), '_', max(0, nrestart), '.ppprofile.ascii'
+      write(profile_file, '(6a,i3.3,a)') trim(log_wr), '/', trim(problem_name), '_', trim(run_id), '_', max(I_ZERO, nrestart), '.ppprofile.ascii'
 
       call ppp_main%init("main", xxl)
 

--- a/src/base/randomization.F90
+++ b/src/base/randomization.F90
@@ -49,6 +49,7 @@ contains
 !<
    subroutine init_randomization
 
+      use constants,  only: INVALID
       use dataio_pub, only: nrestart
 
       implicit none
@@ -59,7 +60,7 @@ contains
       if (.not.allocated(initseed)) allocate(initseed(seed_size))
       if (.not.allocated(redoseed)) allocate(redoseed(seed_size))
 
-      if (nrestart == 0) then
+      if (nrestart == INVALID) then
          do i= 1,seed_size; initseed(i)= 2**i; enddo   ! Simple seed 2,4,8,16,..
       endif
       call random_seed(PUT=initseed)

--- a/src/particles/particle_diag.F90
+++ b/src/particles/particle_diag.F90
@@ -186,7 +186,7 @@ contains
 
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: cwdlen, half, ndims
+      use constants,        only: cwdlen, half, ndims, I_ZERO
       use dataio_pub,       only: log_wr, nrestart, problem_name, run_id
       use global,           only: t, dt
       use particle_gravity, only: get_acc_model
@@ -204,7 +204,7 @@ contains
 
       kdt = dt ; if (.not.twodtscheme) kdt = half * dt
 
-      write(plog_file,'(6a,i3.3,a)') trim(log_wr), '/', trim(problem_name), '_', trim(run_id), '_', max(0, nrestart), '_out.log'
+      write(plog_file,'(6a,i3.3,a)') trim(log_wr), '/', trim(problem_name), '_', trim(run_id), '_', max(I_ZERO, nrestart), '_out.log'
       open(newunit=lun_out, file=plog_file, status='unknown',  position='append')
       cgl => leaves%first
       do while (associated(cgl))

--- a/src/particles/particle_diag.F90
+++ b/src/particles/particle_diag.F90
@@ -204,7 +204,7 @@ contains
 
       kdt = dt ; if (.not.twodtscheme) kdt = half * dt
 
-      write(plog_file,'(6a,i3.3,a)') trim(log_wr),'/',trim(problem_name),'_',trim(run_id),'_',nrestart,'_out.log'
+      write(plog_file,'(6a,i3.3,a)') trim(log_wr), '/', trim(problem_name), '_', trim(run_id), '_', max(0, nrestart), '_out.log'
       open(newunit=lun_out, file=plog_file, status='unknown',  position='append')
       cgl => leaves%first
       do while (associated(cgl))


### PR DESCRIPTION
The value of `nrestart` was ignored because it did not affect the flag `restarted sim`.

It was intended to be a simple and small fix but then some side-effects attacked :-)