### PR TITLE
CRESP (python): update & fix python visualization scripts, allow legacy parameter names

### DIFF
--- a/python/crs_h5.py
+++ b/python/crs_h5.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 from pylab import zeros, sqrt, size
 import matplotlib.pyplot as plt
-from numpy import log10, log, pi, asfarray, array, linspace, sign, around
+from numpy import log10, log, pi, asarray, array, linspace, sign, around
 import h5py
 import os
 import sys
@@ -474,13 +474,13 @@ def crs_initialize(parameter_names, parameter_values):
         p_fix_ratio = 10.0 ** log_width
         p_fix[0] = (sqrt(p_fix[1] * p_fix[2])) / p_fix_ratio
         p_fix[ncrb] = (sqrt(p_fix[ncrb - 2] * p_fix[ncrb - 1])) * p_fix_ratio
-        p_fix = asfarray(p_fix)
+        p_fix = asarray(p_fix)
 
     p_mid_fix = zeros(ncrb)
     p_mid_fix[1:ncrb - 1] = sqrt(p_fix[1:ncrb - 1] * p_fix[2:ncrb])
     p_mid_fix[0] = p_mid_fix[1] / p_fix_ratio
     p_mid_fix[ncrb - 1] = p_mid_fix[ncrb - 2] * p_fix_ratio
-    p_mid_fix = asfarray(p_mid_fix)
+    p_mid_fix = asarray(p_mid_fix)
 
     p_fix = tuple(p_fix)
     p_mid_fix = tuple(p_mid_fix)
