### PR TITLE
Flexible tracers

### DIFF
--- a/doc/general/precompiler.F90
+++ b/doc/general/precompiler.F90
@@ -22,8 +22,6 @@
 !! \b \#define \b "COSM_RAYS" - to include parts of the code related to cosmic ray component
 !!
 !! \b \#define \b "COSM_RAYS_SOURCES" - to take into account several different species of cosmic rays particles
-!!
-!! \b \#define \b "TRACER" - to include parts of the code related to tracer
 !! @n @n
 !!
 !! \b PHYSICS \b INCLUDED \b (i.e. \b FIELDS, \b INTERACTIONS):

--- a/problems/fargo_test/initproblem.F90
+++ b/problems/fargo_test/initproblem.F90
@@ -466,25 +466,20 @@ contains
 !-----------------------------------------------------------------------------------------------------------------------
    subroutine kepler_problem_post_restart
 
+      use all_boundaries,   only: all_fluid_boundaries
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: fluid_n
-      use all_boundaries,   only: all_fluid_boundaries
-      use named_array_list, only: wna
-      use grid_cont,        only: grid_container
-#ifdef TRACER
-      use constants,        only: xdim, ydim, zdim
+      use constants,        only: fluid_n, xdim, ydim, zdim, LO, HI
       use func,             only: resample_gauss
       use fluidindex,       only: flind
-#endif /* TRACER */
+      use grid_cont,        only: grid_container
+      use named_array_list, only: wna
 
       implicit none
 
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg
-#ifdef TRACER
       integer                        :: i, j, k
-#endif /* TRACER */
 
       call my_grav_pot_3d   ! reset gp, to get right values on the boundaries
 
@@ -507,7 +502,6 @@ contains
          cgl => cgl%nxt
       enddo
 
-#ifdef TRACER
       if (gauss(4) > 0.0) then
          cgl => leaves%first
          do while (associated(cgl))
@@ -530,7 +524,6 @@ contains
       endif
 
       call all_fluid_boundaries
-#endif /* TRACER */
 
    end subroutine kepler_problem_post_restart
 !-----------------------------------------------------------------------------------------------------------------------

--- a/problems/sedov/MHD_blast_wave/MHD_tracer/piernik.def
+++ b/problems/sedov/MHD_blast_wave/MHD_tracer/piernik.def
@@ -1,9 +1,0 @@
-#if !defined GLOBAL_FR_SPEED
-#  define LOCAL_FR_SPEED
-#endif
-
-#define IONIZED
-
-#define TRACER
-
-#define MAGNETIC

--- a/problems/sedov/MHD_blast_wave/MHD_tracer/problem.par
+++ b/problems/sedov/MHD_blast_wave/MHD_tracer/problem.par
@@ -50,7 +50,8 @@
     dt_res  = 1e-1
     dt_log  = 1.0e-4
     dt_tsl  = 1.0e-4
-    vars(1:) = 'ener', 'dens', 'ethr', 'magB', "pres", "divb", "divb4", "psi", "level", "ref_01", "trcr"
+    vars(1:) = 'ener', 'dens', 'ethr', 'magB', "pres", "divb", "divb4", "psi", "level", "ref_01", "trcr", "ref_02"
+    verbosity = "verbose"
  /
 
  $FLUID_IONIZED
@@ -93,12 +94,14 @@
  /
 
  $FLUID_TRACER
-    tracers = 1
+    ntracers = 10
+!    trace_fluid = 0, 2
  /
 
  $AMR
     bsize = 3*32
     level_max = 4
     n_updAMR = 3
-    refine_vars(1) = "tracer_01", "threshold", 0.25, 4
+    refine_vars(1) = "tracer_01", "threshold", 0.25, 40, .true.
+    ! fluid name, method, threshold value, level max, create plotfield
  /

--- a/problems/sedov/initproblem.F90
+++ b/problems/sedov/initproblem.F90
@@ -186,11 +186,12 @@ contains
       use fluidindex,   only: flind
       use func,         only: operator(.notequals.)
       use grid_cont,    only: grid_container
+      use inittracer,   only: iarr_trc, trace_fluid, ntracers
 
       implicit none
 
       integer, parameter              :: isub = 4
-      integer                         :: i, j, k, p, ii, jj, kk
+      integer                         :: i, j, k, p, ii, jj, kk, t
       type(cg_list_element),  pointer :: cgl
       type(grid_container),   pointer :: cg
       real :: x, y, z, s
@@ -218,9 +219,9 @@ contains
                      cg%u(fl%imz,i,j,k) = 0.0
                      cg%u(fl%ien,i,j,k) = p0/(fl%gam_1)
                      cg%u(fl%ien,i,j,k) = cg%u(fl%ien,i,j,k) + 0.5*(cg%u(fl%imx,i,j,k)**2 +cg%u(fl%imy,i,j,k)**2 + cg%u(fl%imz,i,j,k)**2)/cg%u(fl%idn,i,j,k)
-#ifdef TRACER
-                     cg%u(flind%trc%beg, i, j, k) = 0.  ! this will be unnecessarily repeated when multiple fluid kinds are enabled
-#endif /* TRACER */
+                     do t = 1, ntracers
+                        if (trace_fluid(t) == p) cg%u(iarr_trc(t), i, j, k) = 0.
+                     enddo
                   enddo
                enddo
             enddo
@@ -254,10 +255,9 @@ contains
                               enddo
                            enddo
                         enddo
-#ifdef TRACER
-                        ! this will be unnecessarily repeated when multiple fluid kinds are enabled
-                        cg%u(flind%trc%beg, i, j, k) = max(0., min(1., (cg%u(fl%ien,i,j,k) - p0/(fl%gam_1)) / Eexpl))
-#endif /* TRACER */
+                        do t = 1, ntracers
+                           if (trace_fluid(t) == p) cg%u(iarr_trc(t), i, j, k) = max(0., min(1., (cg%u(fl%ien,i,j,k) - p0/(fl%gam_1)) / Eexpl)) * t
+                        enddo
                      endif
                   enddo
                enddo

--- a/problems/streaming_global/initproblem.F90
+++ b/problems/streaming_global/initproblem.F90
@@ -570,25 +570,20 @@ contains
 !-----------------------------------------------------------------------------------------------------------------------
    subroutine kepler_problem_post_restart
 
+      use all_boundaries,   only: all_fluid_boundaries
       use cg_leaves,        only: leaves
       use cg_list,          only: cg_list_element
