### PR TITLE
[timestep_cresp] FIX: initialize empty_cell before loop

### DIFF
--- a/src/fluids/cosmicrays/timestep_cresp.F90
+++ b/src/fluids/cosmicrays/timestep_cresp.F90
@@ -74,6 +74,8 @@ contains
       dt_cre_synch = huge(1.)
       dt_cre_adiab = huge(1.)
 
+      empty_cell = .false. ! WARNING if not initialized (additionally) here, it remains .true. and dt_cre_synch is not computed
+
       if (.not. use_cresp_evol) return
 
       abs_max_ud   = zero


### PR DESCRIPTION
Initialize empty_cell before entering the loop to have dt_cre_synch properly computed


Possible gcc issue - if empty_cell is not initialized before loop, it remains .true. regardless of what cresp_find_prepare_spectrum returns. Issue was not detected on earlier GCC versions (not sure when started, possible around GCC-11 or even earlier)
Change will affect gold tests wherever synchrotron & IC cooling processes are involved.