### PR TITLE
CRESP 1-zone problem: introduce spectrum injection

### DIFF
--- a/problems/testing_and_debuging/cresp_1cell/initproblem.F90
+++ b/problems/testing_and_debuging/cresp_1cell/initproblem.F90
@@ -40,10 +40,12 @@ module initproblem
    private
    public :: read_problem_par, problem_initial_conditions, problem_pointers
 
-   real                     :: d0, p0, bx0, by0, bz0, amp_cr1, u_d0, u_b0, u_d_ampl, omega_d, Btot
+   real                     :: d0, p0, bx0, by0, bz0, amp_cr1, u_d0, u_b0, u_d_ampl, omega_d, Btot, &
+                               injection_rate
    character(len=cbuff_len) :: outfile
 
-   namelist /PROBLEM_CONTROL/ d0, p0, bx0, by0, bz0, amp_cr1, u_d0, u_b0, u_d_ampl, omega_d, Btot, outfile
+   namelist /PROBLEM_CONTROL/ d0, p0, bx0, by0, bz0, amp_cr1, u_d0, u_b0, u_d_ampl, omega_d, Btot, &
+                              outfile, injection_rate
 
 contains
 
@@ -81,6 +83,7 @@ contains
       u_d_ampl = -0.2        !< amplitude of variable u_d component (periodic), sums up with u_d0 to u_d
       omega_d  = 0.157079633 !< omega_d parameter for test with periodic adiabatic compression: u_d(t) = u_d0 + u_d_ampl * cos(omega_d * t)
       Btot     = 0.          !< Total amplitude of MF in micro Gauss
+      injection_rate = 0.    !< injects initial spectrum at rate of injection_rate * total_init_cree / time_unit
 
       outfile  = 'crs.dat'
 
@@ -113,6 +116,7 @@ contains
          rbuff(9)  = u_d_ampl
          rbuff(10) = omega_d
          rbuff(11) = Btot
+         rbuff(12) = injection_rate
 
          cbuff(1)  = outfile
 
@@ -134,6 +138,7 @@ contains
          u_d_ampl = rbuff(9)
          omega_d  = rbuff(10)
          Btot     = rbuff(11)
+         injection_rate = rbuff(12)
 
          outfile   = trim(cbuff(1))
 
@@ -234,6 +239,7 @@ contains
       logical, intent(in) :: forward
 
       if (forward) then
+         call inject_spectrum
          call append_cooling_terms
       else
          call printer
@@ -319,6 +325,57 @@ contains
       enddo
 
    end subroutine append_cooling_terms
+
+   subroutine inject_spectrum
+
+      use cg_leaves,          only: leaves
+      use cg_list,            only: cg_list_element
+      use fluidindex,         only: flind
+      use fluidtypes,         only: component_fluid
+      use grid_cont,          only: grid_container
+      use global,             only: dt
+      use initcosmicrays,     only: iarr_cre_n, iarr_cre_e
+      use initcrspectrum,     only: cresp
+      use cresp_crspectrum,   only: cresp_get_scaled_init_spectrum
+! #ifdef CRESP_VERBOSED
+      use dataio_pub,         only: msg, printinfo
+! #endif /* CRESP_VERBOSED */
+
+      implicit none
+
+      type(cg_list_element),  pointer     :: cgl
+      type(grid_container),   pointer     :: cg
+      class(component_fluid), pointer     :: fl
+      integer                             :: i, j, k
+
+      fl => flind%ion
+      cgl => leaves%first
+
+      do while (associated(cgl))
+         cg => cgl%cg
+
+         cresp%n =  0.0;  cresp%e = 0.0
+         call cresp_get_scaled_init_spectrum(cresp%n, cresp%e, injection_rate * dt)
+#ifdef CRESP_VERBOSED
+         write (msg, "(A,E16.8)") "Injecting fraction of initial spectrum: ", injection_rate * dt
+         call printinfo(msg)
+         print *, cresp%n
+         print *, cresp%e
+#endif CRESP_VERBOSED
+         do k = cg%ks, cg%ke
+            do j = cg%js, cg%je
+               do i = cg%is, cg%ie
+                  cg%u(iarr_cre_n,i,j,k) = cg%u(iarr_cre_n,i,j,k) + cresp%n   !< update, TODO need to talk to the team if this should be inside if-clause
+                  cg%u(iarr_cre_e,i,j,k) = cg%u(iarr_cre_e,i,j,k) + cresp%e   !< if outside, cresp%n and cresp%e needs to be zeroed
+!                   print *, "n", cg%u(iarr_cre_n,i,j,k)
+!                   print *, "e", cg%u(iarr_cre_e,i,j,k)
+               enddo
+            enddo
+         enddo
+         cgl => cgl%nxt
+      enddo
+
+   end subroutine inject_spectrum
 
    subroutine printer
 

--- a/problems/testing_and_debuging/cresp_1cell/piernik.def
+++ b/problems/testing_and_debuging/cresp_1cell/piernik.def
@@ -6,4 +6,7 @@
 #define COSM_RAYS
 #define CRESP
 
+/* uncomment "DEBUG" to utilize constant_dt functionality */
+/* #define DEBUG */
+
 #define MAGNETIC