-      use constants,        only: fluid_n
-      use all_boundaries,   only: all_fluid_boundaries
-      use named_array_list, only: wna
-      use grid_cont,        only: grid_container
-#ifdef TRACER
-      use constants,        only: xdim, ydim, zdim
+      use constants,        only: fluid_n, xdim, ydim, zdim, LO, HI
       use func,             only: resample_gauss
       use fluidindex,       only: flind
-#endif /* TRACER */
+      use grid_cont,        only: grid_container
+      use named_array_list, only: wna
 
       implicit none
 
       type(cg_list_element), pointer :: cgl
       type(grid_container),  pointer :: cg
-#ifdef TRACER
       integer                        :: i, j, k
-#endif /* TRACER */
 
       call my_grav_pot_3d   ! reset gp, to get right values on the boundaries
 
@@ -611,7 +606,6 @@ contains
          cgl => cgl%nxt
       enddo
 
-#ifdef TRACER
       if (gauss(4) > 0.0) then
          cgl => leaves%first
          do while (associated(cgl))
@@ -634,7 +628,6 @@ contains
       endif
 
       call all_fluid_boundaries
-#endif /* TRACER */
 
    end subroutine kepler_problem_post_restart
 !-----------------------------------------------------------------------------------------------------------------------

--- a/problems/testing_and_debuging/chimaera/piernik.def
+++ b/problems/testing_and_debuging/chimaera/piernik.def
@@ -7,7 +7,6 @@
 #define IONIZED
 /* NEUTRAL is mutually exclusive with IONIZED at this point */
 #undef NEUTRAL
-#define TRACER
 
 /* Big features */
 #define MAGNETIC

--- a/problems/turbulence/piernik.def
+++ b/problems/turbulence/piernik.def
@@ -4,7 +4,6 @@
 #undef ISO
 
 #define NEUTRAL
-#define TRACER
 
 #undef RESIST
 

--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -104,28 +104,29 @@ contains
 
    subroutine init_hdf5(vars)
 
-      use constants,      only: dsetnamelen, singlechar, RIEMANN_UNSPLIT
-      use fluidindex,     only: flind
-      use dataio_pub,     only: warn, die
-      use fluids_pub,     only: has_ion, has_dst, has_neu
-      use global,         only: cc_mag, which_solver
-      use mpisetup,       only: master
+      use constants,        only: dsetnamelen, singlechar, RIEMANN_UNSPLIT
+      use fluidindex,       only: flind
+      use dataio_pub,       only: warn, die
+      use fluids_pub,       only: has_ion, has_dst, has_neu
+      use global,           only: cc_mag, which_solver
+      use mpisetup,         only: master
+      use named_array_list, only: wna
 #ifdef COSM_RAYS
-      use cr_data,        only: cr_names, cr_spectral
+      use cr_data,          only: cr_names, cr_spectral
 #endif /* COSM_RAYS */
 #ifdef CRESP
-      use initcosmicrays, only: ncrb
+      use initcosmicrays,   only: ncrb
 #endif /* CRESP */
 
       implicit none
 
       character(len=dsetnamelen), dimension(:), intent(in) :: vars  !< quantities to be plotted, see dataio::vars
 
-      integer                                              :: i
-      character(len=singlechar)                            :: fc, ord
-      character(len=dsetnamelen)                           :: aux, ifmt
+      integer                    :: i, k
+      character(len=singlechar)  :: fc, ord
+      character(len=dsetnamelen) :: aux, ifmt
 #ifdef COSM_RAYS
-      integer                                              :: k, ke
+      integer                    :: ke
 #endif /* COSM_RAYS */
 
       i = 10  ! Let the default counter be 2-digit wide
@@ -268,6 +269,10 @@ contains
                   call append_var('zfmomzi')
                   if (flind%ion%has_energy) call append_var('zfenei')
                endif
+            case ('trcr')
+               do k = flind%trc%beg, flind%trc%end
+                  call append_var(wna%get_component_name(wna%fi, int(k, kind=4)))
+               enddo
 #ifdef COSM_RAYS
             case ('encr')
                do k = 1, size(cr_names)

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -493,10 +493,10 @@ contains
             read(var,'(A4,I2.2)') aux, i !> \deprecated BEWARE 0 <= i <= 99, no other indices can be dumped to hdf file
             tab(:,:,:) = cg%w(wna%ind(dfpq%q_nam))%arr(i,RNG)  !flind%cre%fbeg+i-1, RNG)
 #endif /* CRESP */
-#ifdef TRACER
          case ("trcr")
+            ! How to show second tracer?
+            ! What if no tracers are there?
             tab(:,:,:) = cg%u(flind%trc%beg, RNG)
-#endif /* TRACER */
          case ("dend", "deni", "denn")
             if (associated(fl_dni)) tab(:,:,:) = cg%u(fl_dni%idn, RNG)
          case ("vlxd", "vlxn", "vlxi", "vlyd", "vlyn", "vlyi", "vlzd", "vlzn", "vlzi")

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -155,7 +155,7 @@ contains
          case ("gpot", "sgpt")
             f%fu = "\rm{cm}^2 / \rm{s}^2"
             f%f2cgs = 1.0 / (cm**2 / sek**2)
-         case ("tracer_00" : "tracer_99")  ! depends on inittracer::tracers_max
+         case ("tracer_01" : "tracer_10")  ! depends on inittracer::tracers_max
       end select
    end function datafields_descr
 
@@ -494,7 +494,7 @@ contains
             read(var,'(A4,I2.2)') aux, i !> \deprecated BEWARE 0 <= i <= 99, no other indices can be dumped to hdf file
             tab(:,:,:) = cg%w(wna%ind(dfpq%q_nam))%arr(i,RNG)  !flind%cre%fbeg+i-1, RNG)
 #endif /* CRESP */
-         case ("tracer_00" : "tracer_99")  ! Beware: depends on inittracer::tracers_max
+         case ("tracer_01" : "tracer_10")  ! Beware: depends on inittracer::tracers_max
             read(var,'(A7,I2.2)') aux, i
             tab(:,:,:) = cg%u(iarr_trc(i), RNG)
          case ("dend", "deni", "denn")

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -155,7 +155,10 @@ contains
          case ("gpot", "sgpt")
             f%fu = "\rm{cm}^2 / \rm{s}^2"
             f%f2cgs = 1.0 / (cm**2 / sek**2)
-         case ("tracer_01" : "tracer_10")  ! depends on inittracer::tracers_max
+         case default
+            if (var(1:7) == "tracer_") then
+               f%fu = ""
+            endif
       end select
    end function datafields_descr
 