@@ -677,7 +677,7 @@ def crs_plot_main_fpq(parameter_names, parameter_values, plot_var, fcrs, qcrs, p
             p_fix[0] = (sqrt(p_fix[1] * p_fix[2])) / p_fix_ratio
             p_fix[ncrb] = (
                 sqrt(p_fix[ncrb - 2] * p_fix[ncrb - 1])) * p_fix_ratio
-            p_fix = asfarray(p_fix)
+            p_fix = asarray(p_fix)
 
     i_lo = 0
     i_up = ncrb

--- a/python/crs_pf.py
+++ b/python/crs_pf.py
@@ -67,15 +67,15 @@ def initialize_pf_arrays(h5fname, pf_initialized=False):
         p_ratios_up = h5f["cresp/smaps_UP/p_ratios"]
         f_ratios_up = h5f["cresp/smaps_UP/f_ratios"]
         # Use whatever values are saved in h5 file
-        a_min_lo = h5f["cresp"]["smaps_LO"].attrs["a_min"]
-        a_max_lo = h5f["cresp"]["smaps_LO"].attrs["a_max"]
-        n_min_lo = h5f["cresp"]["smaps_LO"].attrs["n_min"]
-        n_max_lo = h5f["cresp"]["smaps_LO"].attrs["n_max"]
+        a_min_lo = h5f["cresp"]["smaps_LO"].attrs["a_min"][0]
+        a_max_lo = h5f["cresp"]["smaps_LO"].attrs["a_max"][0]
+        n_min_lo = h5f["cresp"]["smaps_LO"].attrs["n_min"][0]
+        n_max_lo = h5f["cresp"]["smaps_LO"].attrs["n_max"][0]
 
-        a_min_up = h5f["cresp"]["smaps_UP"].attrs["a_min"]
-        a_max_up = h5f["cresp"]["smaps_UP"].attrs["a_max"]
-        n_min_up = h5f["cresp"]["smaps_UP"].attrs["n_min"]
-        n_max_up = h5f["cresp"]["smaps_UP"].attrs["n_max"]
+        a_min_up = h5f["cresp"]["smaps_UP"].attrs["a_min"][0]
+        a_max_up = h5f["cresp"]["smaps_UP"].attrs["a_max"][0]
+        n_min_up = h5f["cresp"]["smaps_UP"].attrs["n_min"][0]
+        n_max_up = h5f["cresp"]["smaps_UP"].attrs["n_max"][0]
 
         if (h5f["cresp"]["smaps_LO"].attrs["dims"][0] != h5f["cresp"]["smaps_UP"].attrs["dims"][0]):
             die("Error, different sizes of solution maps!")

--- a/python/interactive_plot_crs.py
+++ b/python/interactive_plot_crs.py
@@ -176,7 +176,7 @@ def copy_field(field, data):
 
 def add_cren_tot_to(h5_dataset):
     try:
-        if (h5ds.all_data()[cresp_labels["cre_n"]+"01"].units == "dimensionless"):
+        if (h5ds.all_data()[cresp_labels["cre_n"] + "01"].units == "dimensionless"):
             h5ds.add_field(("gdf", "cren_tot"), units="", function=_total_cren,
                            display_name="Total CR electron number density", sampling_type="cell")
         else:
@@ -189,7 +189,7 @@ def add_cren_tot_to(h5_dataset):
 
 def add_cree_tot_to(h5_dataset):
     try:
-        if (h5ds.all_data()[cresp_labels["cre_e"]+"01"].units == "dimensionless"):
+        if (h5ds.all_data()[cresp_labels["cre_e"] + "01"].units == "dimensionless"):
             h5ds.add_field(("gdf", "cree_tot"), units="", function=_total_cree,
                            display_name="Total CR electron energy density", sampling_type="cell")
         else:
@@ -331,7 +331,7 @@ if f_run is True:
 
     if (plot_field[0:-2] == "en_ratio"):
         try:
-            if str(dsSlice[cresp_labels["cre_n"]+"01"].units) == "dimensionless":  # DEPRECATED
+            if str(dsSlice[cresp_labels["cre_n"] + "01"].units) == "dimensionless":  # DEPRECATED
                 h5ds.add_field(("gdf", plot_field), units="", function=en_ratio,
                                display_name="Ratio e/n in %i-th bin" % int(plot_field[-2:]), sampling_type="cell")
             else:

--- a/python/interactive_plot_crs.py
+++ b/python/interactive_plot_crs.py
@@ -11,7 +11,7 @@ from numpy import array as np_array, log, log10, mean, rot90
 from os import getcwd, makedirs, path
 from optparse import OptionParser
 from re import search
-from read_h5 import read_par, input_names_array
+from read_h5 import read_par, input_names_array, get_CRESP_labels
 from sys import argv, version
 from warnings import simplefilter
 try:
@@ -123,13 +123,15 @@ par_epsilon = 1.0e-15
 f_run = True
 pf_initialized = False
 
+cresp_labels = False
+
 # ------- Local functions -----------
 
 
 def _total_cree(field, data):
     list_cree = []
     for element in h5ds.field_list:
-        if search("cree", str(element[1])):
+        if search(cresp_labels['cre_e'], str(element[1])):
             list_cree.append(element[1])
     cree_tot = data[str(list_cree[0])]
     for element in list_cree[1:]:
@@ -140,7 +142,7 @@ def _total_cree(field, data):
 def _total_cren(field, data):
     list_cren = []
     for element in h5ds.field_list:
-        if search("cren", str(element[1])):
+        if search(cresp_labels['cre_n'], str(element[1])):
             list_cren.append(element[1])
     cren_tot = data[str(list_cren[0])]
     for element in list_cren[1:]:
@@ -157,11 +159,11 @@ def _total_B(field, data):
 def en_ratio(field, data):  # DEPRECATED (?)
     bin_nr = field.name[1][-2:]
     for element in h5ds.field_list:
-        if search("cree" + str(bin_nr.zfill(2)), str(element[1])):
-            cren_data = data["cren" + str(bin_nr.zfill(2))]
+        if search(cresp_labels["cre_e"] + str(bin_nr.zfill(2)), str(element[1])):
+            cren_data = data[cresp_labels["cre_n"] + str(bin_nr.zfill(2))]
             # necessary to avoid FPEs
             cren_data[cren_data <= par_epsilon**2] = par_epsilon
-            cree_data = data["cree" + str(bin_nr.zfill(2))]
+            cree_data = data[cresp_labels["cre_n"] + str(bin_nr.zfill(2))]
             en_ratio = cree_data / cren_data
     return en_ratio
 
@@ -174,7 +176,7 @@ def copy_field(field, data):
 
 def add_cren_tot_to(h5_dataset):
     try:
-        if (h5ds.all_data()["cren01"].units == "dimensionless"):
+        if (h5ds.all_data()[cresp_labels["cre_n"]+"01"].units == "dimensionless"):
             h5ds.add_field(("gdf", "cren_tot"), units="", function=_total_cren,
                            display_name="Total CR electron number density", sampling_type="cell")
         else:
@@ -187,7 +189,7 @@ def add_cren_tot_to(h5_dataset):
 
 def add_cree_tot_to(h5_dataset):
     try:
-        if (h5ds.all_data()["cree01"].units == "dimensionless"):
+        if (h5ds.all_data()[cresp_labels["cre_e"]+"01"].units == "dimensionless"):
             h5ds.add_field(("gdf", "cree_tot"), units="", function=_total_cree,
                            display_name="Total CR electron energy density", sampling_type="cell")
         else:
@@ -226,15 +228,20 @@ if f_run:
 var_array = []
 if f_run is True:
     var_names = []
-    var_names = ["ncrb", "p_min_fix", "p_max_fix",
+    var_names = ["ncrb", "ncre", "p_min_fix", "p_max_fix",
                  "e_small", "cre_eff", "q_big"]
-    var_def = [20, 10., 1.e5, 1.e-6, 0.01, 30., ]
+    var_def = [1, 1, 10., 1.e5, 1.e-6, 0.01, 30., ]
     if len(var_names) == 0:
         prtwarn(
             "Empty list of parameter names provided: enter names of parameters to read")
         var_names = input_names_array()
-
     var_array = read_par(filename, var_names, var_def)
+
+    if var_array[var_names.index("ncre")] == 1:
+        var_array[var_names.index("ncre")] = var_array[var_names.index("ncrb")]
+    elif var_array[var_names.index("ncrb")] == 1:
+        var_array[var_names.index("ncrb")] = var_array[var_names.index("ncre")]
+
     for i in range(len(var_names)):
         exec("%s=%s" % (var_names[i], var_array[i]))
 
@@ -245,6 +252,8 @@ if f_run is True:
 
 # ---------- Open file
     h5ds = yt.load(filename)
+
+    cresp_labels = get_CRESP_labels(filename)
 
     initialize_pf_arrays(filename, pf_initialized)
 # ---------- bounds on domain size
@@ -322,7 +331,7 @@ if f_run is True:
 
     if (plot_field[0:-2] == "en_ratio"):
         try:
-            if str(dsSlice["cren01"].units) == "dimensionless":  # DEPRECATED
+            if str(dsSlice[cresp_labels["cre_n"]+"01"].units) == "dimensionless":  # DEPRECATED
                 h5ds.add_field(("gdf", plot_field), units="", function=en_ratio,
                                display_name="Ratio e/n in %i-th bin" % int(plot_field[-2:]), sampling_type="cell")
             else:
@@ -354,10 +363,7 @@ if f_run is True:
         plot_field = new_field
 
     # WARNING - this makes field_max unitless
-    try:
-        field_max = h5ds.find_max("cr_p+")[0].v
-    except:
-        field_max = h5ds.find_max("cr1")[0].v
+    field_max = h5ds.find_max(cresp_labels["crp"])[0].v
 
 # prepare limits for framebuffer
     # if (options.usr_width == 0.):
@@ -504,16 +510,16 @@ if f_run is True:
         position = h5ds.r[coords:coords]
         if (plot_field[0:-2] != "en_ratio"):
             prtinfo(">>>>>>>>>>>>>>>>>>> Value of %s at point [%f, %f, %f] = %f " % (
-                plot_field, coords[0], coords[1], coords[2], position[plot_field]))
+                plot_field, coords[0], coords[1], coords[2], position[plot_field][0]))
         else:
             prtinfo("Value of %s at point [%f, %f, %f] = %f " % (plot_field, coords[0], coords[1],
-                    coords[2], position["cree" + str(plot_field[-2:])] / position["cren" + str(plot_field[-2:])]))
+                    coords[2], position[cresp_labels["cre_e"] + str(plot_field[-2:])] / position[cresp_labels["cre_n"] + str(plot_field[-2:])]))
             # once again appended - needed as ylimit for the plot
             plot_max = h5ds.find_max(
-                "cre" + plot_var + str(plot_field[-2:]))[0]
+                cresp_labels["cre_e"][0:-1] + plot_var + str(plot_field[-2:]))[0]
 
         btot = (position["mag_field_x"].v**2 + position["mag_field_y"].v **
-                2 + position["mag_field_z"].v**2)**0.5
+                2 + position["mag_field_z"].v**2)[0]**0.5
         btot_uG = 2.85 * btot  # WARNING magic number @btot - conversion factor
         prtinfo("B_tot = %f = %f (uG)" % (btot, btot_uG))
         if (True):   # TODO DEPRECATED save_fqp
