### PR TITLE
Fix dimensions for CRESP number density & mag_field_xyz

### DIFF
--- a/src/base/units.F90
+++ b/src/base/units.F90
@@ -527,7 +527,7 @@ contains
          case ("temn", "temi", "temperature")
             val =  1.0
             write(s_val, '(a)') trim(s_lmtvB(U_TEMP))
-         case ("magx", "magy", "magz")
+         case ("magx", "magy", "magz", "mag_field_x", "mag_field_y", "mag_field_z")
             val = lmtvB(U_MAG)
             write(s_val, '(a)') trim(s_lmtvB(U_MAG))
          case ("cr01" : "cr99", "cr_A000" : "cr_zz99", "cree01" : "cree99")

--- a/src/base/units.F90
+++ b/src/base/units.F90
@@ -498,6 +498,7 @@ contains
       character(len=*), intent(in) :: field
       real, intent(out) :: val
       character(len=units_len), intent(out):: s_val
+      integer(kind=4) :: en_ind
 
       select case (trim(field))
          case ("dend", "deni", "denn", "density")
@@ -530,11 +531,17 @@ contains
             val = lmtvB(U_MAG)
             write(s_val, '(a)') trim(s_lmtvB(U_MAG))
          case ("cr01" : "cr99", "cr_A000" : "cr_zz99", "cree01" : "cree99")
-            val = lmtvB(U_MASS) / lmtvB(U_LEN) / lmtvB(U_TIME) ** 2
-            if (trim(s_lmtvB(U_ENER)) /= "complex") then
-               write(s_val, '(a, "/", a,"**3")') trim(s_lmtvB(U_ENER)), trim(s_lmtvB(U_LEN))
+            en_ind = len(trim(field), kind=4) - 2
+            if (field(en_ind:en_ind) /= "n") then
+               val = lmtvB(U_MASS) / lmtvB(U_LEN) / lmtvB(U_TIME) ** 2
+               if (trim(s_lmtvB(U_ENER)) /= "complex") then
+                  write(s_val, '(a, "/", a,"**3")') trim(s_lmtvB(U_ENER)), trim(s_lmtvB(U_LEN))
+               else
+                  write(s_val, '(a, "/", a, " /",a,"**2")') trim(s_lmtvB(U_MASS)), trim(s_lmtvB(U_LEN)), trim(s_lmtvB(U_TIME))
+               endif
             else
-               write(s_val, '(a, "/", a, " /",a,"**2")') trim(s_lmtvB(U_MASS)), trim(s_lmtvB(U_LEN)), trim(s_lmtvB(U_TIME))
+               val = 1.0 / lmtvB(U_LEN)**3                          !< CRESP number density
+               write(s_val, '( "1  /", a,"**3")') trim(s_lmtvB(U_LEN))
             endif
 #ifdef CRESP
          case ("cren01" : "cren99")


### PR DESCRIPTION
CRESP number density fields shared dimension with energy density fields, as they fell into the same pattern.
Similar approach as in data_hdf5.F90:datafields_hdf5 was used to discriminate between these fields.
Additionally - translated fields mag_field_{x,y,z} were left out from setting dimensions - fixed in this PR.

Note that as of now, such solution should not introduce any problem to defined CR elements, however, given existing naming convention, if hypothetically, elements as Mn, Zn, (Rn,  Sn?) were to be added as CR species, they would have number density dimensions set in HDF file.

To be considered: a warning in cr_data.F90 to alter this method when introducing such new species. There are remaning fields without dimensions implemented -- e.g., momentum datafields.