@@ -351,7 +354,7 @@ contains
       use fluidtypes,       only: component_fluid
       use func,             only: ekin, emag, sq_sum3
       use grid_cont,        only: grid_container
-      use inittracer,       only: iarr_trc
+      use inittracer,       only: iarr_trc, ntracers
       use mpisetup,         only: proc
 #ifdef MAGNETIC
       use constants,        only: xdim, ydim, zdim, half, two, I_TWO, I_FOUR, I_SIX, I_EIGHT
@@ -382,10 +385,10 @@ contains
       integer(kind=4)                                :: i_xyz
       integer                                        :: ii, jj, kk
       integer                                        :: i
-      integer, parameter                             :: auxlen = dsetnamelen - 1
-      character(len=auxlen)                          :: aux
 #ifdef COSM_RAYS
       integer(kind=4)                                :: clast
+      integer, parameter                             :: auxlen = dsetnamelen - 1
+      character(len=auxlen)                          :: aux
       character(len=I_TWO)                           :: varn2
 #endif /* COSM_RAYS */
 #ifdef CRESP
@@ -494,9 +497,6 @@ contains
             read(var,'(A4,I2.2)') aux, i !> \deprecated BEWARE 0 <= i <= 99, no other indices can be dumped to hdf file
             tab(:,:,:) = cg%w(wna%ind(dfpq%q_nam))%arr(i,RNG)  !flind%cre%fbeg+i-1, RNG)
 #endif /* CRESP */
-         case ("tracer_01" : "tracer_10")  ! Beware: depends on inittracer::tracers_max
-            read(var,'(A7,I2.2)') aux, i
-            tab(:,:,:) = cg%u(iarr_trc(i), RNG)
          case ("dend", "deni", "denn")
             if (associated(fl_dni)) tab(:,:,:) = cg%u(fl_dni%idn, RNG)
          case ("vlxd", "vlxn", "vlxi", "vlyd", "vlyn", "vlyi", "vlzd", "vlzn", "vlzi")
@@ -684,7 +684,16 @@ contains
          case ("proc")
             tab(:,:,:) = proc
          case default
-            ierrh = -1
+            if (var(1:7) == "tracer_") then
+               read(var(8:), *, iostat=ierrh) i
+               if (ierrh == 0 .and. i > 0 .and. i <= ntracers) then
+                  tab(:,:,:) = cg%u(iarr_trc(i), RNG)
+               else
+                  ierrh = -1
+               endif
+            else
+               ierrh = -1
+            endif
       end select
       end associate
 

--- a/src/IO/hdf5/data_hdf5.F90
+++ b/src/IO/hdf5/data_hdf5.F90
@@ -155,7 +155,7 @@ contains
          case ("gpot", "sgpt")
             f%fu = "\rm{cm}^2 / \rm{s}^2"
             f%f2cgs = 1.0 / (cm**2 / sek**2)
-         case ("trcr")
+         case ("tracer_00" : "tracer_99")  ! depends on inittracer::tracers_max
       end select
    end function datafields_descr
 
@@ -351,6 +351,7 @@ contains
       use fluidtypes,       only: component_fluid
       use func,             only: ekin, emag, sq_sum3
       use grid_cont,        only: grid_container
+      use inittracer,       only: iarr_trc
       use mpisetup,         only: proc
 #ifdef MAGNETIC
       use constants,        only: xdim, ydim, zdim, half, two, I_TWO, I_FOUR, I_SIX, I_EIGHT
@@ -380,11 +381,11 @@ contains
       class(component_fluid), pointer                :: fl_dni, fl_mach
       integer(kind=4)                                :: i_xyz
       integer                                        :: ii, jj, kk
-#ifdef COSM_RAYS
-      integer(kind=4)                                :: clast
       integer                                        :: i
       integer, parameter                             :: auxlen = dsetnamelen - 1
       character(len=auxlen)                          :: aux
+#ifdef COSM_RAYS
+      integer(kind=4)                                :: clast
       character(len=I_TWO)                           :: varn2
 #endif /* COSM_RAYS */
 #ifdef CRESP
@@ -493,10 +494,9 @@ contains
             read(var,'(A4,I2.2)') aux, i !> \deprecated BEWARE 0 <= i <= 99, no other indices can be dumped to hdf file
             tab(:,:,:) = cg%w(wna%ind(dfpq%q_nam))%arr(i,RNG)  !flind%cre%fbeg+i-1, RNG)
 #endif /* CRESP */
-         case ("trcr")
-            ! How to show second tracer?
-            ! What if no tracers are there?
-            tab(:,:,:) = cg%u(flind%trc%beg, RNG)
+         case ("tracer_00" : "tracer_99")  ! Beware: depends on inittracer::tracers_max
+            read(var,'(A7,I2.2)') aux, i
+            tab(:,:,:) = cg%u(iarr_trc(i), RNG)
          case ("dend", "deni", "denn")
             if (associated(fl_dni)) tab(:,:,:) = cg%u(fl_dni%idn, RNG)
          case ("vlxd", "vlxn", "vlxi", "vlyd", "vlyn", "vlyi", "vlzd", "vlzn", "vlzi")

--- a/src/IO/hdf5/restart_hdf5_v2.F90
+++ b/src/IO/hdf5/restart_hdf5_v2.F90
@@ -965,7 +965,7 @@ contains
       use domain,           only: dom
       use grid_cont,        only: grid_container
       use hdf5,             only: HID_T, HSIZE_T, H5S_SELECT_SET_F, H5T_NATIVE_DOUBLE, &
-           &                      h5dopen_f, h5dclose_f, h5dget_space_f, h5dread_f, h5gopen_f, h5gclose_f, h5screate_simple_f, h5sselect_hyperslab_f
+           &                      h5dopen_f, h5dclose_f, h5dget_space_f, h5dread_f, h5gopen_f, h5gclose_f, h5screate_simple_f, h5sselect_hyperslab_f, h5sget_simple_extent_dims_f
       use named_array_list, only: qna, wna
       use overlap,          only: is_overlap
 #ifdef NBODY
@@ -988,7 +988,7 @@ contains
       integer(HID_T)                               :: cg_g_id !< cg group identifier
       integer(HID_T)                               :: dset_id
       integer(HID_T)                               :: filespace, memspace