@@ -561,9 +567,9 @@ if f_run is True:
 
                 for ind in range(1, ncrb + 1):
                     ecrs.append(
-                        float(mean(position['cree' + str(ind).zfill(2)][0].v)))
+                        float(mean(position[cresp_labels['cre_e'] + str(ind).zfill(2)][0].v)))
                     ncrs.append(
-                        float(mean(position['cren' + str(ind).zfill(2)][0].v)))
+                        float(mean(position[cresp_labels['cre_n'] + str(ind).zfill(2)][0].v)))
 
                 fig2, exit_code = crs_plot_main(
                     plot_var, ncrs, ecrs, time, coords, marker=marker_l[marker_index], clean_plot=options.clean_plot, hide_axes=options.no_axes)
@@ -576,8 +582,8 @@ if f_run is True:
                     position = position = h5ds.r[[coords[0], dom_l[avail_dim[0]] + dl * j, coords[2]]: [
                         coords[0], dom_l[avail_dim[0]] + dl * j, coords[2]]]
                     for ind in range(1, ncrb + 1):
-                        ecrs.append(position['cree' + str(ind).zfill(2)][0].v)
-                        ncrs.append(position['cren' + str(ind).zfill(2)][0].v)
+                        ecrs.append(position[cresp_labels['cre_e'] + str(ind).zfill(2)][0].v)
+                        ncrs.append(position[cresp_labels['cre_n'] + str(ind).zfill(2)][0].v)
                     fig2, exit_code_tmp = crs_plot_main(
                         plot_var, ncrs, ecrs, time, coords, marker=marker_l[marker_index], i_plot=image_number, clean_plot=options.clean_plot, hide_axes=options.no_axes)
                     if (exit_code_tmp is False):
