### PR TITLE
CRESP fixes - logical param fixes, pitch-angle integrated B for synchrotron

### DIFF
--- a/jenkins/gold_configs/mcrtest_CRESP.config
+++ b/jenkins/gold_configs/mcrtest_CRESP.config
@@ -1,7 +1,8 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=1aefd3395554cb51389944837ba48eafc8ee46a7
+GOLD_COMMIT=9a3282a472026e05ae7d96a02fd6b8c9b1d3e144
 
+# 9a3282a472026e05ae7d96a02fd6b8c9b1d3e144 - use pitch-angle integrated cooling factor for CR synchrotron cooling
 # 1aefd3395554cb51389944837ba48eafc8ee46a7 - fix for nonconvergence due to uninitialized variables
 # 649dd5c68b7da35b96de30b87244e3aa5fb64a5a - small change that was causing a 6e-29 discrepancy in gdf_diff
 # aca398c6924df3eb7c01907e2938483242e5ee1c - fixed bug in common_hdf5

--- a/src/fluids/cosmicrays/cresp_NR_method.F90
+++ b/src/fluids/cosmicrays/cresp_NR_method.F90
@@ -527,6 +527,7 @@ contains
 
       sought_by = SLV
 #endif /* CRESP_VERBOSED */
+      exit_code = .true.
 
       prev_solution(1) = p_space(1)
       prev_solution(2) = p_space(1)**q_space(1)
@@ -657,6 +658,7 @@ contains
       real, dimension(1:2)                :: prev_solution
       logical                             :: exit_code
 
+      exit_code = .true.
       prev_solution(1) = p_space(1)              ! refine must be called before these are deallocated
       prev_solution(2) = p_space(1)**q_space(1)
       call prepare_indices(arr_dim_a, i_incr, i_beg, i_end)
@@ -696,6 +698,7 @@ contains
       real, dimension(1:2)                :: prev_solution
       logical                             :: exit_code
 
+      exit_code = .true.
       prev_solution(1) = p_space(1)              ! refine must be called before these are deallocated
       prev_solution(2) = p_space(1)**q_space(1)
       call prepare_indices(arr_dim_a, i_incr, i_beg, i_end)
@@ -1240,6 +1243,7 @@ contains
       real                            :: blin_a, blin_n
       integer(kind=4), dimension(1:2) :: l1, l2 ! indexes that points where alpha_tab_ and up and n_tab_ and up are closest in value to a_val and n_val - indexes point to
 
+      successful = .false.
 #ifdef CRESP_VERBOSED
       write (*,"(A30,A2,A4)",advance="no") "Determining indices for case: ", bound_name(co), "... "  ! QA_WARN debug
 #endif /* CRESP_VERBOSED */
@@ -1273,8 +1277,8 @@ contains
       integer(kind=4),                 intent(in)  :: co
       real,                            intent(in)  :: a_val, n_val
       integer(kind=4), dimension(1:2), intent(out) :: loc1
-      logical,                         intent(out) :: successful
-      logical                                      :: hit_zero
+      logical,                         intent(inout) :: successful
+      logical                                        :: hit_zero
 
       hit_zero  = .false.
       loc1(1) = inverse_f_to_ind(a_val, alpha_tab(co, 1), alpha_tab(co, arr_dim_a), arr_dim_a)

--- a/src/fluids/cosmicrays/cresp_crspectrum.F90
+++ b/src/fluids/cosmicrays/cresp_crspectrum.F90
@@ -515,6 +515,7 @@ contains
       has_n_gt_zero(:) = .false. ; has_e_gt_zero(:)  = .false.
       is_active_bin(:) = .false. ; is_active_edge(:) = .false.
       num_has_gt_zero  = I_ZERO  ; num_active_bins   = I_ZERO
+      empty_cell       = .false.
       pre_i_cut = max_ic
       i_cut     = max_ic
       if (allocated(nonempty_bins)) deallocate(nonempty_bins)
@@ -756,6 +757,8 @@ contains
       integer                            :: i
       logical, intent(inout)             :: negatives_found
 
+      negatives_found = .false.
+
       do i = 1, ncrb
          if (e(i) < zero .or. n(i) < zero .or. edt(i) < zero .or. ndt(i) < zero) then
             if (present(location)) then
@@ -784,6 +787,8 @@ contains
       real,            intent(in)    :: n_bin, e_bin
       integer(kind=4), intent(in)    :: i_bin
       logical,         intent(inout) :: cfl_cresp_violated
+
+      cfl_cresp_violated = .false.
 
       if (e_bin < zero .or. n_bin < zero) then
 #ifdef CRESP_VERBOSED