-      integer(HSIZE_T), dimension(:), allocatable  :: dims, off, cnt
+      integer(HSIZE_T), dimension(:), allocatable  :: dims, off, cnt, restart_dims, restart_maxdims
       integer(kind=4)                              :: error                          !< error perhaps should be of type integer(HID_T)
       integer(kind=8), dimension(xdim:zdim)        :: own_off, restart_off, o_size   ! the position and size of the overlapped region
       integer(kind=8), dimension(xdim:zdim, LO:HI) :: own_box_nb, restart_box_nb              ! variants for AT_NO_B
@@ -1067,25 +1067,30 @@ contains
       endif
 
       if (size(wr_lst) > 0) then
-         allocate(dims(ndims+1), off(ndims+1), cnt(ndims+1))
+         allocate(dims(ndims+1), off(ndims+1), cnt(ndims+1), restart_dims(ndims+1), restart_maxdims(ndims+1))
          do i = lbound(wr_lst, dim=1, kind=4), ubound(wr_lst, dim=1, kind=4)
             call pick_off_and_size(wna%lst(wr_lst(i))%restart_mode, o_size, restart_off, own_off)
             dims(:) = [ int(wna%get_dim4(wr_lst(i)), kind=HSIZE_T), int(o_size(:), kind=HSIZE_T) ]
             call h5dopen_f(cg_g_id, wna%lst(wr_lst(i))%name, dset_id, error)
             call h5dget_space_f(dset_id, filespace, error)
+            call h5sget_simple_extent_dims_f(filespace, restart_dims, restart_maxdims, error)
+            if (wna%get_dim4(wr_lst(i)) /= restart_dims(1)) call fluids_warning(wna%lst(i)%name, int(wna%get_dim4(wr_lst(i)), kind=HSIZE_T), restart_dims(1))
+            if (wna%get_dim4(wr_lst(i)) > restart_dims(1)) dims(:) = restart_dims(:)
             off(:) = [ 0_HSIZE_T, restart_off(:) ]
             cnt(:) = 1
             call h5sselect_hyperslab_f(filespace, H5S_SELECT_SET_F, off(:), cnt(:), error, block=dims(:))
             call h5screate_simple_f(size(dims, kind=4), dims(:), memspace, error)
             allocate(a4d(dims(1), dims(1+xdim), dims(1+ydim), dims(1+zdim)))
             call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, a4d, dims(:), error, file_space_id = filespace, mem_space_id = memspace)
-            cg%w(wr_lst(i))%arr(:, cg%is+own_off(xdim):cg%is+own_off(xdim)+o_size(xdim)-1, &
-                 &                 cg%js+own_off(ydim):cg%js+own_off(ydim)+o_size(ydim)-1, &
-                 &                 cg%ks+own_off(zdim):cg%ks+own_off(zdim)+o_size(zdim)-1) = a4d(:,:,:,:)
+            cg%w(wr_lst(i))%arr(1:dims(1), &
+                 &              cg%is+own_off(xdim):cg%is+own_off(xdim)+o_size(xdim)-1, &
+                 &              cg%js+own_off(ydim):cg%js+own_off(ydim)+o_size(ydim)-1, &
+                 &              cg%ks+own_off(zdim):cg%ks+own_off(zdim)+o_size(zdim)-1) = a4d(:, :, :, :)
+            if (wna%get_dim4(wr_lst(i)) > restart_dims(1)) cg%w(wr_lst(i))%arr(restart_dims(1)+1:, :, :, :) = 0.  ! clear components that weren't present in the restart file
             deallocate(a4d)
             call h5dclose_f(dset_id, error)
          enddo
-         deallocate(dims, off, cnt)
+         deallocate(dims, off, cnt, restart_dims, restart_maxdims)
       endif
 
 #ifdef NBODY
@@ -1219,6 +1224,38 @@ contains
          enddo
 
       end subroutine calc_off_and_size