@@ -592,8 +598,8 @@ if f_run is True:
             ncrs = []
 
             for ind in range(1, ncrb + 1):
-                ecrs.append(float(position['cree' + str(ind).zfill(2)][0].v))
-                ncrs.append(float(position['cren' + str(ind).zfill(2)][0].v))
+                ecrs.append(float(position[cresp_labels['cre_e'] + str(ind).zfill(2)][0].v))
+                ncrs.append(float(position[cresp_labels['cre_n'] + str(ind).zfill(2)][0].v))
 
             for ind in range(1, ncrb + 2):
                 fcrs.append(float(position['cref' + str(ind).zfill(2)][0].v))

--- a/python/read_h5.py
+++ b/python/read_h5.py
@@ -15,11 +15,15 @@ else:
 # String parameter values cannot contain spaces.
 # On input it receives a list of names of variables to be read, while it returns a list of parameter values.
 # Having array of names and array of values one can simply `exec ("%s=%s" %(name,value))
+cr_fieldnames_legacy = {"crp":"cr01",  "cre_e":"cree",   "cre_n":"cren"}
+cr_fieldnames        = {"crp":"cr_p+", "cre_e":"cr_e-e", "cre_n":"cr_e-n"}
+
+legacy_names = {"ncre":"ncrb"}
 
 # searches for variable name, if found splits and appends the value ----------
 
 