@@ -936,6 +941,8 @@ contains
       fail_count_interpol = 0
       fail_count_NR_2dim  = 0
       fail_count_comp_q   = 0
+
+      exit_code = .false.
 
       approx_p    = e_small_approx_p
       e_threshold = e_small_approx_p * e_small
@@ -1817,6 +1824,8 @@ contains
 
       ipfix = i_cut(cutoff) + pm(cutoff)
       qi    = i_cut(cutoff) + oz(cutoff)
+      exit_code = .false.
+
       call assoc_pointers(cutoff)
 
       alpha = e(qi)/(n(qi) * p_fix(ipfix) * clight_cresp)
@@ -1833,7 +1842,6 @@ contains
 #ifdef CRESP_VERBOSED
       write (msg, "(A27,A2,A2,2E22.15)") "Input ratios(p, f) for NR (", bound_name(cutoff), "):", x_NR  ; call printinfo(msg)
 #endif /* CRESP_VERBOSED */
-      exit_code = .false.
       if (NR_refine_pf(cutoff)) then
          call NR_algorithm(x_NR, exit_code)
          if (exit_code) then ! some failures still take place

--- a/src/fluids/cosmicrays/cresp_grid.F90
+++ b/src/fluids/cosmicrays/cresp_grid.F90
@@ -124,7 +124,7 @@ contains
       use global,           only: dt
       use grid_cont,        only: grid_container
       use initcosmicrays,   only: iarr_cre_e, iarr_cre_n
-      use initcrspectrum,   only: adiab_active, synch_active, icomp_active, icomp_active, cresp, crel, dfpq, f_synchIC, spec_mod_trms, u_b_max, use_cresp_evol
+      use initcrspectrum,   only: adiab_active, synch_active, icomp_active, icomp_active, cresp, crel, dfpq, f_loss_B, f_loss_IC, spec_mod_trms, u_b_max, use_cresp_evol
       use initcrspectrum,   only: cresp_substep, n_substeps_max, redshift
       use named_array_list, only: wna
       use ppp,              only: ppp_main
@@ -162,7 +162,7 @@ contains
          call cg%costs%start
 
          sptab%ucmb  = 0.0
-         if (icomp_active) sptab%ucmb = enden_CMB(redshift) * f_synchIC
+         if (icomp_active) sptab%ucmb = enden_CMB(redshift) * f_loss_IC
 
          do k = cg%ks, cg%ke
             do j = cg%js, cg%je
@@ -170,7 +170,7 @@ contains
                   sptab%ud = 0.0 ; sptab%ub = 0.0; sptab%umag = 0.0
                   cresp%n = cg%u(iarr_cre_n, i, j, k)
                   cresp%e = cg%u(iarr_cre_e, i, j, k)
-                  if (synch_active) sptab%umag = min(emag(cg%b(xdim,i,j,k), cg%b(ydim,i,j,k), cg%b(zdim,i,j,k)) * f_synchIC, u_b_max) !< WARNING assusmes that b is in mGs
+                  if (synch_active) sptab%umag = min(emag(cg%b(xdim,i,j,k), cg%b(ydim,i,j,k), cg%b(zdim,i,j,k)) * f_loss_B, u_b_max)
                   if (adiab_active) sptab%ud   = cg%q(divv_i)%point([i,j,k]) * onet
                   sptab%ub = sptab%umag + sptab%ucmb  ! prepare term for synchrotron + IC losses
 

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -42,7 +42,7 @@ module initcrspectrum
            & smallcren, smallcree, max_p_ratio, NR_iter_limit, force_init_NR, NR_run_refine_pf, NR_refine_solution_q, NR_refine_pf, nullify_empty_bins, synch_active, adiab_active,                 &
            & icomp_active, allow_source_spectrum_break, cre_active, tol_f, tol_x, tol_f_1D, tol_x_1D, arr_dim_a, arr_dim_n, arr_dim_q, eps, eps_det, w, p_fix, p_mid_fix, total_init_cree, p_fix_ratio,           &
            & spec_mod_trms, cresp_all_edges, cresp_all_bins, norm_init_spectrum, cresp, crel, dfpq, f_synchIC, init_cresp, cleanup_cresp_sp, check_if_dump_fpq, cleanup_cresp_work_arrays, q_eps,     &