+
+      subroutine fluids_warning(name, size_cur, size_res)
+
+         use constants,  only: INVALID, dsetnamelen
+         use dataio_pub, only: msg, warn
+
+         implicit none
+
+         character(len=dsetnamelen), intent(in) :: name
+         integer(HSIZE_T),           intent(in) :: size_cur, size_res
+
+         logical, save :: warned = .false.
+         integer(HSIZE_T), save :: prev_size_cur = INVALID, prev_size_res = INVALID
+
+         if (warned) warned = ((prev_size_cur == size_cur) .and. (prev_size_res == size_res))  ! check for an additional (unexpected) change
+
+         if (.not. warned) then
+            call warn("[restart_hdf5_v2:read_cg_from_restart:fluids_warning] Number of components in array '" // trim(name) // "' has changed.")
+            write(msg, '(2(a,i0),a)')"[restart_hdf5_v2:read_cg_from_restart:fluids_warning] The restart file contains ", size_res, " components, current setup has ", size_cur, " components."
+            call warn(msg)
+            call warn("[restart_hdf5_v2:read_cg_from_restart:fluids_warning] Hope this is due to a change in the number of tracer fluids, expect crash otherwise.")
+            if (size_cur > size_res) then
+               call warn("[restart_hdf5_v2:read_cg_from_restart:fluids_warning] New components will be initialized with zeroes.")
+            else
+               call warn("[restart_hdf5_v2:read_cg_from_restart:fluids_warning] Extra components from the restart file will be forgotten.")
+            endif
+            prev_size_cur = size_cur
+            prev_size_res = size_res
+            warned = .true.
+         endif
+
+      end subroutine fluids_warning
 
    end subroutine read_cg_from_restart
 

--- a/src/base/finalizepiernik.F90
+++ b/src/base/finalizepiernik.F90
@@ -51,6 +51,7 @@ contains
       use grid,                  only: cleanup_grid
       use grid_container_ext,    only: cg_extptrs
       use initfluids,            only: cleanup_fluids
+      use inittracer,            only: cleanup_tracer
       use interactions,          only: cleanup_interactions
       use procnames,             only: pnames
       use tag_pool,              only: t_pool
@@ -95,6 +96,7 @@ contains
 #ifdef MULTIGRID
       call cleanup_multigrid;      call nextdot
 #endif /* MULTIGRID */
+      call cleanup_tracer;         call nextdot
       call cleanup_fluids;         call nextdot
 #if defined(GRAV) && defined(NBODY)
       call cleanup_particles;      call nextdot

--- a/src/fluids/fluidindex.F90
+++ b/src/fluids/fluidindex.F90
@@ -52,7 +52,7 @@ module fluidindex
    private :: ndims, var_numbers ! QA_WARN: prevent reexporting
    public ! QA_WARN no secrets are kept here
 
-   type(var_numbers),save :: flind     !< COMMENT ME
+   type(var_numbers), save :: flind     !< COMMENT ME
 
    integer(kind=4), parameter  :: nmag = ndims     !< number of magnetic field components
 
@@ -119,12 +119,10 @@ contains
       use initdust,       only: dust_fluid
       use initionized,    only: ion_fluid
       use initneutral,    only: neutral_fluid
+      use inittracer,     only: tracer_index, iarr_trc
 #ifdef COSM_RAYS
       use initcosmicrays, only: iarr_crn, iarr_cre, iarr_crs, cosmicray_index
 #endif /* COSM_RAYS */
-#ifdef TRACER
-      use inittracer,     only: tracer_index, iarr_trc
-#endif /* TRACER */
 
       implicit none
 
@@ -155,9 +153,7 @@ contains
       call cosmicray_index(flind)
 #endif /* !COSM_RAYS */
 
-#ifdef TRACER
       call tracer_index(flind)
-#endif /* TRACER */
 
 ! Allocate index arrays
       allocate(iarr_mag_swp(ndims,nmag),iarr_all_mag(nmag))
@@ -180,11 +176,7 @@ contains
       allocate(iarr_all_crs(0))
 #endif /* !COSM_RAYS */
 
-#ifdef TRACER
       allocate(iarr_all_trc(flind%trc%all))
-#else /* !TRACER */
-      allocate(iarr_all_trc(0))
-#endif /* !TRACER */
 
       ! Compute index arrays for magnetic field
       iarr_mag_swp(xdim,:) = [xdim,ydim,zdim]
@@ -212,13 +204,11 @@ contains
       iarr_all_crs(1:flind%crs%all) = iarr_crs
 #endif /* COSM_RAYS */
 
-#ifdef TRACER
       iarr_all_swp(xdim,flind%trc%beg:flind%trc%end) = iarr_trc
       iarr_all_swp(ydim,flind%trc%beg:flind%trc%end) = iarr_trc
       iarr_all_swp(zdim,flind%trc%beg:flind%trc%end) = iarr_trc
 
       iarr_all_trc(1:flind%trc%all) = iarr_trc
-#endif /* TRACER */
 
       allocate(flind%all_fluids(flind%fluids))
 

--- a/src/fluids/fluidtypes.F90
+++ b/src/fluids/fluidtypes.F90
@@ -62,6 +62,7 @@ module fluidtypes
       integer(kind=4) :: beg = 0   !< beginning number of variables in fluid/component
       integer(kind=4) :: end = 0   !< end number of variables in fluid/component
       integer(kind=4) :: pos = 0   !< index denoting position of the fluid in the row of fluids
+      ! 'pos' seems to be only auxiliary, consider removing it.
 #ifdef CRESP
       integer(kind=4) :: nbeg = 0  !< beginning number of number density components for fluid/component (cre) !!!
       integer(kind=4) :: ebeg = 0  !< beginning number of energy density components for fluid/component (cre) !!!
@@ -120,6 +121,7 @@ module fluidtypes
       integer(kind=4) :: fluids      = 0      !< number of fluids (ionized gas, neutral gas, dust)
       integer(kind=4) :: energ       = 0      !< number of non-isothermal fluids (indicating the presence of energy density in the vector of conservative variables)
       integer(kind=4) :: components  = 0      !< number of components, such as CRs, tracers, magnetic helicity (in future), whose formal description does not involve [???]
+      ! 'components' seems to be only auxiliary, consider removing it.
       integer(kind=4) :: fluids_sg   = 0      !< number of selfgravitating fluids (ionized gas, neutral gas, dust)
 
       type(fluid_arr), dimension(:), pointer :: all_fluids

--- a/src/fluids/fluxes.F90
+++ b/src/fluids/fluxes.F90
@@ -76,13 +76,11 @@ contains
 
       use fluidindex,     only: flind, nmag
       use fluidtypes,     only: component_fluid
+      use fluxtracer,     only: flux_tracer
+      use inittracer,     only: ntracers, trace_fluid
 #ifdef COSM_RAYS
       use fluxcosmicrays, only: flux_crs
 #endif /* COSM_RAYS */
-#ifdef TRACER
-      use fluxtracer,     only: flux_tracer
-      use inittracer,     only: trace_fluid
-#endif /* TRACER */
 
       implicit none
 
@@ -96,9 +94,7 @@ contains
 
       real, dimension(:,:),             pointer                :: pflux, pcfr, puu, pbb
       real, dimension(:),               pointer                :: pvx
-#ifdef TRACER
       real, dimension(:),               pointer                :: pu1d, pfl1d
-#endif /* TRACER */
       class(component_fluid),           pointer                :: pfl
       integer                                                  :: p
 !>
@@ -128,15 +124,13 @@ contains
       cfr (:, flind%crs%beg:flind%crs%end) = spread(cfr(:, flind%all_fluids(1)%fl%iarr(1)), 2, flind%crs%all)
 #endif /* COSM_RAYS */
 
-#ifdef TRACER
-      do p = 1, size(trace_fluid)
+      do p = 1, ntracers
          pu1d  =>   uu(:, flind%trc%beg + p - 1)
          pfl1d => flux(:, flind%trc%beg + p - 1)
          pvx   =>   vx(:, flind%all_fluids(trace_fluid(p))%fl%pos)
          call flux_tracer(pfl1d, pu1d, pvx)
-         cfr(:, flind%trc%beg + p - 1)  = cfr(:, flind%all_fluids(trace_fluid(p))%fl%iarr(1))
+         cfr(:, flind%trc%beg + p - 1)  = cfr(:, flind%all_fluids(trace_fluid(p))%fl%idn)
       enddo
-#endif /* TRACER */
 
    end subroutine all_fluxes
 

--- a/src/fluids/initfluids.F90
+++ b/src/fluids/initfluids.F90
@@ -115,6 +115,7 @@ contains
       use initdust,       only: init_dust
       use initionized,    only: init_ionized
       use initneutral,    only: init_neutral
+      use inittracer,     only: init_tracer
       use mass_defect,    only: init_magic_mass
 #ifdef COSM_RAYS
       use initcosmicrays, only: init_cosmicrays
@@ -122,9 +123,6 @@ contains
 #ifdef CRESP
       use initcrspectrum, only: init_cresp
 #endif /* CRESP */
-#ifdef TRACER
-      use inittracer,     only: init_tracer
-#endif /* TRACER */
 #ifdef VERBOSE
       use dataio_pub,     only: printinfo
 #endif /* VERBOSE */
@@ -148,9 +146,7 @@ contains
 #ifdef CRESP
       call init_cresp
 #endif /* CRESP */
-#ifdef TRACER
-      call init_tracer
-#endif /* TRACER */
+      call init_tracer(count([has_ion, has_neu, has_dst]))  ! Cannot use flind%fluids yet
 
       call fluid_index    ! flind has valid values afterwards
 

--- a/src/fluids/tracer/fluxtracer.F90
+++ b/src/fluids/tracer/fluxtracer.F90
@@ -51,7 +51,7 @@
 !<
 !*/
 module fluxtracer
-! pulled by TRACER
+
    implicit none
    private
    public :: flux_tracer

--- a/src/fluids/tracer/fluxtracer.F90
+++ b/src/fluids/tracer/fluxtracer.F90
@@ -58,7 +58,6 @@ module fluxtracer
 
 contains
 
-#define RNG2 2:nm
    !>
    !! \brief Compute tracer flux
    !!
@@ -72,14 +71,19 @@ contains
       real, dimension(:), intent(in),    pointer :: uut    !< tracer mass density
       real, dimension(:), intent(in),    pointer :: vx     !< velocity component for current sweep direction
 
-      integer :: n, nm
+      integer :: n
 
-      n = size(fluxt,1); nm = n-1
+      n = size(fluxt, 1)
 
-      fluxt(RNG2) = uut(RNG2) * vx(RNG2)
-      fluxt(1)    = fluxt(2); fluxt(n) = fluxt(nm)
+      associate (nm => n - 1)
+         ! Compute flux in the interior domain
+         fluxt(2:nm) = uut(2:nm) * vx(2:nm)
+
+         ! Set boundary values to match the innermost layer
+         fluxt(1) = fluxt(2)
+         fluxt(n) = fluxt(nm)
+      end associate
 
    end subroutine flux_tracer
-#undef RNG2
 
 end module fluxtracer

--- a/src/fluids/tracer/fluxtracer.F90
+++ b/src/fluids/tracer/fluxtracer.F90
@@ -28,9 +28,9 @@
 
 !/*
 !>
-!! \brief Computation of %fluxes for the tracer fluid
+!! \brief Computation of fluxes for tracer fluids
 !!
-!!The flux functions for dust are given by:
+!! The flux functions for tracer fluids are given by:
 !!\f[
 !!  \vec{F}{(\vec{u})} =
 !!  \left(\begin{array}{c}
@@ -59,13 +59,18 @@ module fluxtracer
 contains
 
 #define RNG2 2:nm
+   !>
+   !! \brief Compute tracer flux
+   !!
+   !! Computes the tracer flux as the product of tracer density and velocity.
+   !! Boundary values are set to match the innermost layer.
    subroutine flux_tracer(fluxt, uut, vx)
 
       implicit none
 
-      real, dimension(:), intent(inout), pointer :: fluxt  !< flux for tracer
-      real, dimension(:), intent(in),    pointer :: uut    !< part of u for tracer
-      real, dimension(:), intent(in),    pointer :: vx     !< velocity field of fluid for current sweep
+      real, dimension(:), intent(inout), pointer :: fluxt  !< flux for tracer density
+      real, dimension(:), intent(in),    pointer :: uut    !< tracer mass density
+      real, dimension(:), intent(in),    pointer :: vx     !< velocity component for current sweep direction
 
       integer :: n, nm
 

--- a/src/fluids/tracer/inittracer.F90
+++ b/src/fluids/tracer/inittracer.F90
@@ -40,16 +40,20 @@
 
 module inittracer
 
+   use constants, only: INT4
    implicit none
 
    private
    public :: init_tracer, cleanup_tracer, tracer_index, iarr_trc, trace_fluid, tracers_max, ntracers
 
-   integer(kind=4), dimension(:), allocatable :: iarr_trc     !< Array of indices to tracers
-   integer(kind=4), dimension(:), allocatable :: trace_fluid  !< Which fluid to trace? Currently possible: ionized, neutral, dust
-   integer(kind=4), protected :: ntracers                     !< Number of tracers
-   integer, parameter :: tracers_max = 10                     !< Maximum allowed number of tracer fluids (arbitrary, some hardcoded bits in data_hdf5 depend on it)
+   integer(kind=INT4), dimension(:), allocatable :: iarr_trc     !< Array of indices to tracers
+   integer(kind=INT4), dimension(:), allocatable :: trace_fluid  !< Which fluid to trace? Currently possible: ionized, neutral, dust
+   integer(kind=INT4), protected :: ntracers                     !< Number of tracers
+   integer(kind=INT4), parameter :: tracers_max = 10_INT4        !< Maximum allowed number of tracer fluids (arbitrary, some hardcoded bits in data_hdf5 depend on it)
 
+   ! Note: trace_fluid is allocatable and listed in FLUID_TRACER. It MUST be allocated
+   ! before any read(nml=FLUID_TRACER) statement, otherwise the read will target an
+   ! unallocated array and crash. See init_tracer.
    namelist /FLUID_TRACER/ ntracers, trace_fluid
 
 contains
@@ -73,7 +77,7 @@ contains
    subroutine init_tracer(num_fluids)
 
       use bcast,      only: piernik_MPI_Bcast
-      use constants,  only: INT4, V_INFO
+      use constants,  only: V_INFO
       use dataio_pub, only: warn, nh, die, printinfo, msg
       use mpisetup,   only: master, slave, ibuff
 
@@ -84,7 +88,7 @@ contains
       integer :: i
 
       if (tracers_max > ubound(ibuff, 1) - 1) call die("[inittracer:init_tracer] Too big tracers_max value - the trace fluid array would not fit ibuff array.")
-      allocate(trace_fluid(tracers_max))
+      allocate(trace_fluid(tracers_max))  ! must precede namelist read; see module-level note
 
       ntracers = 0_INT4  ! no tracer fluid by default
       trace_fluid = 1_INT4  ! trace first fluid by default
@@ -114,8 +118,8 @@ contains
 
       if (slave) then
 
-         ntracers    = int(ibuff(1), kind=4)
-         trace_fluid = int(ibuff(2:1+tracers_max), kind=4)
+         ntracers    = int(ibuff(1), kind=INT4)
+         trace_fluid = int(ibuff(2:1+tracers_max), kind=INT4)
 
       endif
 
@@ -177,7 +181,7 @@ contains
       flind%all      = flind%all + flind%trc%all
       flind%trc%end  = flind%all
 
-      iarr_trc = int([(i, i = 0, ntracers-1)], kind=4) + flind%trc%beg
+      if (ntracers > 0) iarr_trc = int([(i, i = 0, ntracers-1)], kind=INT4) + flind%trc%beg
 
       ! Tracer index position is set to -1 since tracers are initialized last
       ! and no other components depend on their index position

--- a/src/fluids/tracer/inittracer.F90
+++ b/src/fluids/tracer/inittracer.F90
@@ -152,6 +152,7 @@ contains
       implicit none
 
       if (allocated(iarr_trc)) deallocate(iarr_trc)
+      if (allocated(trace_fluid)) deallocate(trace_fluid)
 
    end subroutine cleanup_tracer
 

--- a/src/fluids/tracer/inittracer.F90
+++ b/src/fluids/tracer/inittracer.F90
@@ -26,9 +26,9 @@
 !
 #include "piernik.h"
 !>
-!! \brief Initialization of the tracer fluid
+!! \brief Initialization of tracer fluids
 !!
-!! In this module following variables are defined:
+!! In this module, the following variables are defined:
 !! \n \n
 !! <table border="+1">
 !! <tr><td width="150pt"><b>variable</b></td><td width="135pt"><b>type</b></td><td width="200pt"><b>description</b></td></tr>
@@ -55,7 +55,10 @@ module inittracer
 contains
 
 !>
-!! \brief Routine to set parameter values from namelist FLUID_TRACER
+!! \brief Read tracer fluid parameters from namelist and broadcast via MPI
+!!
+!! Reads the FLUID_TRACER namelist from the configuration file and broadcasts
+!! the parameters to all MPI processes.
 !!
 !! \n \n
 !! @b FLUID_TRACER
@@ -140,13 +143,13 @@ contains
       endif
       if (master) call printinfo(msg, V_INFO)
 
-      ! TODO: deallocate this array somewhere
       allocate(iarr_trc(ntracers))
 
    end subroutine init_tracer
 
-!> \brief Routine to deallocate arrays related to tracer fluids
-
+!> \brief Deallocate tracer fluid arrays
+!!
+!! Deallocates arrays allocated during initialization.
    subroutine cleanup_tracer
 
       implicit none
@@ -156,8 +159,9 @@ contains
 
    end subroutine cleanup_tracer
 
-!> \brief Routine to set indices of tracer fluids in the main data array
-
+!> \brief Set indices of tracer fluids in the main data array
+!!
+!! Assigns index ranges for tracer fluid variables and computes the iarr_trc array.
    subroutine tracer_index(flind)
 
       use constants,  only: I_ONE
@@ -175,7 +179,8 @@ contains
 
       iarr_trc = int([(i, i = 0, ntracers-1)], kind=4) + flind%trc%beg
 
-      ! Tracers are initialized at the end so nothing else depends on these auxiliary fields
+      ! Tracer index position is set to -1 since tracers are initialized last
+      ! and no other components depend on their index position
 !      flind%components = flind%components + 1
 !      flind%trc%pos    = flind%components
       flind%trc%pos    = -1

--- a/src/fluids/tracer/inittracer.F90
+++ b/src/fluids/tracer/inittracer.F90
@@ -28,21 +28,29 @@
 !>
 !! \brief Initialization of the tracer fluid
 !!
-!! In this module following namelist of parameters is specified:
-!! \copydetails inittracer::init_tracer
+!! In this module following variables are defined:
+!! \n \n
+!! <table border="+1">
+!! <tr><td width="150pt"><b>variable</b></td><td width="135pt"><b>type</b></td><td width="200pt"><b>description</b></td></tr>
+!! <tr><td>ntracers</td><td>integer</td><td>Number of tracer fluids enabled in the simulation. Allowed values: 0-10. Default value: 0 (no tracer fluids enabled).</td></tr>
+!! <tr><td>iarr_trc</td><td>integer array</td><td>Array of indices of tracer fluids in the main data array.</td></tr>
+!! </table>
+!! \n \n
 !<
 
 module inittracer
-! pulled by TRACER
+
    implicit none
 
    private
-   public :: init_tracer, tracer_index, iarr_trc, trace_fluid, tracers_max
+   public :: init_tracer, cleanup_tracer, tracer_index, iarr_trc, trace_fluid, tracers_max, ntracers
 
-   integer(kind=4), dimension(:), allocatable :: iarr_trc, trace_fluid
-   integer(kind=4) :: ntracers
-   integer, parameter :: tracers_max = 10
-   integer(kind=4), dimension(tracers_max) :: tracers
+   integer(kind=4), dimension(:), allocatable :: iarr_trc     !< Array of indices to tracers
+   integer(kind=4), dimension(:), allocatable :: trace_fluid  !< Which fluid to trace? Currently possible: ionized, neutral, dust
+   integer(kind=4), protected :: ntracers                     !< Number of tracers
+   integer, parameter :: tracers_max = 10                     !< Maximum allowed number of tracer fluids (arbitrary, some hardcoded bits in data_hdf5 depend on it)
+
+   namelist /FLUID_TRACER/ ntracers, trace_fluid
 
 contains
 
@@ -54,25 +62,29 @@ contains
 !! \n \n
 !! <table border="+1">
 !! <tr><td width="150pt"><b>parameter</b></td><td width="135pt"><b>default value</b></td><td width="200pt"><b>possible values</b></td><td width="315pt"> <b>description</b></td></tr>
-!! <tr><td>tracers</td><td>0</td><td>10-element integer array</td><td>\copydoc inittracer::tracers</td></tr>
+!! <tr><td>ntracers</td><td>0</td><td>1-10</td><td>\copydoc inittracer::ntracers</td></tr>
+!! <tr><td>trace_fluid</td><td>1</td><td>1-3</td><td>\copydoc inittracer::trace_fluid</td></tr>
 !! </table>
-!! The list is active while \b "TRACER" is defined.
 !! \n \n
 !<
-   subroutine init_tracer
+   subroutine init_tracer(num_fluids)
 
       use bcast,      only: piernik_MPI_Bcast
-      use constants,  only: INT4
-      use dataio_pub, only: warn, nh, die
+      use constants,  only: INT4, V_INFO
+      use dataio_pub, only: warn, nh, die, printinfo, msg
       use mpisetup,   only: master, slave, ibuff
 
       implicit none
 
-      namelist /FLUID_TRACER/ tracers
+      integer, intent(in) :: num_fluids
 
-      if (tracers_max > ubound(ibuff, 1)) call die("[inittracer:init_tracer] tracers_max exceeds ibuff size")
+      integer :: i
 
-      tracers(:) = 0_INT4; tracers(1) = 1_INT4 ! activate only first tracer fluid by default
+      if (tracers_max > ubound(ibuff, 1) - 1) call die("[inittracer:init_tracer] Too big tracers_max value - the trace fluid array would not fit ibuff array.")
+      allocate(trace_fluid(tracers_max))
+
+      ntracers = 0_INT4  ! no tracer fluid by default
+      trace_fluid = 1_INT4  ! trace first fluid by default
 
       if (master) then
          if (.not.nh%initialized) call nh%init()
@@ -91,37 +103,67 @@ contains
          close(nh%lun)
          call nh%compare_namelist()
 
-         ibuff(1:tracers_max)   = tracers
+         ibuff(1)   = ntracers
+         ibuff(2:1+tracers_max) = trace_fluid
       endif
 
       call piernik_MPI_Bcast(ibuff)
 
       if (slave) then
 
-         tracers  = int(ibuff(1:tracers_max), kind=4)
+         ntracers    = int(ibuff(1), kind=4)
+         trace_fluid = int(ibuff(2:1+tracers_max), kind=4)
 
       endif
 
-      !! \deprecated The values of tracers are ignored except that we just count how many non-0 components are there.
-      !! Seems overcomplicated, we can read ntracers directly as well.
+      if (ntracers < 0) then
+         call warn("[inittracer:init_tracer] Negative number of tracers provided. Reset to 0")
+         ntracers = 0
+      elseif (ntracers > tracers_max) then
+         write(msg, "(A,I0)") "[inittracer:init_tracer] Too many tracers provided. Reset to maximum allowed value: ", tracers_max
+         call warn(msg)
+         ntracers = tracers_max
+      endif
 
-      ntracers = count(tracers > 0, kind=4)
+      if (any(trace_fluid(1:ntracers) < 1) .or. any(trace_fluid(1:ntracers) > num_fluids)) then
+         call warn("[inittracer:init_tracer] Some values of trace_fluid(:) are invalid. Reset them to the default value (1).")
+         where (trace_fluid(1:ntracers) < 1 .or. trace_fluid(1:ntracers) > num_fluids) trace_fluid(1:ntracers) = 1_INT4
+      endif
 
-      if (ntracers < 1) call warn("[inittracer:init_tracer] all tracer fluids are disabled")
+      if (ntracers == 0) then
+         msg = "[inittracer:init_tracer] No tracer fluids are enabled"
+      else
+         write(msg, "(A,I0, A)") "[inittracer:init_tracer] Number of tracer fluids enabled: ", ntracers, ". Traced fluids: "
+         do i = 1, ntracers
+            write(msg(len_trim(msg)+1:), "(' ',I0)") trace_fluid(i)
+         enddo
+      endif
+      if (master) call printinfo(msg, V_INFO)
 
-      ! TODO: deallocate those arrays somewhere
-      allocate(trace_fluid(ntracers))
+      ! TODO: deallocate this array somewhere
       allocate(iarr_trc(ntracers))
-
-      trace_fluid = pack(tracers, mask=(tracers > 0))
 
    end subroutine init_tracer
 
+!> \brief Routine to deallocate arrays related to tracer fluids
+
+   subroutine cleanup_tracer
+
+      implicit none
+
+      if (allocated(iarr_trc)) deallocate(iarr_trc)
+
+   end subroutine cleanup_tracer
+
+!> \brief Routine to set indices of tracer fluids in the main data array
+
    subroutine tracer_index(flind)
+
       use constants,  only: I_ONE
       use fluidtypes, only: var_numbers
 
       implicit none
+
       type(var_numbers), intent(inout) :: flind
       integer :: i
 
@@ -131,6 +173,8 @@ contains
       flind%trc%end  = flind%all
 
       iarr_trc = int([(i, i = 0, ntracers-1)], kind=4) + flind%trc%beg
+
+      ! Tracers are initialized at the end so nothing else depends on these auxiliary fields
 !      flind%components = flind%components + 1
 !      flind%trc%pos    = flind%components
       flind%trc%pos    = -1

--- a/src/grid/cg_list_global.F90
+++ b/src/grid/cg_list_global.F90
@@ -302,20 +302,16 @@ contains
 
       subroutine set_fluid_names
 
+         use constants,        only: dsetnamelen
          use fluidindex,       only: flind
          use fluids_pub,       only: has_dst, has_ion, has_neu
+         use inittracer,       only: tracers_max, ntracers
          use named_array_list, only: wna, na_var_4d
-#ifdef TRACER
-         use constants,        only: dsetnamelen
-         use inittracer,       only: tracers_max
-#endif /* TRACER */
 
          implicit none
 
-#ifdef TRACER
          integer(kind=4) :: i, itrc
          character(len=dsetnamelen) :: trc_name, fmt
-#endif /* TRACER */
 
          select type (lst => wna%lst)
             type is (na_var_4d)
@@ -341,15 +337,17 @@ contains
                   call lst(wna%fi)%set_compname(flind%dst%imy, "momyd")
                   call lst(wna%fi)%set_compname(flind%dst%imz, "momzd")
                endif
-#ifdef TRACER
-               write(fmt, '(i9)') tracers_max
-               itrc = len_trim(adjustl(fmt), kind=4)   ! convert max number of tracers into number of required digits
-               write(fmt,'("(a,i",i1,".",i1,")")') itrc, itrc
-               do i = flind%trc%beg, flind%trc%end
-                  write(trc_name, fmt)"tracer_", i - flind%trc%beg + 1
-                  call lst(wna%fi)%set_compname(i, trc_name)
-               enddo
-#endif /* TRACER */
+
+               if (ntracers > 0) then
+                  write(fmt, '(i9)') tracers_max
+                  itrc = len_trim(adjustl(fmt), kind=4)   ! convert max number of tracers into number of required digits
+                  write(fmt,'("(a,i",i1,".",i1,")")') itrc, itrc
+                  do i = flind%trc%beg, flind%trc%end
+                     write(trc_name, fmt)"tracer_", i - flind%trc%beg + 1
+                     call lst(wna%fi)%set_compname(i, trc_name)
+                  enddo
+               endif
+
          end select
 
       end subroutine set_fluid_names


### PR DESCRIPTION
* Tracers are compiled in by default (TRACER symbol is obsolete now), just their amount is 0 unless you specify otherwise in `problem.par`.
* It is now possible to decrease or increase the number of tracers after restart. Piernik will warn you and try to continue in hope that it is only the number of tracers that has changed. If you change number of cosmic rays, it is **your** fault :)