-def append_split_var(line, variable_name, var_array_to_append, param_found):
+def append_split_var(line, ind, variable_name, var_array_to_append, param_found):
     if (not_py27):
         words = (str(line).replace(" ", "").replace("\t", "").replace("b'", "")).split('=')  # remove leading b' (byte type) in python3
     else:
@@ -29,7 +33,7 @@ def append_split_var(line, variable_name, var_array_to_append, param_found):
         if (not_py27):
             var_value = var_value.strip("'")  # remove remaining b' (byte type) in python3
         var_value = determine_type_append(var_value)
-        var_array_to_append.append(var_value)
+        var_array_to_append[ind] = var_value
         param_found = True
 
     return var_array_to_append, param_found
@@ -43,22 +47,27 @@ def read_par(hdf5_filename, var_nam, default_values):  # , var_array):
         sys.exit("Exiting: no variables to read provided")
 
     found_parameter = [False] * len(var_nam)
-    var_array = []
+    var_array = [False] * len(var_nam)
     value = 0.
     for i in range(len(var_nam)):
         h5File = h5py.File(hdf5_filename, 'r')
         parfile = h5File['problem.par']
         for line in parfile:
             if found_parameter[i] is False:
-                value, found_parameter[i] = append_split_var(line, var_nam[i], var_array, found_parameter[i])
+                value, found_parameter[i] = append_split_var(line, i, var_nam[i], var_array, found_parameter[i])
     for i in range(len(var_nam)):
         if found_parameter[i] is False:
-            prtwarn("Warning: some parameters were not included in problem.par, i.e: %s (default value: %s) . Please provide it:" % (var_nam[i], str(default_values[i])))
-            value = input_names_array()
-            if (len(value) > 1):
-                var_array.append(value)
+            # if legacy parameter has its new counterpart name found, abstain from prompting for parameter value
+            if var_nam[i] in legacy_names and found_parameter[var_nam.index(legacy_names[var_nam[i]])]:
+                prtwarn("Some legacy parameters were not included in problem.par i.e: %s, however its counterpart (%s = %s) was found. "% (var_nam[i], legacy_names[var_nam[i]], str(var_array[var_nam.index(legacy_names[var_nam[i]])]) ) )
+                var_array[i] = var_array[var_nam.index(legacy_names[var_nam[i]])]
             else:
-                var_array.append(default_values[i])
+                prtwarn("Some parameters were not included in problem.par, i.e: >>%s<< (default value: %s).\nPlease provide parameter value(s)." % (var_nam[i], str(default_values[i])))
+                value = input_names_array()
+                if (len(value) > 1):
+                    var_array[i] = value
+                else:
+                    var_array[i] =  default_values[i]
     return var_array
 # for given string value it determines the type of value and returns it -------
 # Value types supported: integer, float, boolean and string.
@@ -99,6 +108,17 @@ def determine_type_append(var):
         print("Type for provided variable %s not recognized - ")
         return var
 # read names if nothing provided
+
+def get_CRESP_labels(fileh5_name):
+
+   h5f = h5py.File(fileh5_name, 'r')
+   h5f_attr_keys = h5f.attrs.keys()
+   if 'ncre' in h5f_attr_keys:
+      return cr_fieldnames_legacy
+   elif 'ncrb' in h5f_attr_keys:
+      return cr_fieldnames
+   else:
+      sys.exit("Error reading CRESP parameters -- number of bins (ncre or ncrb) not found in h5 file.")
 
 
 def input_names_array():