-           & u_b_max, def_dtsynchIC, def_dtadiab, NR_smap_file, NR_allow_old_smaps, cresp_substep, n_substeps_max, allow_unnatural_transfer, K_cresp_paral, K_cresp_perp, p_min_fix, p_max_fix, redshift
+           & u_b_max, def_dtsynchIC, def_dtadiab, NR_smap_file, NR_allow_old_smaps, cresp_substep, n_substeps_max, allow_unnatural_transfer, K_cresp_paral, K_cresp_perp, p_min_fix, p_max_fix, redshift, f_loss_IC, f_loss_B
 
 ! contains routines reading namelist in problem.par file dedicated to cosmic ray electron spectrum and initializes types used.
 ! available via namelist COSMIC_RAY_SPECTRUM
@@ -161,7 +161,7 @@ module initcrspectrum
    end type dump_fpq_type
    type(dump_fpq_type) :: dfpq
 
-   real :: f_synchIC, def_dtadiab, def_dtsynchIC
+   real :: f_synchIC, f_loss_IC, f_loss_B, def_dtadiab, def_dtsynchIC
 
 contains
 
@@ -597,13 +597,15 @@ contains
 
       f_synchIC = (4. / 3. ) * sigma_T / (me * clight)
       write (msg, *) "[initcrspectrum:init_cresp] 4/3 * sigma_T / ( me * c ) = ", f_synchIC
+      f_loss_B  = f_synchIC * 2. / 3.     ! separate factors: synchrotron cooling is applied isotropically -- factor 2/3 pitch angle integration
+      f_loss_IC = f_synchIC
 
       def_dtadiab   = cfl_cre * half * three * logten * w
       def_dtsynchIC = cfl_cre * half * w
 
       if (master) call printinfo(msg)
 
-      u_b_max = f_synchIC * emag(b_max_db, 0., 0.)   !< initializes factor for comparing u_b with u_b_max
+      u_b_max = f_loss_B * emag(b_max_db, 0., 0.)   !< initializes factor for comparing u_b with u_b_max
 
       write (msg, "(A,F10.4,A,ES12.5)") "[initcrspectrum:init_cresp] Maximal B_tot =",b_max_db, "mGs, u_b_max = ", u_b_max
       if (master)  call warn(msg)

--- a/src/fluids/cosmicrays/timestep_cresp.F90
+++ b/src/fluids/cosmicrays/timestep_cresp.F90
@@ -58,7 +58,7 @@ contains
       use grid_cont,        only: grid_container
       use initcosmicrays,   only: cfl_cr, iarr_cre_e, iarr_cre_n, diff_max_lev
       use initcrspectrum,   only: K_cresp_paral, K_cresp_perp, spec_mod_trms, synch_active, adiab_active, icomp_active, &
-           &                      use_cresp_evol, cresp, f_synchIC, u_b_max, cresp_substep, n_substeps_max, redshift
+           &                      use_cresp_evol, cresp, f_loss_B, f_loss_IC, u_b_max, cresp_substep, n_substeps_max, redshift
 
       implicit none
 
@@ -94,13 +94,13 @@ contains
          endif
 
          sptab%ucmb = zero
-         if (icomp_active) sptab%ucmb = enden_CMB(redshift) * f_synchIC ! NOTICE redshift is hard-coded to zero (current epoch)
+         if (icomp_active) sptab%ucmb = enden_CMB(redshift) * f_loss_IC ! NOTICE redshift is hard-coded to zero (current epoch)
 
          do k = cg%ks, cg%ke
             do j = cg%js, cg%je
                do i = cg%is, cg%ie
                   sptab%ub = zero ; sptab%ud = zero ; sptab%umag = zero ; empty_cell = .false.
-                  if (synch_active) sptab%umag = emag(cg%b(xdim,i,j,k), cg%b(ydim,i,j,k), cg%b(zdim,i,j,k)) * f_synchIC
+                  if (synch_active) sptab%umag = emag(cg%b(xdim,i,j,k), cg%b(ydim,i,j,k), cg%b(zdim,i,j,k)) * f_loss_B
                   cresp%n = cg%u(iarr_cre_n, i, j, k)
                   cresp%e = cg%u(iarr_cre_e, i, j, k)
                   call cresp_find_prepare_spectrum(cresp%n, cresp%e, empty_cell, i_up_max_tmp) ! needed for synchrotron timestep


### PR DESCRIPTION
Contains fixes for potentially uninitialized logical parameters, assumes pitch-angle integrated B for synchrotron cooling in CRESP.
The latter results in splitting of 'f_synchIC' to separate factors for synchrotron & IC process -> f_loss_B, f_loss_IC.

GOLD change!
Changes in synchrotron cooling coefficient result in slower changes (CRe- cool less in time unit), fixed logical parameters on the other hand improve active bin detection (bins are longer evolved / subjected to loss processes).