--- a/problems/testing_and_debuging/cresp_1cell/problem.par.synch+inj
+++ b/problems/testing_and_debuging/cresp_1cell/problem.par.synch+inj
@@ -1,0 +1,122 @@
+$BASE_DOMAIN
+    n_d    = 4, 1, 1
+    bnd_xl = 'per'
+    bnd_xr = 'per'
+    bnd_yl = 'per'
+    bnd_yr = 'per'
+    bnd_zl = 'per'
+    bnd_zr = 'per'
+    xmin   = -50.0
+    xmax   =  50.0
+    ymin   = -50.0
+    ymax   =  50.0
+    zmin   = -50.0
+    zmax   =  50.0
+ /
+
+ $UNITS
+    units_set = "PSM"
+ /
+
+ $RESTART_CONTROL
+    restart  = 'last'
+    res_id   = ''
+ /
+
+ $END_CONTROL
+    tend   = 100.0
+    nend   = 1000000
+ /
+
+ $OUTPUT_CONTROL
+    problem_name = 'emulate-isolated'
+    run_id       = 'is1'
+    dt_hdf       = 100.0
+    dt_res       = 0.0
+    dt_log       = 1.0e3
+    dt_tsl       = 1.0e3
+    vars(1:)     = 'ener', 'dens', 'magx', 'magy', 'magz', 'encr', 'velx', 'vely', 'velz', 'cree', 'cren', 'cref', 'creq', 'crep'
+ /
+
+ $NUMERICAL_SETUP
+    cfl               = 0.5
+    smalld            = 1.e-3
+    smallei           = 1.e-5
+    integration_order = 2
+    limiter           = 'vanleer'
+    solver_str        = "RTVD"
+    skip_sweep(1:3)   = .false., .true., .true.
+ /
+
+ $FLUID_IONIZED
+    gamma  = 1.66666666666666666
+ /
+
+ $COSMIC_RAYS
+    cfl_cr        = 0.9
+    cr_active     = 0.0
+    ncrb          = 50    ! number of spectrum bins (including cutoff bins)
+    gamma_cr      = 1.333333
+    K_cr_paral(1) = 0.0
+    K_cr_perp(1)  = 0.0
+    divv_scheme   = '6lp'
+ /
+
+ $COSMIC_RAY_SPECTRUM
+    cfl_cre           = 0.1
+    cre_eff           = 0.01
+    p_min_fix         = 1.e0    ! < momentum fixed grid
+    p_max_fix         = 1.e6    ! < momentum fixed grid
+    p_lo_init         = 3.5e0    ! < initial lower cut momentum
+    p_up_init         = 3.5e5   ! < initial upper cut momentum
+    p_br_init_lo      = 3.5e1   ! < initial lower momentum break
+    p_br_init_up      = 3.5e5   ! < iniital upper momentum break
+    expan_order       = 3
+    f_init            = 5.e-12 !1.e-10
+    q_init            = 4.1     ! < initial value of power law coefficient in cre enrgy spectrum
+    q_big             = 30.0
+!    K_cre_paral_1     = 1.e5
+!    K_cre_perp_1      = 1.e3
+    K_cre_pow         = 0.3
+    p_diff            = 20000.  ! Ee ~ 10 GeV, set so as e- of this energy have the same K as protons of 10GeV ! default 1.e4
+    e_small           = 1.0e-10 ! lower energy cutoff for energy-approximated cutoff momenta
+    initial_spectrum  = 'plpc'  !'brpg' ! 'powl', 'brpl', 'bump', 'symf', 'syme', 'plpc'
+    NR_iter_limit     = 50
+    adiab_active      = .false.
+    icomp_active      = .false.
+    synch_active      = .true.
+    use_cresp_evol    = .true.
+    approx_cutoffs    = .true.
+    q_eps             = 0.001  ! optimal: 0.001
+    arr_dim_q         = 1000   ! optimal: 1000
+    NR_refine_solution_q = .false.
+    b_max_db      = 100. ! microgauss
+    cresp_substep = .false.
+    n_substeps_max  = 100
+    NR_smap_file         = 'NR_smaps1.h5'
+ /
+
+ $CR_SPECIES
+   eE  = .true., .false., .true.
+   eH1 = .true., .true., .false.
+ /
+
+ $PROBLEM_CONTROL
+    d0       = 1.0
+    p0       = 1.0
+    bx0      = 0.0
+    by0      = 0.0
+    bz0      = 1.1342882082462484   !10. ! .39894232190023153533 ! 1.0
+    amp_cr1  = 0.1
+    u_b0     = 0.0           ! initial magnetic energy-density
+    u_d0     = 0.0           ! initial magnitude of div_v
+    u_d_ampl = 0.          ! amplitude of variable u_d component (periodic), sums up with u_d0 to u_d
+    omega_d  = 0. ! 0.157079633   ! omega_d parameter for test with periodic adiabatic compression: u_d(t) = u_d0 + u_d_ampl * cos(omega_d * t)
+    Btot     = 0. ! 30.      ! Total amplitude of MF in micro Gauss
+    outfile  = 'e_in1.dat' !
+    injection_rate = 5.e-4
+ /
+
+ $PIERNIK_DEBUG
+    constant_dt = 0.02
+ /


### PR DESCRIPTION
Adds way to inject initial spectrum at a fixed rate - a step towards steady-state evolution test.
Introduces problem.par with synchrotron + injection 