--- a/python/read_h5.py
+++ b/python/read_h5.py
@@ -15,10 +15,10 @@ else:
 # String parameter values cannot contain spaces.
 # On input it receives a list of names of variables to be read, while it returns a list of parameter values.
 # Having array of names and array of values one can simply `exec ("%s=%s" %(name,value))
-cr_fieldnames_legacy = {"crp":"cr01",  "cre_e":"cree",   "cre_n":"cren"}
-cr_fieldnames        = {"crp":"cr_p+", "cre_e":"cr_e-e", "cre_n":"cr_e-n"}
+cr_fieldnames_legacy = {"crp": "cr01", "cre_e": "cree", "cre_n": "cren"}
+cr_fieldnames = {"crp": "cr_p+", "cre_e": "cr_e-e", "cre_n": "cr_e-n"}
 
-legacy_names = {"ncre":"ncrb"}
+legacy_names = {"ncre": "ncrb"}
 
 # searches for variable name, if found splits and appends the value ----------
 
@@ -59,7 +59,7 @@ def read_par(hdf5_filename, var_nam, default_values):  # , var_array):
         if found_parameter[i] is False:
             # if legacy parameter has its new counterpart name found, abstain from prompting for parameter value
             if var_nam[i] in legacy_names and found_parameter[var_nam.index(legacy_names[var_nam[i]])]:
-                prtwarn("Some legacy parameters were not included in problem.par i.e: %s, however its counterpart (%s = %s) was found. "% (var_nam[i], legacy_names[var_nam[i]], str(var_array[var_nam.index(legacy_names[var_nam[i]])]) ) )
+                prtwarn("Some legacy parameters were not included in problem.par i.e: %s, however its counterpart (%s = %s) was found. " % (var_nam[i], legacy_names[var_nam[i]], str(var_array[var_nam.index(legacy_names[var_nam[i]])])))
                 var_array[i] = var_array[var_nam.index(legacy_names[var_nam[i]])]
             else:
                 prtwarn("Some parameters were not included in problem.par, i.e: >>%s<< (default value: %s).\nPlease provide parameter value(s)." % (var_nam[i], str(default_values[i])))
@@ -67,7 +67,7 @@ def read_par(hdf5_filename, var_nam, default_values):  # , var_array):
                 if (len(value) > 1):
                     var_array[i] = value
                 else:
-                    var_array[i] =  default_values[i]
+                    var_array[i] = default_values[i]
     return var_array
 # for given string value it determines the type of value and returns it -------
 # Value types supported: integer, float, boolean and string.
@@ -109,16 +109,17 @@ def determine_type_append(var):
         return var
 # read names if nothing provided
 
+
 def get_CRESP_labels(fileh5_name):
 
-   h5f = h5py.File(fileh5_name, 'r')
-   h5f_attr_keys = h5f.attrs.keys()
-   if 'ncre' in h5f_attr_keys:
-      return cr_fieldnames_legacy
-   elif 'ncrb' in h5f_attr_keys:
-      return cr_fieldnames
-   else:
-      sys.exit("Error reading CRESP parameters -- number of bins (ncre or ncrb) not found in h5 file.")
+    h5f = h5py.File(fileh5_name, 'r')
+    h5f_attr_keys = h5f.attrs.keys()
+    if 'ncre' in h5f_attr_keys:
+        return cr_fieldnames_legacy
+    elif 'ncrb' in h5f_attr_keys:
+        return cr_fieldnames
+    else:
+        sys.exit("Error reading CRESP parameters -- number of bins (ncre or ncrb) not found in h5 file.")
 
 
 def input_names_array():


### PR DESCRIPTION
Contains adaptations for changed parameter and field names (e.g. ncre->ncrb, cree..-> cr_e-e,  cren..-> cr_e-n), changes deprecated 'asfarray' to 'asarray'.